### PR TITLE
fix(canvas): wire the per-node toolbar delete (CVS-61)

### DIFF
--- a/src/features/canvas/components/nodes/shared/EnhancedNodeToolbar.tsx
+++ b/src/features/canvas/components/nodes/shared/EnhancedNodeToolbar.tsx
@@ -23,6 +23,8 @@ import {
   PopoverTrigger,
 } from '@/shared/components/ui/popover';
 import { Separator } from '@/shared/components/ui/separator';
+import { useCanvasStore } from '@/lib/stores';
+import { toast } from 'sonner';
 
 interface EnhancedNodeToolbarProps {
   isVisible: boolean;
@@ -275,9 +277,17 @@ export function useNodeToolbarActions(nodeId: string, nodeType: string) {
   }, [nodeId, nodeType]);
 
   const handleDelete = React.useCallback(() => {
-    console.log(`🗑️ Delete ${nodeType} node:`, nodeId);
-    // Implement delete logic with confirmation
-  }, [nodeId, nodeType]);
+    // The per-node toolbar delete was a no-op stub (CVS-61). Wire it to the real
+    // store's persisting delete — the same path the card's own delete uses — so it
+    // actually removes the node (all 4 toolbar node types are metric_cards).
+    void useCanvasStore
+      .getState()
+      .persistNodeDelete(nodeId)
+      .catch((e) => {
+        console.error('Toolbar delete failed:', e);
+        toast.error('Failed to delete');
+      });
+  }, [nodeId]);
 
   const handleShare = React.useCallback(() => {
     console.log(`🔗 Share ${nodeType} node:`, nodeId);


### PR DESCRIPTION
Fixes **CVS-61** — deleting a node via the per-node floating toolbar's Delete button did nothing (other delete paths worked).

## Root cause
`useNodeToolbarActions.handleDelete` was a **stub**: `console.log(...)` + `// Implement delete logic`. The node components (`MetricNode`/`ValueNode`/`HypothesisNode`/`ActionNode`) pass that stub as the toolbar's `onDelete`, so the button was a no-op.

## Fix
Wire `handleDelete` to `useCanvasStore.getState().persistNodeDelete(nodeId)` — the real store's persisting delete, the same path the card's own delete uses. One fix covers all 4 toolbar node types (all `metric_cards`).

Note: the other actions in that hook (view/edit/copy/…) are also stubs — left for CVS-67 (make the toolbar node-type-aware) / follow-ups, out of scope here.

## Verification
type-check ✓, lint ✓ (0 errors), full Vitest ✓. The actual remove-and-persist is covered by the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)