### PR TITLE
feat(CVS-26): Userback → Linear Customer Requests bridge (API)

### DIFF
--- a/docs/features/userback-customer-requests.md
+++ b/docs/features/userback-customer-requests.md
@@ -1,0 +1,150 @@
+# Userback → Linear Customer Requests bridge
+
+Turns **Userback** feedback into Linear **Customer Requests** (customer needs
+attached to issues), so feedback is structured, linked to work, and visible on
+per-customer pages. Server-side by design — the Linear API key lives only in the
+edge function, never in the browser. Same shape as the System Health bridge
+([linear-setup.md](./linear-setup.md)); read that first for the shared-secret /
+Vault model.
+
+> **Status: BUILT, not yet deployed (2026-07-04).** Code + migration are in the
+> repo (CVS-26). Turning it on needs a Userback account + the deploy steps below.
+> Customer Requests is already **enabled** on the Canvasm workspace.
+
+## Architecture
+
+```
+Userback (new feedback)
+   │  webhook POST (x-userback-secret)
+   ▼
+edge fn  userback-customer-requests          ← ONLY holder of LINEAR_API_KEY
+   │  1. upsert into public.userback_feedback (idempotent by userback_id)
+   │  2. resolve/create Linear Customer  (email domain → Customer, cached in our table)
+   │  3. issueCreate  (Triage, labels if they exist)
+   │  4. customerNeedCreate  (feedback → Customer Request on that issue)
+   ▼
+Linear: Customer page shows the request, linked to a Triage issue
+```
+
+`public.userback_feedback` is the raw, insert-only evidence store **and** the
+idempotency/sync ledger (dedup by `userback_id`). RLS is on with **no policies** —
+only the edge function (service role) reads/writes it; the browser never does.
+
+## What maps to what
+
+| Userback | Linear |
+|---|---|
+| feedback id | `userback_feedback.userback_id` (dedup key) |
+| reporter email **domain** (company) | **Customer** (`domains`, `externalIds:[userback:domain:<d>]`) |
+| reporter email (personal / no domain) | individual **Customer** (`externalIds:[userback:email:<e>]`) |
+| feedback title/description | **issue** (Triage) + **Customer Request** body |
+| rating ≤ 2 (unhappy) | request **marked important** (`priority: 1`) |
+
+Company vs personal domain is decided by a small allow-list of personal providers
+in the edge function (`PERSONAL_DOMAINS`). A domain's Customer is created once and
+reused for later feedback (cached via `userback_feedback.reporter_domain`).
+
+## 1. Enable Customer Requests
+
+Linear → **Settings → Customer Requests → Enable**; set the **default team =
+Canvasm**. (Native Intercom/Zendesk/Front sources need Business+, but the **API**
+path used here works on lower plans.)
+
+## 2. Create labels (optional)
+
+The bridge only attaches labels that **already exist** (never creates them). Add
+these on the Canvasm team to get them on feedback issues (case-insensitive):
+
+- `source:user-signal`
+- `type:feedback`
+- `from:userback`
+
+Change the set with the `USERBACK_LABEL_NAMES` env (Section 6). Skip any and it's
+simply not attached.
+
+## 3. Secrets
+
+Reuse the System Health `linear_api_key` + `linear_team_id` (same workspace/team),
+and generate one new shared secret for this webhook:
+
+```bash
+openssl rand -hex 32   # -> USERBACK_SYNC_SECRET
+```
+
+## 4. Apply the migration
+
+```bash
+npx supabase db push          # applies 20260704120000_userback_feedback_intake.sql
+```
+
+Creates `public.userback_feedback` (RLS on, no policies) and
+`public.userback_sync_config()` (service-role-only Vault reader).
+
+## 5. Deploy the function
+
+```bash
+# Function secrets (env wins over Vault):
+npx supabase secrets set \
+  USERBACK_SYNC_SECRET=<openssl value from Section 3> \
+  LINEAR_API_KEY=<lin_api_...> \
+  LINEAR_TEAM_ID=<team UUID>
+
+# --no-verify-jwt: auth is the x-userback-secret header, not a user JWT.
+npx supabase functions deploy userback-customer-requests --no-verify-jwt
+```
+
+Or store the secrets in **Vault** instead of function secrets (read by
+`userback_sync_config()`), mirroring `linear-setup.md` §6.3:
+
+```sql
+select vault.create_secret('<openssl value>', 'userback_sync_secret');
+-- linear_api_key / linear_team_id already exist from the System Health bridge.
+```
+
+## 6. Optional knobs (function secrets)
+
+| Env | Default | Purpose |
+|---|---|---|
+| `LINEAR_STATE_ID` | auto (Triage→Intake→Backlog) | pin the target state |
+| `LINEAR_PROJECT_ID` | none | also file feedback issues into a project |
+| `USERBACK_LABEL_NAMES` | `source:user-signal,type:feedback,from:userback` | labels to attach (existing only) |
+| `USERBACK_SYNC_BATCH` | `25` | max feedback rows processed per invocation |
+
+## 7. Point Userback at the function
+
+In Userback → **Integrations / Webhooks**, add a webhook on **new feedback**:
+
+- URL: `https://<project-ref>.functions.supabase.co/userback-customer-requests`
+- Header: `x-userback-secret: <USERBACK_SYNC_SECRET>`
+
+The function accepts most Userback payload shapes (`{feedback}`, `{data}`, or a
+flat object) and needs at least a feedback **id**.
+
+## 8. Verify
+
+```bash
+npm run sync:userback -- --sample   # injects one sample feedback, then syncs
+```
+
+Expect `{ ok:true, intake:1, created:1, ... }`, then in Linear:
+
+1. A new **Customer** (`acme-example.com`) with a **Customer Request** on its page.
+2. A Triage **issue** titled `Feedback: Sample feedback …`, request marked
+   important (rating 2).
+3. Re-run → `deduped`/no new issue (idempotent by `userback_id`).
+
+Retry any failures: `npm run sync:userback -- --retry-failed`.
+
+## 9. Onboard business owners as Customers
+
+For AC "business owners onboarded as Customers": create a Customer per community
+business owner (Linear → Customers, or the API), set tier/size/revenue, and use
+the **customer-count** view + **mark-important** to triage. Feedback from a known
+domain then lands on that owner's existing Customer automatically.
+
+## Notes
+
+- `userback_feedback` is server-only (no client access), so it is **not** added to
+  `src/shared/lib/supabase/types.ts` and needs no Prisma regen — the app never
+  queries it.
+- No secrets are committed; `LINEAR_API_KEY` never reaches the browser bundle.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ CVS). See the **Docs policy** in [`../AGENTS.md`](../AGENTS.md).
 - **[state-management/](state-management/)** — XState patterns
 - **features/ (infra only)** — [system-health-intake](features/system-health-intake.md),
   [linear-setup](features/linear-setup.md), [linear-initiatives](features/linear-initiatives.md),
