### PR TITLE
feat(auth): server-side user provisioning via Clerk webhook (CVS-74)

### DIFF
--- a/docs/features/clerk-webhook-user-provisioning.md
+++ b/docs/features/clerk-webhook-user-provisioning.md
@@ -1,0 +1,50 @@
+# Server-side user provisioning (Clerk webhook)
+
+Reliably creates/updates the `public.users` row for every Clerk user, server-side —
+so ownership/collaborator foreign keys always resolve. Fixes CVS-74.
+
+## Why
+
+Provisioning used to be **client-side** (`ClerkSupabaseProvider` upserts `users` in a
+`useEffect` right after Clerk loads, using the Clerk-token Supabase client). That path
+is RLS-gated (`users_insert WITH CHECK (id = requesting_user_id())`) and races the
+token — and it **swallows failures** (`console.error` only). So a first-login `users`
+row could silently never be created, breaking collaborator/owner FKs.
+
+The webhook makes it deterministic: Clerk fires `user.*` events server-to-server, and
+the edge function upserts with the **service role** (bypasses RLS, no token race).
+
+## Flow
+
+```
+Clerk (user.created / user.updated)
+  → POST edge fn `clerk-webhook`  (verify Svix signature)
+    → upsert public.users (service role): id, email, name, avatar_url, updated_at
+```
+
+`user.deleted` is intentionally a no-op — hard-deleting the row would orphan
+ownership/collaborator FKs. (Revisit with a soft-delete if ever needed.)
+
+The old client-side upsert is left in place as a harmless best-effort fallback.
+
+## Setup (one-time)
+
+The edge function is already deployed (`clerk-webhook`, `verify_jwt` off). To turn it on:
+
+1. **Clerk → Configure → Webhooks → Add Endpoint**
+   - Endpoint URL: `https://iqrclwolhookzzmiedun.functions.supabase.co/clerk-webhook`
+   - Subscribe to: **`user.created`**, **`user.updated`** (optionally `user.deleted`).
+   - Create it, then copy the **Signing Secret** (`whsec_…`).
+
+2. **Set the secret in Supabase** → Dashboard → **Edge Functions → Manage secrets** →
+   add `CLERK_WEBHOOK_SIGNING_SECRET = whsec_…`. (No CLI needed — the dashboard sets
+   function secrets directly.)
+
+3. Done. Until the secret is set, the function returns `500 { "CLERK_WEBHOOK_SIGNING_SECRET not configured" }` and provisioning falls back to the client-side path.
+
+## Verify
+
+- **Reachable / fail-safe:** `curl -X POST https://iqrclwolhookzzmiedun.functions.supabase.co/clerk-webhook -d '{}'` → `{"error":"CLERK_WEBHOOK_SIGNING_SECRET not configured"}` before setup.
+- **After setup:** in Clerk → Webhooks → your endpoint → **Send test event** (`user.created`) → expect `200 {"ok":true,"action":"upsert"}` and a matching row in `public.users`.
+- **Real signup:** create a new Clerk user → confirm a `users` row appears within seconds.
+- **Bad signature** (any random POST with a body) → `401 {"error":"Invalid signature"}`.

