### PR TITLE
fix(canvas): stop React #185 render loop on /canvas/:id (CVS-19)

### DIFF
--- a/src/features/canvas/hooks/useCanvasEvents.test.tsx
+++ b/src/features/canvas/hooks/useCanvasEvents.test.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ReactFlowProvider } from '@xyflow/react';
+import { useCanvasEvents } from './useCanvasEvents';
+
+// Regression guard for the /canvas/:id React #185 ("max update depth") loop:
+// useCanvasEvents must return referentially STABLE handlers even though its
+// `state` prop (from useCanvasPageState) is a brand-new object every render.
+// If the handlers churn, the CanvasPage `edges`/`nodes` memos that depend on
+// them rebuild every render and feed React Flow new props → infinite loop.
+describe('useCanvasEvents', () => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <ReactFlowProvider>{children}</ReactFlowProvider>
+  );
+  const makeOpts = () => ({
+    state: {} as any,
+    canvasMachine: {} as any,
+    viewportSync: { updateViewport: () => {} },
+    onApplyLayout: () => {},
+  });
+
+  it('keeps a stable object + handler identities across state-object churn', () => {
+    const { result, rerender } = renderHook((p) => useCanvasEvents(p), {
+      initialProps: makeOpts(),
+      wrapper,
+    });
+    const first = result.current;
+
+    // Re-render with a brand-new options/state object (mimics every render).
+    rerender(makeOpts());
+
+    expect(result.current).toBe(first);
+    expect(result.current.handleOpenRelationshipSheet).toBe(
+      first.handleOpenRelationshipSheet
+    );
+    expect(result.current.handleSwitchToRelationship).toBe(
+      first.handleSwitchToRelationship
+    );
+    expect(result.current.handleOpenSettingsSheet).toBe(
+      first.handleOpenSettingsSheet
+    );
+  });
+});

--- a/src/features/canvas/hooks/useCanvasEvents.ts
+++ b/src/features/canvas/hooks/useCanvasEvents.ts
@@ -1,3 +1,4 @@
+import { useCallback, useMemo, useRef } from 'react';
 import { useEvidenceStore } from '@/features/evidence/stores/useEvidenceStore';
 import { useCanvasStore } from '@/lib/stores';
 import { useAppStore } from '@/shared/stores/useAppStore';