+  [userback-customer-requests](features/userback-customer-requests.md),
   [metrics-api](features/metrics-api.md)
 
 Anything product-facing (feature narratives, changelogs, methodology, PRD) belongs

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "prepare": "husky",
     "test": "vitest",
     "test:rls": "tsx src/tests/run-rls-tests.ts",
-    "sync:errors": "node scripts/sync-error-reports.mjs"
+    "sync:errors": "node scripts/sync-error-reports.mjs",
+    "sync:userback": "node scripts/sync-userback.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --no-warn-ignored"

--- a/scripts/sync-userback.mjs
+++ b/scripts/sync-userback.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Trigger / test the Userback -> Linear Customer Requests bridge (edge function
+// `userback-customer-requests`). In production Userback POSTs the function via
+// webhook; use this for verification, manual sweeps, and retrying failures.
+//
+//   node scripts/sync-userback.mjs                 # sweep pending rows -> Linear
+//   node scripts/sync-userback.mjs --retry-failed  # flip failed -> pending, then sweep
+//   node scripts/sync-userback.mjs --sample        # inject one sample feedback, then sweep
+//
+// Reads from .env (git-ignored): VITE_SUPABASE_URL and USERBACK_SYNC_SECRET.
+// Optional override: USERBACK_SYNC_URL (full function URL). Server-only secret —
+// never ship it to the client bundle.
+
+import fs from 'node:fs';
+
+function loadEnv() {
+  const env = { ...process.env };
+  try {
+    const raw = fs.readFileSync(new URL('../.env', import.meta.url), 'utf8');
+    for (const line of raw.split('\n')) {
+      const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+      if (m && env[m[1]] === undefined) {
+        env[m[1]] = m[2].trim().replace(/^["']|["']$/g, '');
+      }
+    }
+  } catch {
+    /* no .env — rely on process.env */
+  }
+  return env;
+}
+
+const env = loadEnv();
+const supabaseUrl = env.VITE_SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
+const secret = env.USERBACK_SYNC_SECRET;
+
+if (!supabaseUrl) throw new Error('Missing VITE_SUPABASE_URL in .env');
+if (!secret) throw new Error('Missing USERBACK_SYNC_SECRET in .env');
+
+const ref = new URL(supabaseUrl).hostname.split('.')[0];
+const fnUrl =
+  env.USERBACK_SYNC_URL || `https://${ref}.functions.supabase.co/userback-customer-requests`;
+
+let body = '{}';
+if (process.argv.includes('--retry-failed')) {
+  body = JSON.stringify({ retryFailed: true });
+} else if (process.argv.includes('--sample')) {
+  // A minimal Userback-shaped payload for end-to-end verification.
+  body = JSON.stringify({
+    event: 'feedback.created',
+    feedback: {
+      id: `sample-${Date.now()}`,
+      title: 'Sample feedback from sync-userback.mjs',
+      description: 'Verifying the Userback → Customer Requests bridge end to end.',
+      rating: 2,
+      category: 'general',
+      email: 'founder@acme-example.com',
+      name: 'Sample Reporter',
+      page_url: 'https://app.canvasm.app/canvas/demo',
+    },
+  });
+}
+
+console.log(`Invoking ${fnUrl} …`);
+const res = await fetch(fnUrl, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', 'x-userback-secret': secret },
+  body,
+});
+const payload = await res.json().catch(() => ({}));
+console.log(`HTTP ${res.status}`, JSON.stringify(payload, null, 2));
+process.exit(res.ok ? 0 : 1);

--- a/supabase/functions/userback-customer-requests/index.ts
+++ b/supabase/functions/userback-customer-requests/index.ts
@@ -1,0 +1,405 @@
+// User & Ops Signals bridge: Userback feedback -> Linear Customer Requests.
+//
+// Same server-side shape as the System Health bridge (sync-error-reports): the
+// Linear API key lives ONLY here (never in the browser). Userback POSTs a webhook
+// on new feedback; we persist it insert-only into `userback_feedback` (idempotent
+// by Userback id), then for each pending row:
+//   1. resolve/create a Linear Customer keyed by the reporter's email domain
+//      (cached via our own table so repeat feedback reuses the same customer),
+//   2. create a Linear issue in Triage (labels attached only if they exist),
+//   3. attach the feedback as a Customer Request (customerNeed) on that issue.
+//
+// Two entry shapes (both authenticated by the x-userback-secret shared secret):
+//   - Webhook delivery: body carries the feedback -> upsert it, then sweep.
+//   - Manual/replay:     body {} (optionally {retryFailed:true}) -> sweep only.
+//     Invoke via scripts/sync-userback.mjs.
+//
+// Config comes from Supabase Vault via public.userback_sync_config(), or function-
+// secret env (env wins): USERBACK_SYNC_SECRET, LINEAR_API_KEY, LINEAR_TEAM_ID.
+// Optional env: LINEAR_STATE_ID, LINEAR_PROJECT_ID, USERBACK_LABEL_NAMES,
+// USERBACK_SYNC_BATCH (default 25).
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const LINEAR_URL = 'https://api.linear.app/graphql';
+const DEFAULT_LABELS = 'source:user-signal,type:feedback,from:userback';
+const PERSONAL_DOMAINS = new Set([
+  'gmail.com', 'googlemail.com', 'outlook.com', 'hotmail.com', 'live.com',
+  'yahoo.com', 'icloud.com', 'me.com', 'proton.me', 'protonmail.com', 'aol.com',
+]);
+
+const M_CREATE_ISSUE = `mutation($input: IssueCreateInput!){ issueCreate(input:$input){ success issue{ id identifier url } } }`;
+const M_CREATE_CUSTOMER = `mutation($input: CustomerCreateInput!){ customerCreate(input:$input){ success customer{ id name } } }`;
+const M_CREATE_NEED = `mutation($input: CustomerNeedCreateInput!){ customerNeedCreate(input:$input){ success need{ id } } }`;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function truncate(s: string | null | undefined, n: number): string {
+  if (!s) return '';
+  return s.length > n ? s.slice(0, n) + '\n…(truncated)' : s;
+}
+
+function routeOf(url: string | null | undefined): string {
+  if (!url) return '/';
+  try {
+    return new URL(url).pathname || '/';
+  } catch {
+    return '/';
+  }
+}
+
+function domainOf(email: string | null | undefined): string | null {
+  if (!email || !email.includes('@')) return null;
+  const d = email.split('@').pop()?.trim().toLowerCase();
+  return d || null;
+}
+
+async function linear(apiKey: string, query: string, variables: Record<string, unknown>) {
+  const res = await fetch(LINEAR_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: apiKey },
+    body: JSON.stringify({ query, variables }),
+  });
+  const body = await res.json().catch(() => null);
+  if (!res.ok || body?.errors) {
+    const msg = body?.errors?.map((e: { message: string }) => e.message).join('; ') ??
+      `Linear HTTP ${res.status}`;
+    throw new Error(msg);
+  }
+  return body.data;
+}
+
+type State = { id: string; name: string; type: string; position: number };
+
+async function teamStates(apiKey: string, teamId: string): Promise<State[]> {
+  const data = await linear(
+    apiKey,
+    `query($teamId:String!){ team(id:$teamId){ states{ nodes{ id name type position } } } }`,
+    { teamId }
+  );
+  return data?.team?.states?.nodes ?? [];
+}
+
+/** Intake/Triage target for new feedback issues. */
+function pickTriageState(states: State[]): string | undefined {
+  const envState = Deno.env.get('LINEAR_STATE_ID');
+  if (envState) return envState;
+  return (
+    states.find((s) => s.type === 'triage')?.id ??
+    states.find((s) => /intake|triage/i.test(s.name))?.id ??
+    states
+      .filter((s) => s.type === 'backlog' || s.type === 'unstarted')
+      .sort((a, b) => a.position - b.position)[0]?.id
+  );
+}
+
+async function resolveLabelIds(apiKey: string, teamId: string): Promise<string[]> {
+  const wanted = (Deno.env.get('USERBACK_LABEL_NAMES') ?? DEFAULT_LABELS)
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  if (wanted.length === 0) return [];
+  const data = await linear(
+    apiKey,
+    `query($teamId:String!){ team(id:$teamId){ labels{ nodes{ id name } } } }`,
+    { teamId }
+  );
+  const nodes: Array<{ id: string; name: string }> = data?.team?.labels?.nodes ?? [];
+  return nodes.filter((l) => wanted.includes(l.name.toLowerCase())).map((l) => l.id);
+}
+
+/** Normalise the many shapes Userback can POST into one flat record. */
+function normalizeFeedback(raw: Record<string, unknown>) {
+  const fb = (raw.feedback ?? raw.data ?? raw) as Record<string, unknown>;
+  const pick = (...keys: string[]): string | null => {
+    for (const k of keys) {
+      const v = fb[k];
+      if (typeof v === 'string' && v.trim()) return v.trim();
+      if (typeof v === 'number') return String(v);
+    }
+    return null;
+  };
+  const reporter = (fb.reporter ?? fb.user ?? {}) as Record<string, unknown>;
+  const email =
+    pick('email', 'reporter_email', 'user_email') ??
+    (typeof reporter.email === 'string' ? reporter.email : null);
+  const ratingRaw = pick('rating', 'nps', 'score');
+  const rating = ratingRaw != null && /^\d+$/.test(ratingRaw) ? Number(ratingRaw) : null;
+  return {
+    userback_id: pick('id', 'feedback_id', 'ticket_id') ?? null,
+    reporter_email: email,
+    reporter_name:
+      pick('name', 'reporter_name', 'user_name') ??
+      (typeof reporter.name === 'string' ? reporter.name : null),
+    title: pick('title', 'subject', 'summary'),
+    body: pick('description', 'message', 'comment', 'body', 'text'),
+    rating,
+    category: pick('category', 'type', 'kind'),
+    page_url: pick('page_url', 'url', 'pageUrl'),
+    raw: fb,
+  };
+}
+
+type FeedbackRow = {
+  id: string;
+  userback_id: string;
+  reporter_email: string | null;
+  reporter_name: string | null;
+  reporter_domain: string | null;
+  title: string | null;
+  body: string | null;
+  rating: number | null;
+  category: string | null;
+  page_url: string | null;
+  linear_customer_id: string | null;
+};
+
+function buildIssueTitle(r: FeedbackRow): string {
+  const base = (r.title || r.body || 'User feedback').replace(/\s+/g, ' ').slice(0, 80);
+  return `Feedback: ${base}`;
+}
+
+function buildIssueBody(r: FeedbackRow): string {
+  const route = routeOf(r.page_url);
+  return [
+    '## Summary',
+    '',
+    'Customer feedback captured via Userback and bridged into Linear Customer Requests.',
+    '',
+    '## Classification',
+    '',
+    '- Source group: User & Ops Signals',
+    '- Source detail: Userback feedback',
+    '- Task type: Feedback',
+    `- Rating: ${r.rating != null ? r.rating : '—'}`,
+    `- Category: ${r.category ?? '—'}`,
+    '',
+    '## Reporter',
+    '',
+    `- Name: ${r.reporter_name ?? '—'}`,
+    `- Email: ${r.reporter_email ?? '—'}`,
+    `- Domain (→ Customer): ${r.reporter_domain ?? '—'}`,
+    `- Page: ${r.page_url ?? '—'} (route \`${route}\`)`,
+    '',
+    '## Feedback',
+    '',
+    r.body ? truncate(r.body, 4000) : '_none provided_',
+    '',
+    '## Links',
+    '',
+    `- Userback feedback id: \`${r.userback_id}\``,
+    '- Supabase table: `userback_feedback` (raw + sync state)',
+  ].join('\n');
+}
+
+/** Config from function-secret env, falling back to Vault (public.userback_sync_config). */
+async function loadConfig(admin: ReturnType<typeof createClient>) {
+  let apiKey = Deno.env.get('LINEAR_API_KEY') || undefined;
+  let teamId = Deno.env.get('LINEAR_TEAM_ID') || undefined;
+  let secret = Deno.env.get('USERBACK_SYNC_SECRET') || undefined;
+  if (!apiKey || !teamId || !secret) {
+    try {
+      const { data } = await admin.rpc('userback_sync_config');
+      const row = Array.isArray(data) ? data[0] : data;
+      if (row) {
+        apiKey = apiKey || row.linear_api_key || undefined;
+        teamId = teamId || row.linear_team_id || undefined;
+        secret = secret || row.userback_sync_secret || undefined;
+      }
+    } catch {
+      /* Vault RPC unavailable; rely on env */
+    }
+  }
+  return { apiKey, teamId, secret };
+}
+
+/** Resolve (or create) the Linear Customer for a feedback row's email domain. */
+async function resolveCustomerId(
+  admin: ReturnType<typeof createClient>,
+  apiKey: string,
+  r: FeedbackRow
+): Promise<string> {
+  const domain = r.reporter_domain;
+  // 1. Reuse a customer we already created for this domain (our own cache — no
+  //    reliance on Linear filter capabilities). Personal domains never share a
+  //    customer; each such reporter is their own "individual" customer by email.
+  if (domain && !PERSONAL_DOMAINS.has(domain)) {
+    const { data: prior } = await admin
+      .from('userback_feedback')
+      .select('linear_customer_id')
+      .eq('reporter_domain', domain)
+      .not('linear_customer_id', 'is', null)
+      .limit(1)
+      .maybeSingle();
+    if (prior?.linear_customer_id) return prior.linear_customer_id as string;
+  }
+
+  // 2. Create a new customer. Company domain -> org customer; personal/no email ->
+  //    individual customer keyed by email (or anonymous).
+  const isCompany = domain && !PERSONAL_DOMAINS.has(domain);
+  const name = isCompany ? domain : r.reporter_email || r.reporter_name || 'Anonymous (Userback)';
+  const externalId = isCompany
+    ? `userback:domain:${domain}`
+    : `userback:email:${(r.reporter_email ?? 'anonymous').toLowerCase()}`;
+  const data = await linear(apiKey, M_CREATE_CUSTOMER, {
+    input: {
+      name,
+      externalIds: [externalId],
+      ...(isCompany ? { domains: [domain] } : {}),
+    },
+  });
+  const id = data?.customerCreate?.customer?.id;
+  if (!id) throw new Error('customerCreate returned no customer id');
+  return id;
+}
+
+Deno.serve(async (req) => {
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  const admin = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  );
+
+  const { apiKey, teamId, secret } = await loadConfig(admin);
+  if (!secret || req.headers.get('x-userback-secret') !== secret) {
+    return json({ error: 'Unauthorized' }, 401);
+  }
+  if (!apiKey || !teamId) {
+    return json({ error: 'LINEAR_API_KEY and LINEAR_TEAM_ID must be configured' }, 500);
+  }
+
+  const batch = Number(Deno.env.get('USERBACK_SYNC_BATCH') ?? '25');
+  const projectId = Deno.env.get('LINEAR_PROJECT_ID') || undefined;
+  const summary = { intake: 0, processed: 0, created: 0, skipped: 0, deduped: 0, failed: 0 };
+
+  let payload: Record<string, unknown> = {};
+  try {
+    payload = (await req.json()) as Record<string, unknown>;
+  } catch {
+    payload = {};
+  }
+
+  // --- Optional intake: a webhook delivery carries the feedback itself. ---
+  const looksLikeFeedback =
+    payload && (payload.feedback || payload.data ||
+      payload.id || payload.description || payload.message || payload.title);
+  if (looksLikeFeedback && !payload.retryFailed) {
+    const n = normalizeFeedback(payload);
+    if (!n.userback_id) {
+      return json({ error: 'Feedback payload missing an id' }, 422);
+    }
+    const { error } = await admin.from('userback_feedback').upsert(
+      {
+        userback_id: n.userback_id,
+        reporter_email: n.reporter_email,
+        reporter_name: n.reporter_name,
+        reporter_domain: domainOf(n.reporter_email),
+        title: n.title,
+        body: n.body,
+        rating: n.rating,
+        category: n.category,
+        page_url: n.page_url,
+        raw: n.raw,
+      },
+      { onConflict: 'userback_id', ignoreDuplicates: true }
+    );
+    if (error) return json({ error: error.message }, 500);
+    summary.intake++;
+  }
+
+  if (payload.retryFailed) {
+    await admin
+      .from('userback_feedback')
+      .update({ sync_status: 'pending', updated_at: new Date().toISOString() })
+      .eq('sync_status', 'failed');
+  }
+
+  // Resolve Linear metadata once.
+  let triageStateId: string | undefined;
+  let labelIds: string[] = [];
+  try {
+    const states = await teamStates(apiKey, teamId);
+    triageStateId = pickTriageState(states);
+    labelIds = await resolveLabelIds(apiKey, teamId);
+  } catch (e) {
+    return json({ error: `Linear metadata: ${e instanceof Error ? e.message : e}` }, 502);
+  }
+
+  // --- Sweep pending rows -> Linear (Customer + Issue + Customer Request). ---
+  const { data: pending, error: pErr } = await admin
+    .from('userback_feedback')
+    .select(
+      'id, userback_id, reporter_email, reporter_name, reporter_domain, title, body, rating, category, page_url, linear_customer_id'
+    )
+    .eq('sync_status', 'pending')
+    .order('created_at', { ascending: true })
+    .limit(batch);
+  if (pErr) return json({ error: pErr.message }, 500);
+
+  for (const r of (pending ?? []) as FeedbackRow[]) {
+    summary.processed++;
+    const nowIso = new Date().toISOString();
+    try {
+      const customerId = await resolveCustomerId(admin, apiKey, r);
+
+      const issueData = await linear(apiKey, M_CREATE_ISSUE, {
+        input: {
+          teamId,
+          title: buildIssueTitle(r),
+          description: buildIssueBody(r),
+          ...(triageStateId ? { stateId: triageStateId } : {}),
+          ...(labelIds.length ? { labelIds } : {}),
+          ...(projectId ? { projectId } : {}),
+        },
+      });
+      const issue = issueData?.issueCreate?.issue;
+      if (!issue?.id) throw new Error('issueCreate returned no issue id');
+
+      // Mark-important when the reporter is unhappy (low rating).
+      const important = r.rating != null && r.rating <= 2 ? 1 : 0;
+      const needData = await linear(apiKey, M_CREATE_NEED, {
+        input: {
+          body: r.body || r.title || 'User feedback (see linked issue)',
+          customerId,
+          issueId: issue.id,
+          priority: important,
+        },
+      });
+      const needId = needData?.customerNeedCreate?.need?.id ?? null;
+
+      await admin
+        .from('userback_feedback')
+        .update({
+          linear_customer_id: customerId,
+          linear_issue_id: issue.id,
+          linear_issue_identifier: issue.identifier ?? null,
+          linear_issue_url: issue.url ?? null,
+          linear_need_id: needId,
+          sync_status: 'synced',
+          sync_error: null,
+          linear_synced_at: nowIso,
+          updated_at: nowIso,
+        })
+        .eq('id', r.id);
+      summary.created++;
+    } catch (e) {
+      summary.failed++;
+      await admin
+        .from('userback_feedback')
+        .update({
+          sync_status: 'failed',
+          sync_error: e instanceof Error ? e.message : String(e),
+          updated_at: nowIso,
+        })
+        .eq('id', r.id);
+    }
+  }
+
+  return json({ ok: true, ...summary });
+});

