### PR TITLE
CVS-86: build out Account & Settings (personal/workspace split)

### DIFF
--- a/src/features/settings/pages/AccountSettingsPage.tsx
+++ b/src/features/settings/pages/AccountSettingsPage.tsx
@@ -1,18 +1,37 @@
 import { UserProfile } from '@clerk/react-router';
+import { Badge } from '@/shared/components/ui/badge';
 import { Button } from '@/shared/components/ui/button';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import {
+  createApiKey,
+  deleteApiKey,
+  listApiKeys,
+  type ApiKey,
+} from '@/shared/lib/supabase/services/apiKeys';
 import { cn } from '@/shared/utils';
 import {
   ArrowLeft,
+  Bell,
+  BarChart3,
+  Copy,
+  CreditCard,
+  KeyRound,
   Monitor,
   Moon,
   Palette,
+  Plug,
+  Plus,
   SlidersHorizontal,
   Sparkles,
   Sun,
+  Table,
+  Trash2,
   User,
 } from 'lucide-react';
 import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 const THEMES = [
   { id: 'light', label: 'Light', icon: Sun },
@@ -21,15 +40,44 @@ const THEMES = [
   { id: 'system', label: 'System', icon: Monitor },
 ] as const;
 
+// Personal notification/UI preferences — local to this browser until a prefs
+// table exists (see the product vault).
+const PREF_KEY = 'metrimap-notif-prefs';
+const PREFS = [
+  { id: 'mention', label: 'Email me when I’m mentioned' },
+  { id: 'assigned', label: 'Email me when I’m assigned to a metric' },
+  { id: 'dataAlert', label: 'Email me on data/source alerts' },
+  { id: 'inAppMention', label: 'Show in-app notifications for mentions' },
+  { id: 'weeklyDigest', label: 'Send me a weekly activity digest' },
+] as const;
+
+function loadPrefs(): Record<string, boolean> {
+  try {
+    return JSON.parse(localStorage.getItem(PREF_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+// Connected accounts are scaffolded here; the OAuth/data pipes are owned by the
+// Integrations work and the workspace-level warehouse connections.
+const CONNECTORS = [
+  { id: 'ga4', label: 'Google Analytics 4', icon: BarChart3 },
+  { id: 'sheets', label: 'Google Sheets', icon: Table },
+  { id: 'stripe', label: 'Stripe', icon: CreditCard },
+] as const;
+
 function Section({
   icon: Icon,
   title,
   description,
+  action,
   children,
 }: {
   icon: React.ElementType;
   title: string;
   description?: string;
+  action?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
@@ -37,6 +85,7 @@ function Section({
       <div className="mb-4 flex items-center gap-2">
         <Icon className="h-4 w-4 text-primary" />
         <h2 className="text-base font-semibold">{title}</h2>
+        {action && <div className="ml-auto">{action}</div>}
       </div>
       {description && (
         <p className="-mt-3 mb-4 text-sm text-muted-foreground">{description}</p>
@@ -48,13 +97,62 @@ function Section({
 
 /**
  * Personal account settings (per-user), distinct from Workspace Settings
- * (per-org). Reached from the user menu's single "Settings" entry — collapses
- * the old duplicate Profile/Settings items (CVS-87). Identity is managed inline
- * via Clerk's UserProfile; workspace-level config lives at /settings/workspace.
+ * (per-org). Reached from the user menu's single "Settings" entry (CVS-87).
+ * Built out per CVS-86: Profile, Appearance, Notifications, API keys — moved
+ * here from Workspace Settings so personal vs workspace config is cleanly split
+ * — plus Connected accounts and Billing (scaffolded, pending backend).
  */
 export default function AccountSettingsPage() {
   const navigate = useNavigate();
+  const client = useClerkSupabase();
   const { theme, setTheme } = useTheme();
+
+  const [prefs, setPrefs] = useState<Record<string, boolean>>(() => loadPrefs());
+  const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
+  const [newKey, setNewKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!client) return;
+    listApiKeys(client)
+      .then(setApiKeys)
+      .catch(() => setApiKeys([]));
+  }, [client]);
+
+  const togglePref = (id: string) => {
+    setPrefs((prev) => {
+      const next = { ...prev, [id]: !prev[id] };
+      try {
+        localStorage.setItem(PREF_KEY, JSON.stringify(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  };
+
+  const generateKey = async () => {
+    if (!client) return;
+    const name = window.prompt('Name this API key (e.g. "CI pipeline")')?.trim();
+    if (!name) return;
+    try {
+      const { key, row } = await createApiKey(name, client);
+      setApiKeys((prev) => [row, ...prev]);
+      setNewKey(key);
+    } catch {
+      toast.error('Failed to create API key');
+    }
+  };
+
+  const revokeKey = async (id: string) => {
+    if (!client) return;
+    try {
+      await deleteApiKey(id, client);
+      setApiKeys((prev) => prev.filter((k) => k.id !== id));
+      toast.success('API key revoked');
+    } catch {
+      toast.error('Failed to revoke key');
+    }
+  };
 
   return (
     <div className="min-h-screen bg-background">
@@ -78,7 +176,18 @@ export default function AccountSettingsPage() {
       </div>
 
       <div className="mx-auto max-w-3xl space-y-5 px-6 py-6">
-        {/* Appearance (personal preference) */}
+        {/* Profile / identity (Clerk) */}
+        <Section
+          icon={User}
+          title="Profile"
+          description="Manage your name, email, avatar, connected logins, and account security."
+        >
+          <div className="overflow-hidden rounded-md border border-border">
+            <UserProfile routing="hash" />
+          </div>
+        </Section>
+
+        {/* Appearance */}
         <Section
           icon={Palette}
           title="Appearance"
@@ -107,14 +216,154 @@ export default function AccountSettingsPage() {
           </div>
         </Section>
 
-        {/* Profile / identity (Clerk) */}
+        {/* Notifications & preferences */}
         <Section
-          icon={User}
-          title="Profile"
-          description="Manage your name, email, avatar, connected logins, and account security."
+          icon={Bell}
+          title="Notifications & preferences"
+          description="Control what Metrimap emails and shows you. Local to this browser for now."
         >
-          <div className="overflow-hidden rounded-md border border-border">
-            <UserProfile routing="hash" />
+          <div className="space-y-2">
+            {PREFS.map((p) => (
+              <label
+                key={p.id}
+                className="flex cursor-pointer items-center justify-between rounded-md border border-border px-3 py-2 text-sm"
+              >
+                <span>{p.label}</span>
+                <input
+                  type="checkbox"
+                  checked={!!prefs[p.id]}
+                  onChange={() => togglePref(p.id)}
+                  className="h-4 w-4 accent-primary"
+                />
+              </label>
+            ))}
+          </div>
+        </Section>
+
+        {/* Personal API keys */}
+        <Section
+          icon={KeyRound}
+          title="API keys"
+          description="Generate keys to push & pull metric values programmatically (send an x-api-key header to the metrics-api endpoint)."
+          action={
+            <Button variant="outline" size="sm" onClick={generateKey}>
+              <Plus className="mr-1 h-4 w-4" />
+              Generate key
+            </Button>
+          }
+        >
+          {newKey && (
+            <div className="mb-3 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/50 dark:bg-amber-950/30">
+              <p className="mb-1 text-xs font-medium text-amber-800 dark:text-amber-300">
+                Copy your key now — it won’t be shown again.
+              </p>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 truncate rounded bg-background px-2 py-1 font-mono text-xs">
+                  {newKey}
+                </code>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    navigator.clipboard.writeText(newKey).then(
+                      () => toast.success('Key copied'),
+                      () => toast.error('Copy failed')
+                    )
+                  }
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => setNewKey(null)}>
+                  Done
+                </Button>
+              </div>
+            </div>
+          )}
+          {apiKeys.length === 0 ? (
+            <p className="text-sm text-muted-foreground/70">No API keys yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {apiKeys.map((k) => (
+                <div
+                  key={k.id}
+                  className="flex items-center justify-between rounded-md border border-border px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">{k.name}</div>
+                    <div className="truncate font-mono text-xs text-muted-foreground">
+                      {k.key_prefix}…{' '}
+                      {k.last_used_at
+                        ? `· last used ${new Date(k.last_used_at).toLocaleDateString()}`
+                        : '· never used'}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => revokeKey(k.id)}
+                    title="Revoke key"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </Section>
+
+        {/* Connected accounts (scaffold — pipes owned by Integrations) */}
+        <Section
+          icon={Plug}
+          title="Connected accounts"
+          description="Link data sources to pull metrics automatically. Workspace-wide warehouse connections live in Workspace Settings."
+        >
+          <div className="space-y-2">
+            {CONNECTORS.map((c) => {
+              const Icon = c.icon;
+              return (
+                <div
+                  key={c.id}
+                  className="flex items-center justify-between rounded-md border border-border px-3 py-2"
+                >
+                  <div className="flex items-center gap-2 text-sm">
+                    <Icon className="h-4 w-4 text-muted-foreground" />
+                    {c.label}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary" className="font-normal">
+                      Soon
+                    </Badge>
+                    <Button variant="outline" size="sm" disabled>
+                      Connect
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </Section>
+
+        {/* Billing (scaffold — pending backend) */}
+        <Section
+          icon={CreditCard}
+          title="Billing"
+          description="Your plan, usage, and payment method."
+        >
+          <div className="flex items-center justify-between rounded-md border border-border p-4">
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">Free plan</span>
+                <Badge variant="secondary" className="font-normal">
+                  Current
+                </Badge>
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Plans, usage, and invoices are coming soon.
+              </p>
+            </div>
+            <Button variant="outline" size="sm" disabled>
+              Manage billing
+            </Button>
           </div>
         </Section>
       </div>

--- a/src/features/settings/pages/WorkspaceSettingsPage.tsx
+++ b/src/features/settings/pages/WorkspaceSettingsPage.tsx
@@ -1,57 +1,8 @@
 import { OrganizationProfile } from '@clerk/react-router';
 import { Button } from '@/shared/components/ui/button';
 import { ConnectionsPanel } from '@/features/data/components/ConnectionsPanel';
-import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
-import {
-  createApiKey,
-  deleteApiKey,
-  listApiKeys,
-  type ApiKey,
-} from '@/shared/lib/supabase/services/apiKeys';
-import { cn } from '@/shared/utils';
-import {
-  ArrowLeft,
-  Bell,
-  Copy,
-  Database,
-  KeyRound,
-  Monitor,
-  Moon,
-  Palette,
-  Plus,
-  Sparkles,
-  Sun,
-  Trash2,
-  Users,
-} from 'lucide-react';
-import { useTheme } from 'next-themes';
-import { useEffect, useState } from 'react';
+import { ArrowLeft, Database, User, Users } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
-
-const THEMES = [
-  { id: 'light', label: 'Light', icon: Sun },
-  { id: 'dark', label: 'Dark', icon: Moon },
-  { id: 'night', label: 'Night', icon: Sparkles },
-  { id: 'system', label: 'System', icon: Monitor },
-] as const;
-
-// Notification preferences are local-only for now (no backend prefs table yet —
-// see the product vault).
-const PREF_KEY = 'metrimap-notif-prefs';
-const PREFS = [
-  { id: 'mention', label: 'Email me when I’m mentioned' },
-  { id: 'assigned', label: 'Email me when I’m assigned to a metric' },
-  { id: 'dataAlert', label: 'Email me on data/source alerts' },
-] as const;
-
-function loadPrefs(): Record<string, boolean> {
-  try {
-    return JSON.parse(localStorage.getItem(PREF_KEY) || '{}');
-  } catch {
-    return {};
-  }
-}
 
 function Section({
   icon: Icon,
@@ -78,57 +29,13 @@ function Section({
   );
 }
 
+/**
+ * Workspace (per-org) settings: data-source connections and members/roles.
+ * Personal settings (profile, appearance, notifications, API keys) live at
+ * /settings (Account Settings) — see CVS-86.
+ */
 export default function WorkspaceSettingsPage() {
   const navigate = useNavigate();
-  const client = useClerkSupabase();
-  const { theme, setTheme } = useTheme();
-
-  const [prefs, setPrefs] = useState<Record<string, boolean>>(() => loadPrefs());
-  const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
-  const [newKey, setNewKey] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!client) return;
-    listApiKeys(client)
-      .then(setApiKeys)
-      .catch(() => setApiKeys([]));
-  }, [client]);
-
-  const generateKey = async () => {
-    if (!client) return;
-    const name = window.prompt('Name this API key (e.g. "CI pipeline")')?.trim();
-    if (!name) return;
-    try {
-      const { key, row } = await createApiKey(name, client);
-      setApiKeys((prev) => [row, ...prev]);
-      setNewKey(key);
-    } catch {
-      toast.error('Failed to create API key');
-    }
-  };
-
-  const revokeKey = async (id: string) => {
-    if (!client) return;
-    try {
-      await deleteApiKey(id, client);
-      setApiKeys((prev) => prev.filter((k) => k.id !== id));
-      toast.success('API key revoked');
-    } catch {
-      toast.error('Failed to revoke key');
-    }
-  };
-
-  const togglePref = (id: string) => {
-    setPrefs((prev) => {
-      const next = { ...prev, [id]: !prev[id] };
-      try {
-        localStorage.setItem(PREF_KEY, JSON.stringify(next));
-      } catch {
-        /* ignore */
-      }
-      return next;
-    });
-  };
 
   return (
     <div className="min-h-screen bg-background">
@@ -139,141 +46,26 @@ export default function WorkspaceSettingsPage() {
             Home
           </Button>
           <h1 className="text-xl font-bold">Workspace Settings</h1>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto"
+            onClick={() => navigate('/settings')}
+          >
+            <User className="mr-1 h-4 w-4" />
+            Account Settings
+          </Button>
         </div>
       </div>
 
       <div className="mx-auto max-w-3xl space-y-5 px-6 py-6">
-        {/* Appearance */}
-        <Section
-          icon={Palette}
-          title="Appearance"
-          description="Choose how Metrimap looks. Night is a deeper, warm-black variant."
-        >
-          <div className="flex flex-wrap gap-2">
-            {THEMES.map((t) => {
-              const Icon = t.icon;
-              const active = (theme ?? 'system') === t.id;
-              return (
-                <button
-                  key={t.id}
-                  onClick={() => setTheme(t.id)}
-                  className={cn(
-                    'flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors',
-                    active
-                      ? 'border-primary bg-primary/10 text-foreground'
-                      : 'border-border text-muted-foreground hover:bg-muted'
-                  )}
-                >
-                  <Icon className="h-4 w-4" />
-                  {t.label}
-                </button>
-              );
-            })}
-          </div>
-        </Section>
-
-        {/* Data source connections */}
+        {/* Data source connections (workspace-wide) */}
         <Section
           icon={Database}
           title="Data source connections"
           description="Warehouse connections available to Source Nodes across this workspace."
         >
           <ConnectionsPanel />
-        </Section>
-
-        {/* API keys */}
-        <Section
-          icon={KeyRound}
-          title="API keys"
-          description="Push & pull metric values programmatically (POST/GET the metrics-api endpoint with an x-api-key header). Scoped to this workspace."
-        >
-          {newKey && (
-            <div className="mb-3 rounded-md border border-amber-200 bg-amber-50 p-3">
-              <p className="mb-1 text-xs font-medium text-amber-800">
-                Copy your key now — it won’t be shown again.
-              </p>
-              <div className="flex items-center gap-2">
-                <code className="flex-1 truncate rounded bg-white px-2 py-1 font-mono text-xs">
-                  {newKey}
-                </code>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    navigator.clipboard.writeText(newKey).then(
-                      () => toast.success('Key copied'),
-                      () => toast.error('Copy failed')
-                    );
-                  }}
-                >
-                  <Copy className="h-3.5 w-3.5" />
-                </Button>
-                <Button variant="ghost" size="sm" onClick={() => setNewKey(null)}>
-                  Done
-                </Button>
-              </div>
-            </div>
-          )}
-          <div className="mb-3">
-            <Button variant="outline" size="sm" onClick={generateKey}>
-              <Plus className="mr-1 h-4 w-4" />
-              Generate API key
-            </Button>
-          </div>
-          {apiKeys.length === 0 ? (
-            <p className="text-sm text-muted-foreground/70">No API keys yet.</p>
-          ) : (
-            <div className="space-y-2">
-              {apiKeys.map((k) => (
-                <div
-                  key={k.id}
-                  className="flex items-center justify-between rounded-md border border-border px-3 py-2"
-                >
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-medium">{k.name}</div>
-                    <div className="truncate font-mono text-xs text-muted-foreground">
-                      {k.key_prefix}…{' '}
-                      {k.last_used_at
-                        ? `· last used ${new Date(k.last_used_at).toLocaleDateString()}`
-                        : '· never used'}
-                    </div>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => revokeKey(k.id)}
-                    title="Revoke key"
-                  >
-                    <Trash2 className="h-4 w-4 text-destructive" />
-                  </Button>
-                </div>
-              ))}
-            </div>
-          )}
-        </Section>
-
-        {/* Notification preferences */}
-        <Section
-          icon={Bell}
-          title="Notification preferences"
-          description="Local to this browser for now."
-        >
-          <div className="space-y-2">
-            {PREFS.map((p) => (
-              <label
-                key={p.id}
-                className="flex cursor-pointer items-center justify-between rounded-md border border-border px-3 py-2 text-sm"
-              >
-                <span>{p.label}</span>
-                <input
-                  type="checkbox"
-                  checked={!!prefs[p.id]}
-                  onChange={() => togglePref(p.id)}
-                  className="h-4 w-4 accent-primary"
-                />
-              </label>
-            ))}
-          </div>
         </Section>
 
         {/* Members & roles (Clerk org) */}


### PR DESCRIPTION
Closes CVS-86.

> ⚠️ **Stacked on #18 (CVS-87).** Until #18 merges, this PR's diff also shows the CVS-87 commit. Merge **#18 first**, then this.

Turns the thin account surface into a proper settings area and resolves the personal-vs-workspace redundancy the epic calls out.

## Account Settings (`/settings`) — built out
- **Profile** (Clerk) and **Appearance** (from CVS-87)
- **Notifications & preferences** — functional (per-user, localStorage-backed; expanded set incl. in-app + weekly digest)
- **API keys** — generate/revoke via the existing `apiKeys` service; **moved here from Workspace Settings** (they're per-user)
- **Connected accounts** — scaffolded list (GA4, Sheets, Stripe) with disabled "Soon" connect buttons. OAuth/data pipes are owned by the **Integrations lane**; workspace warehouse connections stay in Workspace Settings.
- **Billing** — scaffolded plan/usage card ("coming soon"), pending backend.

## Workspace Settings (`/settings/workspace`) — now workspace-only
- Data-source connections + Members/roles. Appearance, Notifications, and API keys removed (moved to Account). Cross-links added between the two pages.

## Notes / scope
- Connected accounts + Billing are **intentionally scaffolded** (no backend / cross-lane) — the epic's sub-issues fill them in. Everything else is functional.
- Stayed in-lane (`src/features/settings/**`).

Verify: type-check clean · changed files lint-clean (0 findings) · 107 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)