### PR TITLE
fix(CVS-127): DB hardening Phase 1 — function grants + search_path

### DIFF
--- a/supabase/migrations/20260704130000_harden_function_grants_phase1.sql
+++ b/supabase/migrations/20260704130000_harden_function_grants_phase1.sql
@@ -1,0 +1,46 @@
+-- =====================================================================
+-- DB SECURITY HARDENING — Phase 1 (CVS-127).
+-- Addresses Supabase security advisors:
+--   * function_search_path_mutable (stamp_updated_by_and_at)
+--   * {anon,authenticated}_security_definer_function_executable, restricted to
+--     the PURE trigger/cron functions that no client `.rpc()` and no RLS policy
+--     calls by name.
+--
+-- WHY THIS IS SAFE:
+--   - Trigger functions run in the trigger/owner context on the table event; the
+--     invoking role does NOT need EXECUTE on them. Revoking anon/authenticated
+--     therefore cannot break INSERT/UPDATE paths.
+--   - run_alert_sweep / dispatch_error_report_sync are invoked by pg_cron /
+--     service_role, and upsert_user by the Clerk webhook (service_role). We do
+--     NOT touch service_role, so cron + webhook keep working.
+--   - Identity/permission helpers used by RLS policies + client `.rpc`
+--     (get_clerk_user_id, requesting_*, has_project_access, can_*,
+--     my_project_permission, emit_card_alert, notify_card_assigned) are LEFT
+--     ALONE here — the anon revoke on those is Phase 2 (needs anon-policy check).
+--
+-- Verify after apply (all should be false / true respectively):
+--   select p.proname,
+--     has_function_privilege('anon', p.oid, 'EXECUTE')          as anon,
+--     has_function_privilege('authenticated', p.oid, 'EXECUTE') as auth,
+--     has_function_privilege('service_role', p.oid, 'EXECUTE')  as svc
+--   from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+--   where n.nspname='public' and p.proname in ('rollup_error_report','run_alert_sweep', ...);
+-- =====================================================================
+BEGIN;
+
+-- 1. Fixed search_path for the one flagged mutable-search_path function.
+ALTER FUNCTION public.stamp_updated_by_and_at() SET search_path = public;
+
+-- 2. Revoke EXECUTE from anon + authenticated on pure trigger/cron functions.
+--    (service_role is intentionally NOT revoked.)
+REVOKE EXECUTE ON FUNCTION public.rollup_error_report()                    FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_updated_at_column()               FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_projects_updated_at()             FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.handle_new_user()                        FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.handle_user_update()                     FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.stamp_updated_by_and_at()                FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.run_alert_sweep()                        FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.dispatch_error_report_sync()             FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.upsert_user(text, text, text, text)      FROM anon, authenticated;
+
+COMMIT;


### PR DESCRIPTION
Phase 1 of hardening the **96 Supabase security-advisor warnings** (CVS-127). Conservative, high-confidence subset only — no blanket "fix all".

## Changes (one migration)
- **`function_search_path_mutable`** → set fixed `search_path` on `stamp_updated_by_and_at`.
- **Revoke `EXECUTE` from `anon` + `authenticated`** on 9 pure trigger/cron functions: `rollup_error_report`, `update_updated_at_column`, `update_projects_updated_at`, `handle_new_user`, `handle_user_update`, `upsert_user`, `stamp_updated_by_and_at`, `run_alert_sweep`, `dispatch_error_report_sync`. Clears 18 of the 37 SECURITY-DEFINER exec findings.

## Why it's safe (verified read-only against prod)
- Trigger functions run in the trigger/owner context — the invoking role needs no `EXECUTE`, so INSERT/UPDATE paths can't break.
- `run_alert_sweep` / `dispatch_error_report_sync` run via pg_cron/`service_role`; `upsert_user` via the Clerk webhook (`service_role`). Confirmed **all 9 retain `service_role` + `postgres` EXECUTE** — untouched by this migration.
- No client `.rpc()` and no RLS policy calls these by name (checked the codebase).

## Deliberately NOT touched
- `error_report_groups` / `userback_feedback` RLS-no-policy and `error_reports` always-true INSERT — **intentional by design**.
- Identity/permission helpers (`get_clerk_user_id`, `requesting_*`, `has_project_access`, `can_*`, `my_project_permission`, `emit_card_alert`, `notify_card_assigned`) — used by RLS/client; anon-revoke is Phase 2.

## Review notes
- ⚠️ **Not self-merged** — this changes production grants. Please review, then apply via `npx supabase db push` and run the CVS-127 manual test (verify privileges + a live crash-report/alert still file).
- Phase 2 (disable the unused GraphQL endpoint → clears all 56 GraphQL findings, anon revokes on helpers, move `pg_net` out of `public`) is documented in CVS-127.

Ref: CVS-127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)