### PR TITLE
fix(csp): allow Supabase realtime wss + Userback stylesheet

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.canvasm.app https://accounts.google.com https://apis.google.com https://*.userback.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://*.clerk.accounts.dev https://*.clerk.com https://clerk.canvasm.app https://accounts.google.com https://api.openai.com https://*.userback.io; img-src 'self' data: https: blob:; worker-src 'self' blob:; frame-src 'self' https://accounts.google.com https://*.clerk.accounts.dev https://*.clerk.com https://clerk.canvasm.app; object-src 'none'; base-uri 'self';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.canvasm.app https://accounts.google.com https://apis.google.com https://*.userback.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.userback.io; font-src 'self' https://fonts.gstatic.com https://*.userback.io; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.clerk.accounts.dev https://*.clerk.com https://clerk.canvasm.app https://accounts.google.com https://api.openai.com https://*.userback.io; img-src 'self' data: https: blob:; worker-src 'self' blob:; frame-src 'self' https://accounts.google.com https://*.clerk.accounts.dev https://*.clerk.com https://clerk.canvasm.app; object-src 'none'; base-uri 'self';"
         }
       ]
     }


### PR DESCRIPTION
## Problem
Production CSP blocks the Supabase realtime websocket and the Userback widget stylesheet:
- `wss://*.supabase.co/realtime/...` blocked — `connect-src` only allowed the `https` scheme, but realtime uses `wss`.
- `https://static.userback.io/widget/v1.css` blocked — `style-src`/`font-src` didn't include `*.userback.io`.

## Fix (`vercel.json`)
- `connect-src`: add `wss://*.supabase.co`
- `style-src`: add `https://*.userback.io`
- `font-src`: add `https://*.userback.io`

Takes effect on the next Vercel production deploy from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)