@@ -23,46 +24,58 @@ export function useCanvasEvents({
 }: UseCanvasEventsOptions) {
   const { screenToFlowPosition } = useReactFlow();
 
-  const handlePaneClick = () => {
-    // Clear any transient UI or selections if neededs
-  };
+  // Keep the latest props reachable from stable handlers WITHOUT changing their
+  // identity. `state` (from useCanvasPageState) is a fresh object every render, so
+  // closing over it directly would give every handler a new identity each render —
+  // which rebuilds the `nodes`/`edges` memos that depend on these handlers and
+  // feeds React Flow new props each render (the React #185 "max update depth" loop
+  // on /canvas/:id). Reading through a ref keeps handlers referentially stable.
+  const latest = useRef({ state, onApplyLayout, screenToFlowPosition });
+  latest.current = { state, onApplyLayout, screenToFlowPosition };
 
-  const handleOpenSettingsSheet = (nodeId: string) => {
+  const handlePaneClick = useCallback(() => {
+    // Clear any transient UI or selections if neededs
+  }, []);
+
+  const handleOpenSettingsSheet = useCallback((nodeId: string) => {
+    const { state } = latest.current;
     console.log('🔧 Opening settings sheet for node:', nodeId);
     state.setIsSettingsSheetOpen(true);
     state.setSettingsCardId?.(nodeId);
-  };
+  }, []);
 
-  const handleOpenRelationshipSheet = (edgeId: string) => {
+  const handleOpenRelationshipSheet = useCallback((edgeId: string) => {
+    const { state } = latest.current;
     console.log('🔗 Opening relationship sheet for edge:', edgeId);
     state.setIsRelationshipSheetOpen(true);
     state.setRelationshipSheetId?.(edgeId);
-  };
+  }, []);
 
-  const handleSwitchToCard = (nodeId: string) => {
+  const handleSwitchToCard = useCallback((nodeId: string) => {
     handleOpenSettingsSheet(nodeId);
-  };
+  }, [handleOpenSettingsSheet]);
 
-  const handleSwitchToRelationship = (edgeId: string) => {
+  const handleSwitchToRelationship = useCallback((edgeId: string) => {
     handleOpenRelationshipSheet(edgeId);
-  };
+  }, [handleOpenRelationshipSheet]);
 
-  const handleToggleCollapse = (groupId: string) => {
-    state.toggleGroupCollapsed?.(groupId);
-  };
+  const handleToggleCollapse = useCallback((groupId: string) => {
+    latest.current.state.toggleGroupCollapsed?.(groupId);
+  }, []);
 
-  const handleUpdateGroupSize = (
+  const handleUpdateGroupSize = useCallback((
     groupId: string,
     size: { width: number; height: number }
   ) => {
-    state.updateGroupSize?.(groupId, size);
-  };
+    latest.current.state.updateGroupSize?.(groupId, size);
+  }, []);
 
-  const handleOpenFilters = () => {
-    state.setIsFiltersOpen?.(true);
-  };
+  const handleOpenFilters = useCallback(() => {
+    latest.current.state.setIsFiltersOpen?.(true);
+  }, []);
 
-  const handleAddEvidence = () => {
+  const handleAddEvidence = useCallback(() => {
+    const { state, screenToFlowPosition } = latest.current;
     // The page-state hook never implemented addEvidenceAtCenter, so the button
     // was a silent no-op. Add a positioned evidence item directly so an
     // evidence node appears on the canvas (it renders from the evidence store).
@@ -96,18 +109,19 @@ export function useCanvasEvents({
     } as any);
     // Also call the legacy hook if a page ever provides it.
     state.addEvidenceAtCenter?.();
-  };
+  }, []);
 
-  const handleApplyLayout = () => {
+  const handleApplyLayout = useCallback(() => {
     console.log('🔄 Layout button clicked');
+    const { onApplyLayout } = latest.current;
     if (onApplyLayout) {
       onApplyLayout();
     } else {
       console.warn('⚠️ No layout handler provided');
     }
-  };
+  }, []);
 
-  const handleGroupSelectedNodes = () => {
+  const handleGroupSelectedNodes = useCallback(() => {
     // The page-state hook never implemented groupSelectedNodes, so the button
     // was a no-op. Drive the real canvas-store action with the live selection,
     // which persists a group (DB) and tags member cards with parentId.
@@ -122,10 +136,10 @@ export function useCanvasEvents({
         console.error('Group failed', err);
         toast.error('Could not group selected cards');
       });
-  };
+  }, []);
 
-  const handleUngroupSelectedGroups = () => {
-    const groupIds = state.selectedGroupIds || [];
+  const handleUngroupSelectedGroups = useCallback(() => {
+    const groupIds = latest.current.state.selectedGroupIds || [];
     if (groupIds.length === 0) {
       toast.error('Select a group to ungroup');
       return;
@@ -136,17 +150,17 @@ export function useCanvasEvents({
         console.error('Ungroup failed', err);
         toast.error('Could not ungroup');
       });
-  };
+  }, []);
 
-  const handleDeleteSelectedItems = () => {
-    state.deleteSelectedItems?.();
-  };
+  const handleDeleteSelectedItems = useCallback(() => {
+    latest.current.state.deleteSelectedItems?.();
+  }, []);
 
-  const handleDuplicateSelectedItems = () => {
-    state.duplicateSelectedItems?.();
-  };
+  const handleDuplicateSelectedItems = useCallback(() => {
+    latest.current.state.duplicateSelectedItems?.();
+  }, []);
 
-  const handleOpenSelectedSettings = () => {
+  const handleOpenSelectedSettings = useCallback(() => {
     // Open the Settings sheet for the (first) selected node. The page-state hook
     // never implemented openSelectedSettings, so wire it to the real opener.
     const { selectedNodeIds } = useCanvasStore.getState();
@@ -155,42 +169,66 @@ export function useCanvasEvents({
     } else {
       toast.error('Select a card first');
     }
-  };
+  }, [handleOpenSettingsSheet]);
 
   // Modals/Sheets integration used by CanvasModals
-  const handleApplyFilters = (filters?: any) => {
-    state.applyFilters?.(filters);
-  };
-  const handleCloseSettingsSheet = () => {
+  const handleApplyFilters = useCallback((filters?: any) => {
+    latest.current.state.applyFilters?.(filters);
+  }, []);
+  const handleCloseSettingsSheet = useCallback(() => {
+    const { state } = latest.current;
     console.log('🔧 Closing settings sheet');
     state.setIsSettingsSheetOpen?.(false);
     state.setSettingsCardId?.(undefined);
     state.setSettingsInitialTab?.(undefined);
-  };
-  const handleCloseRelationshipSheet = () => {
+  }, []);
+  const handleCloseRelationshipSheet = useCallback(() => {
+    const { state } = latest.current;
     console.log('🔗 Closing relationship sheet');
     state.setIsRelationshipSheetOpen?.(false);
     state.setRelationshipSheetId?.(undefined);
-  };
+  }, []);
 
-  return {
-    handlePaneClick,
-    handleOpenSettingsSheet,
-    handleOpenRelationshipSheet,
-    handleSwitchToCard,
-    handleSwitchToRelationship,
-    handleToggleCollapse,
-    handleUpdateGroupSize,
-    handleOpenFilters,
-    handleAddEvidence,
-    handleApplyLayout,
-    handleGroupSelectedNodes,
-    handleUngroupSelectedGroups,
-    handleDeleteSelectedItems,
-    handleDuplicateSelectedItems,
-    handleOpenSelectedSettings,
-    handleApplyFilters,
-    handleCloseSettingsSheet,
-    handleCloseRelationshipSheet,
-  };
+  return useMemo(
+    () => ({
+      handlePaneClick,
+      handleOpenSettingsSheet,
+      handleOpenRelationshipSheet,
+      handleSwitchToCard,
+      handleSwitchToRelationship,
+      handleToggleCollapse,
+      handleUpdateGroupSize,
+      handleOpenFilters,
+      handleAddEvidence,
+      handleApplyLayout,
+      handleGroupSelectedNodes,
+      handleUngroupSelectedGroups,
+      handleDeleteSelectedItems,
+      handleDuplicateSelectedItems,
+      handleOpenSelectedSettings,
+      handleApplyFilters,
+      handleCloseSettingsSheet,
+      handleCloseRelationshipSheet,
+    }),
+    [
+      handlePaneClick,
+      handleOpenSettingsSheet,
+      handleOpenRelationshipSheet,
+      handleSwitchToCard,
+      handleSwitchToRelationship,
+      handleToggleCollapse,
+      handleUpdateGroupSize,
+      handleOpenFilters,
+      handleAddEvidence,
+      handleApplyLayout,
+      handleGroupSelectedNodes,
+      handleUngroupSelectedGroups,
+      handleDeleteSelectedItems,
+      handleDuplicateSelectedItems,
+      handleOpenSelectedSettings,
+      handleApplyFilters,
+      handleCloseSettingsSheet,
+      handleCloseRelationshipSheet,
+    ]
+  );
 }

--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -651,13 +651,17 @@ function CanvasPageInner() {
   }, [focusedGroupId]);
 
   // Create stable event handlers to prevent circular dependencies
+  // Depend on the concrete (stable) useState setters, NOT the whole `state`
+  // object — `state` from useCanvasPageState is a fresh object every render, so
+  // `[state]` made these "stable" handlers churn each render, rebuilding the
+  // `nodes` memo and feeding React Flow new nodes every render (React #185 loop).
   const stableHandleOpenSettingsSheet = useCallback(
     (nodeId: string) => {
       log.debug('🔧 Opening settings sheet for node:', nodeId);
       state.setIsSettingsSheetOpen(true);
       state.setSettingsCardId?.(nodeId);
     },
-    [state]
+    [state.setIsSettingsSheetOpen, state.setSettingsCardId]
   );
 
   const stableHandleSwitchToCard = useCallback(
@@ -669,7 +673,11 @@ function CanvasPageInner() {
         state.setSettingsInitialTab?.(tab);
       }
     },
-    [state]
+    [
+      state.setIsSettingsSheetOpen,
+      state.setSettingsCardId,
+      state.setSettingsInitialTab,
+    ]
   );
 
   const stableHandleToggleCollapse = useCallback((groupId: string) => {
@@ -788,7 +796,12 @@ function CanvasPageInner() {
     }));
 
     const convertedEvidenceNodes = evidenceNodes.map((evidence) =>
-      convertToEvidenceNode(evidence, updateEvidence, deleteEvidence)
+      convertToEvidenceNode(
+        evidence,
+        updateEvidence,
+        deleteEvidence,
+        selectedNodeIds
+      )
     );
 
     // Grouping redesign: the on-canvas group frame is gone. Group data still

