### PR TITLE
fix(canvas): don't crash Strategy page on auth-client race (CVS-22)

### DIFF
--- a/src/features/canvas/hooks/useProjectMembers.ts
+++ b/src/features/canvas/hooks/useProjectMembers.ts
@@ -3,7 +3,7 @@ import {
   getProjectCollaborators,
   type Collaborator,
 } from '@/shared/lib/supabase/services/collaborators';
-import { getClientForEnvironment } from '@/shared/utils/authenticatedClient';
+import { whenAuthenticatedClientReady } from '@/shared/utils/authenticatedClient';
 import * as React from 'react';
 
 export interface ProjectMember {
@@ -53,7 +53,12 @@ export function useProjectMembers(
     let mounted = true;
     if (!enabled || !projectId) return;
     setIsLoading(true);
-    getProjectCollaborators(projectId, getClientForEnvironment())
+    // Wait for the Clerk-authenticated client instead of calling
+    // getClientForEnvironment() synchronously — it THROWS if the client isn't set
+    // yet (it's evaluated as an argument, so the .catch below never sees it),
+    // which crashed the Strategy page on first render (CVS-22).
+    whenAuthenticatedClientReady()
+      .then((client) => getProjectCollaborators(projectId, client))
       .then((rows) => {
         if (mounted) setCollaborators(rows || []);
       })


### PR DESCRIPTION
Fixes **CVS-22** — `/canvas/:id/strategy` crashed with *"Authenticated client not available. Please ensure you are logged in."*

## Root cause
`useProjectMembers` (used by StrategyPage on mount, `enabled=true`) fetched collaborators as:
```ts
getProjectCollaborators(projectId, getClientForEnvironment())
```
`getClientForEnvironment()` **throws** when the Clerk-authenticated client isn't set yet. It's evaluated **synchronously as an argument**, so the promise `.catch()` never catches it — the throw escapes the effect → ErrorBoundary. On first render (before `AuthenticatedSupabaseProvider` sets the client), the Strategy page hit this every time it lost the race.

## Fix
Await the **non-throwing** `whenAuthenticatedClientReady()` first (the exact gate `CanvasPage` already uses at line ~340), then fetch:
```ts
whenAuthenticatedClientReady()
  .then((client) => getProjectCollaborators(projectId, client))
  .then(...)
```
Now it waits for auth instead of throwing; real fetch errors are still caught.

## Verification
type-check ✓, lint ✓, full Vitest ✓. Cold-load-on-`/strategy` covered by the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)