### PR TITLE
fix(canvas): pane-click and Esc clear node selection (CVS-68)

### DIFF
--- a/src/features/canvas/hooks/useCanvasEvents.ts
+++ b/src/features/canvas/hooks/useCanvasEvents.ts
@@ -34,7 +34,11 @@ export function useCanvasEvents({
   latest.current = { state, onApplyLayout, screenToFlowPosition };
 
   const handlePaneClick = useCallback(() => {
-    // Clear any transient UI or selections if neededs
+    // Clicking empty canvas clears the (controlled) selection. Without this,
+    // React Flow's native pane-click deselect is immediately overridden by our
+    // `selected` prop (derived from selectedNodeIds), so nodes stay stuck
+    // selected and there's no way back to "nothing selected" (CVS-68).
+    useCanvasStore.getState().clearSelection();
   }, []);
 
   const handleOpenSettingsSheet = useCallback((nodeId: string) => {

--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -1026,7 +1026,8 @@ function CanvasPageInner() {
     return () => clearTimeout(t);
   }, [evidenceList, canvasId, supabaseClient]);
 
-  // Keyboard: Ctrl/Cmd + C / V / D / Z (ignored while typing in a field).
+  // Keyboard: Esc clears selection; Ctrl/Cmd + C / V / D / Z (ignored while
+  // typing in a field).
   useEffect(() => {
     const isEditable = (el: EventTarget | null) => {
       const n = el as HTMLElement | null;
@@ -1039,8 +1040,16 @@ function CanvasPageInner() {
       );
     };
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.ctrlKey || e.metaKey)) return;
       if (isEditable(e.target)) return;
+      // Esc → back to "nothing selected" (CVS-68).
+      if (e.key === 'Escape') {
+        const s = useCanvasStore.getState();
+        if (s.selectedNodeIds.length || s.selectedEdgeIds.length) {
+          s.clearSelection();
+        }
+        return;
+      }
+      if (!(e.ctrlKey || e.metaKey)) return;
       const k = e.key.toLowerCase();
       if (k === 'c') canvasActions.copySelection();
       else if (k === 'v') canvasActions.paste();

--- a/src/features/canvas/stores/canvasStore.ts
+++ b/src/features/canvas/stores/canvasStore.ts
@@ -857,7 +857,7 @@ export const useCanvasStore = create<CanvasStoreState>()(
         selectedNodeIds: state.selectedNodeIds.filter((id) => id !== nodeId),
       })),
     deselectNodes: () => set({ selectedNodeIds: [] }),
-    clearSelection: () => set({ selectedNodeIds: [] }),
+    clearSelection: () => set({ selectedNodeIds: [], selectedEdgeIds: [] }),
 
     // Edge management
     addEdge: (edge: Relationship) =>


### PR DESCRIPTION
Fixes **CVS-68** — once you clicked a node there was no way back to "nothing selected".

## Root cause
Selection is **controlled** — each node's `selected` prop is derived from `selectedNodeIds`. So React Flow's native pane-click deselect was immediately overridden by that prop, leaving nodes stuck-selected. And there was no Esc handler.

## Fix
- `handlePaneClick` was an **empty no-op** → now calls `clearSelection()`.
- Added **Esc → clearSelection** in the existing canvas keydown effect (behind its `isEditable` guard, so Esc while typing doesn't clear).
- `clearSelection()` now also clears `selectedEdgeIds` (it previously cleared only nodes).

## Verification
type-check ✓, lint ✓ (0 errors), full Vitest ✓ (107). Runtime interaction covered by the manual-test sub-issue (needs a loaded canvas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)