### PR TITLE
feat(canvas): off-screen node wayfinding indicator + recenter shortcut (CVS-30)

### DIFF
--- a/src/features/canvas/components/wayfinding/OffscreenNodeIndicator.tsx
+++ b/src/features/canvas/components/wayfinding/OffscreenNodeIndicator.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from 'react';
+import {
+  Panel,
+  useNodes,
+  useReactFlow,
+  useStore,
+  useViewport,
+} from '@xyflow/react';
+import { ArrowRight } from 'lucide-react';
+
+// Wayfinding (CVS-30): when the user pans/zooms so that NO node is in view, show
+// an edge-anchored arrow pointing toward the nodes' centroid. Clicking it (or the
+// Shift+1 shortcut wired in CanvasPage) fits the view back to the content.
+
+const DEFAULT_W = 220;
+const DEFAULT_H = 120;
+const EDGE_PAD = 30;
+
+export default function OffscreenNodeIndicator() {
+  const nodes = useNodes();
+  const { fitView } = useReactFlow();
+  const { x, y, zoom } = useViewport();
+  const width = useStore((s) => s.width);
+  const height = useStore((s) => s.height);
+
+  const indicator = useMemo(() => {
+    if (!nodes.length || !width || !height) return null;
+
+    // Current viewport in flow coordinates (screen = flow * zoom + pan).
+    const xMin = -x / zoom;
+    const xMax = (width - x) / zoom;
+    const yMin = -y / zoom;
+    const yMax = (height - y) / zoom;
+
+    let anyVisible = false;
+    let sumX = 0;
+    let sumY = 0;
+    for (const n of nodes) {
+      const w = n.measured?.width ?? n.width ?? DEFAULT_W;
+      const h = n.measured?.height ?? n.height ?? DEFAULT_H;
+      const cx = n.position.x + w / 2;
+      const cy = n.position.y + h / 2;
+      sumX += cx;
+      sumY += cy;
+      if (cx >= xMin && cx <= xMax && cy >= yMin && cy <= yMax) anyVisible = true;
+    }
+    if (anyVisible) return null;
+
+    // Project the centroid to screen, then anchor an arrow at the viewport edge
+    // along the direction from the screen center to that point.
+    const centroidX = sumX / nodes.length;
+    const centroidY = sumY / nodes.length;
+    const sx = centroidX * zoom + x;
+    const sy = centroidY * zoom + y;
+    const cxp = width / 2;
+    const cyp = height / 2;
+    const dx = sx - cxp;
+    const dy = sy - cyp;
+    if (dx === 0 && dy === 0) return null;
+
+    const halfW = width / 2 - EDGE_PAD;
+    const halfH = height / 2 - EDGE_PAD;
+    const tx = Math.abs(dx) > 1e-3 ? halfW / Math.abs(dx) : Infinity;
+    const ty = Math.abs(dy) > 1e-3 ? halfH / Math.abs(dy) : Infinity;
+    const t = Math.min(tx, ty);
+
+    return {
+      left: cxp + dx * t,
+      top: cyp + dy * t,
+      angleDeg: (Math.atan2(dy, dx) * 180) / Math.PI,
+      count: nodes.length,
+    };
+  }, [nodes, x, y, zoom, width, height]);
+
+  if (!indicator) return null;
+
+  return (
+    <Panel
+      position="top-left"
+      className="pointer-events-none !inset-0 !m-0"
+    >
+      <button
+        type="button"
+        onClick={() => fitView({ padding: 0.2, duration: 800 })}
+        aria-label={`${indicator.count} off-screen node${indicator.count === 1 ? '' : 's'} — return to your nodes`}
+        title="Return to your nodes (Shift+1)"
+        style={{ left: indicator.left, top: indicator.top }}
+        className="pointer-events-auto absolute z-10 flex -translate-x-1/2 -translate-y-1/2 items-center gap-1 rounded-full border border-border bg-primary px-2.5 py-1.5 text-primary-foreground shadow-lg outline-none transition-transform hover:scale-105 focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <ArrowRight
+          className="h-4 w-4"
+          style={{ transform: `rotate(${indicator.angleDeg}deg)` }}
+        />
+        <span className="text-xs font-semibold tabular-nums">{indicator.count}</span>
+      </button>
+    </Panel>
+  );
+}

--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -98,6 +98,7 @@ import CanvasModals from '@/features/canvas/components/layout/CanvasModals';
 
 // Core components
 import SelectionPanel from '@/features/canvas/components/grouping/SelectionPanel';
+import OffscreenNodeIndicator from '@/features/canvas/components/wayfinding/OffscreenNodeIndicator';
 import ControlPanel from '@/features/canvas/components/left-sidepanel/ControlPanel';
 import GroupsPanel from '@/features/canvas/components/left-sidepanel/GroupsPanel';
 import TopCanvasToolbar from '@/features/canvas/components/mini-control/TopCanvasToolbar';
@@ -1048,6 +1049,12 @@ function CanvasPageInner() {
         }
         return;
       }
+      // Shift+1 → fit view to content / recenter (CVS-30 wayfinding).
+      if (e.shiftKey && e.code === 'Digit1') {
+        e.preventDefault();
+        fitView({ padding: 0.2, duration: 800 });
+        return;
+      }
       if (!(e.ctrlKey || e.metaKey)) return;
       const k = e.key.toLowerCase();
       if (k === 'c') canvasActions.copySelection();
@@ -1066,7 +1073,7 @@ function CanvasPageInner() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [canvasActions]);
+  }, [canvasActions, fitView]);
 
   // Memoized filter options
   const availableFilterOptions = useMemo(() => {
@@ -1997,6 +2004,7 @@ function CanvasPageInner() {
           >
             <Background />
             <Controls />
+            <OffscreenNodeIndicator />
             <CanvasCursorsLayer sendCursor={sendCursor} />
 
             {/* Read-only / comment-only banner for restricted collaborators. */}


### PR DESCRIPTION
Fixes **CVS-30** — panning/zooming away from your nodes left you lost with no cue where they are.

## Change
- New **`OffscreenNodeIndicator`** (mounted in `<ReactFlow>`): when **no node is within the viewport**, it renders an **edge-anchored arrow** pointing toward the nodes' centroid, with an off-screen **count** badge. Clicking it **fits the view** back to the content. It hides as soon as any node is visible.
- **Shift+1 → fitView** recenter shortcut (guarded by the `isEditable` check so it's inert while typing). The existing `<Controls>` fit button remains the persistent recenter control.

Geometry is pure viewport math (flow↔screen via `useViewport` + store dims), reactive to node moves via `useNodes`. Direction verified: nodes off-right → arrow at right edge pointing right; nodes above → top edge pointing up; etc.

## Acceptance criteria
- [x] Panned away → directional indicator at the viewport edge pointing to the nodes
- [x] Click → fit/zoom-to-content
- [x] Recenter via control (`<Controls>`) + shortcut (Shift+1)
- [x] Hides when nodes are in view; centroid handles multiple clusters (+ count)
- [x] Keyboard-accessible button (aria-label, focus ring), adequate target size

## Verification
type-check ✓, lint ✓ (0 errors), full Vitest ✓. Visual behavior (arrow appears/points/recenters) covered by the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)