### PR TITLE
feat(collab): stable codename for comment authors, not raw Clerk id (CVS-33)

### DIFF
--- a/src/features/canvas/components/collaboration/CollaborationPanel.tsx
+++ b/src/features/canvas/components/collaboration/CollaborationPanel.tsx
@@ -51,6 +51,7 @@ import {
 } from '@/shared/lib/supabase/services/collaboration';
 import { setProjectPublic } from '@/shared/lib/supabase/services/projects';
 import { getClientForEnvironment } from '@/shared/utils/authenticatedClient';
+import { userCodename } from '@/shared/utils/codename';
 import {
   ArrowLeft,
   Check,
@@ -98,11 +99,12 @@ export function CollaborationPanel({
   currentPage,
 }: CollaborationPanelProps) {
   const user = useAppStore((s) => s.user);
-  const { members, byId, isLoading: membersLoading, reload: reloadMembers } =
+  const { members, isLoading: membersLoading, reload: reloadMembers } =
     useProjectMembers(projectId, open, presence);
 
-  const authorName = (id: string | null) =>
-    (id && byId[id]?.name) || id || 'Unknown';
+  // Comment authors show a stable pseudonymous codename — never the raw Clerk id
+  // or real name (CVS-33). The People list keeps real names (intentional).
+  const authorName = (id: string | null) => userCodename(id);
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange} modal={false}>

--- a/src/features/canvas/components/panels/relationship-panel/tabs/comments-tab.tsx
+++ b/src/features/canvas/components/panels/relationship-panel/tabs/comments-tab.tsx
@@ -12,6 +12,7 @@ import {
   type CommentRow,
 } from '@/shared/lib/supabase/services/collaboration';
 import { getClientForEnvironment } from '@/shared/utils/authenticatedClient';
+import { userCodename } from '@/shared/utils/codename';
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -45,14 +46,15 @@ export function CommentsTab({ cardId }: CommentsTabProps) {
   const { canvasId } = useParams();
   const projectId = canvasId && canvasId !== 'new' ? canvasId : undefined;
   const user = useAppStore((s) => s.user);
-  const { members, byId } = useProjectMembers(projectId, Boolean(cardId));
+  const { members } = useProjectMembers(projectId, Boolean(cardId));
 
   const [threadId, setThreadId] = React.useState<string | null>(null);
   const [comments, setComments] = React.useState<CommentRow[]>([]);
   const [posting, setPosting] = React.useState(false);
 
-  const authorName = (id: string | null) =>
-    (id && byId[id]?.name) || id || 'Unknown';
+  // Privacy: show a stable pseudonymous codename, never the raw Clerk id or the
+  // real name/email (CVS-33).
+  const authorName = (id: string | null) => userCodename(id);
 
   // Resolve (but don't create) this card's thread on open.
   React.useEffect(() => {

--- a/src/shared/utils/codename.test.ts
+++ b/src/shared/utils/codename.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { userCodename, codenameInitials } from './codename';
+
+describe('userCodename', () => {
+  const id = 'user_30uQARGozqSApAChPSGSwFyUiy85';
+
+  it('is deterministic + stable for the same id', () => {
+    expect(userCodename(id)).toBe(userCodename(id));
+    expect(userCodename(id)).toMatch(/^[A-Z][a-z]+ [A-Z][a-z]+$/);
+  });
+
+  it('never leaks the raw id', () => {
+    const name = userCodename(id);
+    expect(name).not.toContain('user_');
+    expect(name).not.toBe(id);
+  });
+
+  it('differs across different ids (no trivial collision on a small set)', () => {
+    const ids = Array.from({ length: 20 }, (_, i) => `user_${i}abcXYZ`);
+    const names = new Set(ids.map(userCodename));
+    expect(names.size).toBeGreaterThan(15); // mostly unique
+  });
+
+  it('handles null/empty', () => {
+    expect(userCodename(null)).toBe('Unknown');
+    expect(userCodename(undefined)).toBe('Unknown');
+    expect(userCodename('')).toBe('Unknown');
+  });
+});
+
+describe('codenameInitials', () => {
+  it('derives two uppercase letters from the codename', () => {
+    const init = codenameInitials('user_abc');
+    expect(init).toMatch(/^[A-Z]{2}$/);
+    // stable + derived from the codename, not the id
+    const [a, b] = userCodename('user_abc').split(' ');
+    expect(init).toBe((a[0] + b[0]).toUpperCase());
+  });
+});

--- a/src/shared/utils/codename.ts
+++ b/src/shared/utils/codename.ts
@@ -1,0 +1,52 @@
+// Deterministic, stable, pseudonymous codename for a user id (CVS-33).
+// Comment/collaboration UI must not leak raw Clerk ids (`user_…`) or real
+// names/emails. Given a user id we derive a readable "Adjective Noun" handle
+// from a hash of the id — the SAME id always yields the SAME codename, across
+// sessions and comments, with no PII and no network lookup.
+//
+// Shared utility: reuse this everywhere author identity is shown (comments,
+// avatars, mentions, notifications). Do not reimplement per surface.
+
+const ADJECTIVES = [
+  'Swift', 'Bright', 'Calm', 'Bold', 'Keen', 'Brave', 'Quiet', 'Nimble',
+  'Lucid', 'Merry', 'Noble', 'Amber', 'Cosmic', 'Golden', 'Silver', 'Crimson',
+  'Azure', 'Jade', 'Rapid', 'Gentle', 'Clever', 'Vivid', 'Mellow', 'Steady',
+  'Sunny', 'Frosty', 'Lively', 'Solar', 'Lunar', 'Wild', 'Zesty', 'Curious',
+];
+
+const NOUNS = [
+  'Falcon', 'Otter', 'Cedar', 'Comet', 'Heron', 'Maple', 'Willow', 'Lynx',
+  'Sparrow', 'Badger', 'Coral', 'Ember', 'Harbor', 'Meadow', 'Quartz', 'Raven',
+  'Sable', 'Thistle', 'Vale', 'Wren', 'Aspen', 'Birch', 'Cobalt', 'Delta',
+  'Fable', 'Grove', 'Halo', 'Iris', 'Juniper', 'Koi', 'Larch', 'Onyx',
+];
+
+/** FNV-1a — small, fast, deterministic string hash. */
+function hash(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/** Stable "Adjective Noun" handle for a user id (never the raw id or real name). */
+export function userCodename(id: string | null | undefined): string {
+  if (!id) return 'Unknown';
+  const h = hash(id);
+  const adj = ADJECTIVES[h % ADJECTIVES.length];
+  const noun = NOUNS[Math.floor(h / ADJECTIVES.length) % NOUNS.length];
+  return `${adj} ${noun}`;
+}
+
+/** Two-letter avatar initials derived from the codename (e.g. "SF"). */
+export function codenameInitials(id: string | null | undefined): string {
+  return userCodename(id)
+    .split(' ')
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+}


### PR DESCRIPTION
Fixes **CVS-33** — comment threads showed the author as a raw Clerk id (`user_30uQ…`) when the real name wasn't resolved: unreadable + leaks an internal identifier.

## Change
- New shared util **`userCodename` / `codenameInitials`** (`src/shared/utils/codename.ts`): a deterministic **"Adjective Noun"** handle hashed from the user id — **same id → same codename** across sessions/comments, no PII, no network lookup. Unit-tested.
- Applied to the **comment author name + avatar initials** in `CommentsTab` and `CollaborationPanel` (both had the same `byId[id]?.name || id` fallback).

## Scope decision (please confirm)
The issue asks for "no real names anywhere," but I deliberately **kept real names** in two places where codenames would break usability:
- the **People / members list** (you need to see who's on your project), and
- the **@mention picker** + already-posted `@name` text (stored as literal `@Name` in comment content; you can't pick "Swift Falcon" without knowing who that is).

If you want those converted to codenames too, that's a follow-up (it also affects stored mention text). Notifications are already clean ("You were mentioned" / "You were assigned to <card>" — no ids).

Shared util — the **Evidence lane (CVS-34/35/36) reuses it**, unblocking that lane.

## Verification
type-check ✓, lint ✓ (0 errors), Vitest ✓ (112, incl. 5 new codename tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)