--- a/src/shared/utils/canvasConverters.ts
+++ b/src/shared/utils/canvasConverters.ts
@@ -155,7 +155,8 @@ export const convertToEdge = (
 export const convertToEvidenceNode = (
   evidence: EvidenceItem,
   onUpdateEvidence: (id: string, updates: Partial<EvidenceItem>) => void,
-  onDeleteEvidence: (id: string) => void
+  onDeleteEvidence: (id: string) => void,
+  selectedNodeIds: string[] = []
 ): Node => ({
   id: evidence.id,
   type: 'evidenceNode',
@@ -165,6 +166,10 @@ export const convertToEvidenceNode = (
     onUpdateEvidence,
     onDeleteEvidence,
   },
+  // Keep the controlled `selected` prop symmetric with every other node type
+  // (cards/canvas/PRD). Omitting it let React Flow and the store disagree on
+  // selection, bouncing onSelectionChange -> setState -> re-derive (React #185).
+  selected: selectedNodeIds.includes(evidence.id),
   selectable: true,
   draggable: true,
 });


### PR DESCRIPTION
Fixes **CVS-19** — the recurring production **React error #185 ("Maximum update depth exceeded")** on `/canvas/:id`, auto-filed by the System Health intake bridge.

## Root cause
The canvas `<ReactFlow>` is **controlled**, but its `nodes`/`edges` memos were rebuilt with **new identities every render**, so ReactFlow re-synced fresh props into its internal store each commit → scheduled updates → re-emitted changes → infinite loop, inside the RF node subtree (matching the minified prod stack).

Two independent static investigations converged on the same causes:

1. **`useCanvasEvents` returned fresh handler identities every render** (no memoization). The `edges` memo depends on `handleOpenRelationshipSheet`/`handleSwitchToRelationship`, so `edges` rebuilt every render. → Now reads latest props via a ref and returns `useCallback`/`useMemo`-stable handlers.
2. **`CanvasPage` `stableHandleOpenSettingsSheet`/`stableHandleSwitchToCard` used `[state]`** as their dep, but `state` (`useCanvasPageState`) is a new object every render, so they churned and rebuilt the `nodes` memo. → Now depend on the concrete (stable) `useState` setters.
3. **`convertToEvidenceNode` never set the controlled `selected` prop** (unlike every other node type), so RF and the store disagreed on selection and bounced `onSelectionChange → setState`. → Now sets `selected` from `selectedNodeIds`.

## Tests
- New `useCanvasEvents.test.tsx` asserts handler identities stay stable across state-object churn (the loop's fuel).
- Full suite green (118/118), type-check + lint clean.

## ⚠️ Verification gap — please smoke-test before merge
This was verified by static analysis + type-check/lint/unit tests, **but not reproduced at runtime** (needs Clerk auth + the specific canvas). Please load **`/canvas/34d5c80b-5b1a-4f27-9892-2cf1a5ab6715`** on a preview/local build and confirm it no longer crashes.

Known secondary amplifier left as follow-up: `handleNodesChange` (CanvasPage) calls `setExtraNodes` for foreign changes when any extra node exists — gated + not the primary cause, but worth tightening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)