### PR TITLE
feat(notifications): emit "assigned to me" notifications (CVS-73)

### DIFF
--- a/src/features/canvas/components/panels/task-panel/TaskPanel.tsx
+++ b/src/features/canvas/components/panels/task-panel/TaskPanel.tsx
@@ -10,6 +10,7 @@ import { useConfirm } from '@/shared/components/ConfirmDialog';
 import { Button } from '@/shared/components/ui/button';
 import { Label } from '@/shared/components/ui/label';
 import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import { notifyCardAssigned } from '@/shared/lib/supabase/services/collaboration';
 import {
   getUsersByIds,
   type UserLite,
@@ -159,7 +160,16 @@ export function TaskPanel({
             userMap={userMap}
             members={members}
             disabled={!canEdit}
-            onChange={(ids) => void persist({ assignees: ids })}
+            onChange={(ids) => {
+              // Notify only the NEWLY-added assignees (the RPC skips the caller).
+              const added = ids.filter((id) => !assignees.includes(id));
+              void persist({ assignees: ids });
+              if (added.length > 0 && card && client) {
+                void notifyCardAssigned(card.id, added, client).catch((e) =>
+                  console.error('assigned notification failed', e)
+                );
+              }
+            }}
           />
         </div>
 

--- a/src/features/strategy/pages/StrategyPage.tsx
+++ b/src/features/strategy/pages/StrategyPage.tsx
@@ -13,7 +13,10 @@ import {
 } from '@/shared/lib/supabase/services/metric-cards';
 import { getProjectById } from '@/shared/lib/supabase/services/projects';
 import { getUsersByIds, type UserLite } from '@/shared/lib/supabase/services/users';
-import { getCommentCountsByCard } from '@/shared/lib/supabase/services/collaboration';
+import {
+  getCommentCountsByCard,
+  notifyCardAssigned,
+} from '@/shared/lib/supabase/services/collaboration';
 import type {
   CardWorkflow,
   GroupNode,
@@ -234,7 +237,14 @@ export default function StrategyPage() {
     applyPatch(cardId, { workflow });
   };
   const handleAssigneesChange = (cardId: string, assignees: string[]) => {
+    const prev = cards.find((c) => c.id === cardId)?.assignees ?? [];
     applyPatch(cardId, { assignees });
+    const added = assignees.filter((id) => !prev.includes(id));
+    if (added.length > 0 && client) {
+      void notifyCardAssigned(cardId, added, client).catch((e) =>
+        console.error('assigned notification failed', e)
+      );
+    }
   };
 
   const handleCreateItem = async (

--- a/src/shared/lib/supabase/services/collaboration.ts
+++ b/src/shared/lib/supabase/services/collaboration.ts
@@ -312,6 +312,29 @@ export async function createNotification(
   return data as NotificationRow;
 }
 
+/**
+ * Emit an 'assigned' notification to each newly-added card assignee (CVS-73).
+ * Cross-user notifications are RLS-blocked for clients, so this goes through the
+ * `notify_card_assigned` SECURITY DEFINER RPC, which verifies project access and
+ * skips the caller. Pass only the NEWLY added ids so re-saves don't re-notify.
+ */
+export async function notifyCardAssigned(
+  cardId: string,
+  userIds: string[],
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<void> {
+  if (!userIds || userIds.length === 0) return;
+  const client = authenticatedClient || supabase();
+  const { error } = await client.rpc('notify_card_assigned' as never, {
+    p_card_id: cardId,
+    p_user_ids: userIds,
+  } as never);
+  if (error) {
+    console.error('Error emitting assigned notification:', error);
+    throw error;
+  }
+}
+
 export interface NotificationFilter {
   unreadOnly?: boolean;
   // Restrict to these notification types (e.g. ['mention'], ['assigned']).

--- a/supabase/migrations/20260706120000_notify_card_assigned.sql
+++ b/supabase/migrations/20260706120000_notify_card_assigned.sql
@@ -1,0 +1,56 @@
+-- =====================================================================
+-- CVS-73 — "assigned to me" notification producer.
+-- The inbox/feed already filters type='assigned', but nothing emitted them.
+-- Clients can't insert notifications for OTHER users (RLS), so mirror the
+-- emit_card_alert pattern: a SECURITY DEFINER RPC that verifies the caller has
+-- project access, then inserts an 'assigned' notification for each newly-added
+-- assignee (skipping the caller themselves). APPLIED to prod 2026-07-04.
+-- =====================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.notify_card_assigned(
+  p_card_id  uuid,
+  p_user_ids text[]
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_project uuid;
+  v_title   text;
+  v_caller  text := public.requesting_user_id();
+  uid       text;
+BEGIN
+  SELECT project_id, title INTO v_project, v_title
+  FROM public.metric_cards WHERE id = p_card_id;
+  IF v_project IS NULL THEN RETURN; END IF;
+
+  -- Caller must have access to the card's project.
+  IF NOT public.has_project_access(v_project, false) THEN
+    RAISE EXCEPTION 'not authorized to notify for this card';
+  END IF;
+
+  FOREACH uid IN ARRAY coalesce(p_user_ids, ARRAY[]::text[])
+  LOOP
+    -- Skip empty ids and self-assignment (don't notify yourself).
+    IF uid IS NULL OR uid = '' OR uid = v_caller THEN
+      CONTINUE;
+    END IF;
+    INSERT INTO public.notifications (user_id, type, title, description, metadata)
+    VALUES (
+      uid,
+      'assigned',
+      'You were assigned to ' || coalesce(nullif(v_title, ''), 'a card'),
+      NULL,
+      jsonb_build_object('projectId', v_project::text, 'cardId', p_card_id::text)
+    );
+  END LOOP;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.notify_card_assigned(uuid, text[]) FROM public;
+GRANT EXECUTE ON FUNCTION public.notify_card_assigned(uuid, text[]) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
Fixes **CVS-73** — the inbox/feed "Assigned to me" filter existed but nothing produced `type='assigned'` events, so it was always empty.

## Change
- **`notify_card_assigned(p_card_id, p_user_ids[])`** SECURITY DEFINER RPC (migration `20260706120000`), mirroring `emit_card_alert`: verifies the caller has project access (`has_project_access`), then inserts an `'assigned'` notification for each user, **skipping the caller** (no self-notify), with `metadata {projectId, cardId}` — the exact shape `NotificationInbox` already reads.
- **`notifyCardAssigned()`** service wrapper in `collaboration.ts`.
- Wired at **both** assignee editors: canvas **TaskPanel** (Action/Hypothesis cards) and the **Strategy table** — emitting only for **newly-added** assignees (diff vs. the previous list) so re-saves don't spam.

## Why an RPC
Clients can't insert notifications for *other* users under RLS (same reason alerting uses `emit_card_alert`). The RPC runs as definer and gates on project access.

## Verification
type-check ✓, lint ✓ (0 errors), full Vitest ✓ (107). Migration applied to prod. Cross-user delivery (needs 2 accounts) is covered by the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)