### PR TITLE
fix(canvas): one selection-actions toolbar, not two (CVS-66)

### DIFF
--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -97,7 +97,6 @@ import CanvasDebugPanels from '@/features/canvas/components/layout/CanvasDebugPa
 import CanvasModals from '@/features/canvas/components/layout/CanvasModals';
 
 // Core components
-import BulkOperationsToolbar from '@/features/canvas/components/bulk/BulkOperationsToolbar';
 import SelectionPanel from '@/features/canvas/components/grouping/SelectionPanel';
 import ControlPanel from '@/features/canvas/components/left-sidepanel/ControlPanel';
 import GroupsPanel from '@/features/canvas/components/left-sidepanel/GroupsPanel';
@@ -2212,9 +2211,6 @@ function CanvasPageInner() {
         onCloseSettingsSheet={events.handleCloseSettingsSheet}
         onCloseRelationshipSheet={events.handleCloseRelationshipSheet}
       />
-
-      {/* Bulk operations toolbar (appears when items are selected) */}
-      <BulkOperationsToolbar />
 
       {/* Quick Search */}
       <QuickSearchCommand


### PR DESCRIPTION
Fixes **CVS-66** — selecting a node showed **two** stacked bottom action panels.

## Root cause
Two selection surfaces both rendered on select:
- `SelectionPanel` ("N selected · N nodes") — bottom-center, wired to the **real** store + `canvasActions`.
- `BulkOperationsToolbar` ("**N metrics** · Duplicate · Edit · Delete · ⋯") — the "1 metrics" panel in the screenshot.

`BulkOperationsToolbar` runs on `useBulkOperations`, which imports the **orphan** canvas store (`@/features/canvas/stores/useCanvasStore`, the split-brain copy — the real one is `@/lib/stores` → `canvasStore.ts`). So its bulk actions were operating on the wrong/empty store anyway.

## Fix
Remove the `BulkOperationsToolbar` mount (+ import). `SelectionPanel` — the correctly-wired one — now renders **alone**: Duplicate / Settings / Delete once, plus Group/Ungroup on multi-select. (The component + hook files are left in place for a future real-store rebuild under the CVS-31 toolbar consolidation.)

## Verification
type-check ✓, lint ✓ (0 errors), full Vitest ✓ (107). Visual single-panel behavior covered by the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)