--- a/supabase/functions/clerk-webhook/index.ts
+++ b/supabase/functions/clerk-webhook/index.ts
@@ -1,0 +1,95 @@
+// Server-side user provisioning (CVS-74). Clerk posts user.* webhooks here; we
+// verify the Svix signature and upsert the row into public.users with the SERVICE
+// ROLE — so a user's row is reliably created/updated regardless of the client's
+// token-timing race (the old client-side upsert in ClerkSupabaseProvider ran in a
+// useEffect right after load, was RLS-gated, and swallowed failures).
+//
+// Deploy: npx supabase functions deploy clerk-webhook  (or via MCP)
+// verify_jwt MUST be off — auth is the Svix signature, not a user JWT.
+//
+// Required env (Supabase → Edge Functions → Manage secrets):
+//   CLERK_WEBHOOK_SIGNING_SECRET   the "whsec_..." from Clerk → Webhooks → your endpoint
+// SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are injected by the edge runtime.
+
+import { Webhook } from 'https://esm.sh/svix@1.42.0';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+interface ClerkEmail {
+  id: string;
+  email_address: string;
+}
+interface ClerkUser {
+  id: string;
+  email_addresses?: ClerkEmail[];
+  primary_email_address_id?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  username?: string | null;
+  image_url?: string | null;
+}
+
+function pickEmail(u: ClerkUser): string {
+  const list = u.email_addresses ?? [];
+  const primary = list.find((e) => e.id === u.primary_email_address_id);
+  return (primary ?? list[0])?.email_address ?? '';
+}
+
+function pickName(u: ClerkUser, email: string): string {
+  const full = [u.first_name, u.last_name].filter(Boolean).join(' ').trim();
+  return full || u.username || email || 'User';
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  const secret = Deno.env.get('CLERK_WEBHOOK_SIGNING_SECRET');
+  if (!secret) return json({ error: 'CLERK_WEBHOOK_SIGNING_SECRET not configured' }, 500);
+
+  // Verify the Svix signature over the RAW body.
+  const payload = await req.text();
+  const headers = {
+    'svix-id': req.headers.get('svix-id') ?? '',
+    'svix-timestamp': req.headers.get('svix-timestamp') ?? '',
+    'svix-signature': req.headers.get('svix-signature') ?? '',
+  };
+  let evt: { type: string; data: ClerkUser };
+  try {
+    evt = new Webhook(secret).verify(payload, headers) as { type: string; data: ClerkUser };
+  } catch {
+    return json({ error: 'Invalid signature' }, 401);
+  }
+
+  const admin = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  );
+
+  const { type, data } = evt;
+
+  if (type === 'user.created' || type === 'user.updated') {
+    const email = pickEmail(data);
+    const { error } = await admin.from('users').upsert(
+      {
+        id: data.id,
+        email,
+        name: pickName(data, email),
+        avatar_url: data.image_url ?? null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' }
+    );
+    if (error) return json({ error: error.message }, 500);
+    return json({ ok: true, action: 'upsert', id: data.id });
+  }
+
+  // user.deleted: leave the row in place — ownership/collaborator FKs point at it,
+  // and hard-deleting would orphan them. (Revisit with soft-delete if needed.)
+  return json({ ok: true, action: 'ignored', type });
+});


### PR DESCRIPTION
Fixes **CVS-74** — a first-login `public.users` row could silently never be created.

## Root cause
Provisioning was **client-side** (`ClerkSupabaseProvider` upserts `users` in a `useEffect` right after Clerk loads, via the Clerk-token client). That path is RLS-gated (`users_insert WITH CHECK (id = requesting_user_id())`), **races the token**, and **swallows failures** (`console.error` only). So the row can silently fail to be created → broken ownership/collaborator FKs.

## Fix
New **`clerk-webhook`** edge function (Svix-verified, `verify_jwt` off) that upserts the `users` row with the **service role** on `user.created` / `user.updated` — deterministic, no token race, no RLS gate. `user.deleted` is a no-op (hard delete would orphan FKs). The old client-side upsert stays as a harmless fallback.

- Columns written: `id, email, name, avatar_url, updated_at` (verified against schema; `created_at` defaults). No migration needed.
- Deployed via MCP (**ACTIVE**). Fails safe: returns `500 "CLERK_WEBHOOK_SIGNING_SECRET not configured"` until set. Verified reachable.

## Owner setup to activate (in the manual-test sub-issue)
1. Clerk → Webhooks → add endpoint `https://iqrclwolhookzzmiedun.functions.supabase.co/clerk-webhook`, subscribe `user.created` + `user.updated`; copy the `whsec_…`.
2. Supabase → Edge Functions → Manage secrets → set `CLERK_WEBHOOK_SIGNING_SECRET`.
3. Send a Clerk test event → expect `200 {"ok":true,"action":"upsert"}` + a `users` row.

Full setup + verification: `docs/features/clerk-webhook-user-provisioning.md`.

## Verification
type-check ✓, lint ✓, full Vitest suite ✓ (107). Endpoint smoke-tested (fail-safe response). Live signature+upsert path is covered by the manual-test sub-issue (needs owner's Clerk config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)