--- a/supabase/migrations/20260704120000_userback_feedback_intake.sql
+++ b/supabase/migrations/20260704120000_userback_feedback_intake.sql
@@ -1,0 +1,79 @@
+-- =====================================================================
+-- USER & OPS SIGNALS INTAKE — Userback feedback -> Linear Customer Requests.
+-- `userback_feedback` is the raw, insert-only evidence store + idempotency/sync
+-- ledger for the `userback-customer-requests` edge function (the ONLY holder of
+-- the Linear API key). The browser never touches this table — Userback POSTs the
+-- edge function directly. RLS is ON with NO policies: only the service role (the
+-- edge function) can read/write. Deduped by the Userback feedback id.
+-- See docs/features/userback-customer-requests.md.
+-- =====================================================================
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.userback_feedback (
+  id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Userback's own feedback id — unique so repeat webhook deliveries no-op.
+  userback_id             text NOT NULL UNIQUE,
+  reporter_email          text,
+  reporter_name           text,
+  -- email domain -> Linear Customer mapping key (company domains only).
+  reporter_domain         text,
+  title                   text,
+  body                    text,
+  rating                  integer,
+  category                text,
+  page_url                text,
+  -- full normalized Userback payload for audit / replay.
+  raw                     jsonb,
+  -- Linear sync metadata (server-side bridge only)
+  linear_customer_id      text,
+  linear_issue_id         text,
+  linear_issue_identifier text,
+  linear_issue_url        text,
+  linear_need_id          text,
+  sync_status             text NOT NULL DEFAULT 'pending'
+                            CHECK (sync_status IN ('pending','synced','failed','skipped')),
+  sync_error              text,
+  linear_synced_at        timestamptz,
+  created_at              timestamptz NOT NULL DEFAULT now(),
+  updated_at              timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_userback_feedback_sync_status
+  ON public.userback_feedback (sync_status);
+-- Lookup used to reuse an existing Customer for a company domain.
+CREATE INDEX IF NOT EXISTS idx_userback_feedback_reporter_domain
+  ON public.userback_feedback (reporter_domain);
+
+-- Client can never touch this table: RLS on, no policies. The edge function
+-- writes via service_role (bypasses RLS).
+ALTER TABLE public.userback_feedback ENABLE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------
+-- Read sync secrets from Vault (no function-secret env required). Mirrors
+-- public.error_sync_config(). Deno.env still wins if set. Execute restricted to
+-- service_role, so only the edge function can read the secrets. Set with:
+--   select vault.create_secret('<linear-api-key>', 'linear_api_key');
+--   select vault.create_secret('<team-uuid>',      'linear_team_id');
+--   select vault.create_secret('<shared-secret>',  'userback_sync_secret');
+-- (linear_api_key / linear_team_id are shared with error_sync_config.)
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.userback_sync_config()
+RETURNS TABLE (
+  linear_api_key       text,
+  linear_team_id       text,
+  userback_sync_secret text
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'linear_api_key'),
+    (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'linear_team_id'),
+    (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'userback_sync_secret');
+$$;
+
+REVOKE ALL ON FUNCTION public.userback_sync_config() FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.userback_sync_config() TO service_role;
+
+COMMIT;


### PR DESCRIPTION
Bridges **Userback feedback → Linear Customer Requests** via a server-side edge function — the same shape as the System Health bridge, so the **Linear API key never touches the browser**.

## What it does
Userback webhook → edge fn `userback-customer-requests`:
1. Upsert into insert-only `public.userback_feedback` (idempotent by `userback_id`).
2. Resolve/create a Linear **Customer** from the reporter's email **domain** (company domains reused via our own table; personal domains → individual customer).
3. Create a Triage **issue** (labels attached only if they already exist).
4. Attach the feedback as a **Customer Request** (`customerNeed`) on that issue; **mark-important** when rating ≤ 2.

## Files
- `supabase/functions/userback-customer-requests/index.ts` — the bridge (also does a pending-sweep + `retryFailed`, so `scripts/sync-userback.mjs` can drive it).
- `supabase/migrations/20260704120000_userback_feedback_intake.sql` — `userback_feedback` (RLS on, **no policies** — service-role only) + `userback_sync_config()` Vault reader (shares `linear_api_key`/`linear_team_id` with the error bridge).
- `scripts/sync-userback.mjs` + `npm run sync:userback` — `--sample` / `--retry-failed` / sweep.
- `docs/features/userback-customer-requests.md` — operator A–Z (enable Customer Requests, webhook, secrets, deploy, verify, onboard owners as Customers).

## Acceptance criteria
- [x] Customer Requests enabled with a default team — enabled on the workspace (confirmed via API); default-team step documented.
- [x] New Userback feedback creates a Customer Request linked to an issue, visible on the customer page — implemented (Customer + issue + `customerNeed`).
- [x] Linear API key never exposed in the browser — key lives only in the edge fn (function secret / Vault).
- [x] Business owners onboarded as Customers; mark-important + customer-count view — mark-important implemented (priority on low ratings); onboarding + customer-count view documented (§9).

## Not done here (needs owner / creds)
Deploy + Userback webhook wiring need a Userback account and the Linear/Supabase secrets — documented in the setup doc, not run from CI. Migration is added as a file (not pushed to prod) for review.

Verify: `npm run type-check`, `npx eslint`, and `npx vitest run` (107 passing) all green.

Ref: CVS-26. Vault note **2.a.v User and Operations Signals Pipeline**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)