### PR TITLE
feat(CVS-28): free security PR checks — Dependabot + CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Free dependency (SCA) scanning — GitHub-native, surfaced in the repo Security tab.
+# Part of the security PR-checks work (CVS-28, Path B: Dependabot + CodeQL instead
+# of paid Snyk). Weekly PRs for npm deps + the GitHub Actions we use.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    # Reduce PR noise: batch non-major bumps; majors still come as their own PRs.
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+# Free static analysis (SAST) — GitHub-native CodeQL, results in the Security tab.
+# Part of the security PR-checks work (CVS-28, Path B). JS/TS needs no build, so
+# build-mode: none keeps runs fast. security-extended widens the query set.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 3 * * 1" # weekly, Monday 03:27 UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/docs/features/security-scanning.md
+++ b/docs/features/security-scanning.md
@@ -1,0 +1,33 @@
+# Security scanning (free, GitHub-native)
+
+Dependency (SCA) + static-analysis (SAST) scanning for the repo, using free
+GitHub-native tools instead of a paid Snyk plan (CVS-28, Path B). Findings land in
+the repo **Security** tab; the plan is to route only High/Critical into Linear
+later (see below).
+
+## What's wired
+
+| Tool | Config | Covers |
+|---|---|---|
+| **Dependabot** | `.github/dependabot.yml` | npm dependency CVEs (SCA) + GitHub-Actions version bumps. Weekly PRs; non-major bumps grouped to cut noise. |
+| **CodeQL** | `.github/workflows/codeql.yml` | JS/TS static analysis (SAST), `security-extended` query set. Runs on push/PR to `main` + weekly. `build-mode: none` (no build needed for JS/TS). |
+
+Also enable in **repo Settings → Code security**: *Dependabot alerts* and
+*Dependabot security updates* (the config file drives version PRs; the alerts
+toggle drives the vulnerability feed).
+
+## Not this layer
+
+- **Database security** (RLS, GraphQL exposure, SECURITY DEFINER grants) is covered
+  by **Supabase advisors**, not CodeQL/Dependabot — disjoint layer, tracked in
+  CVS-127. Don't cross-route.
+- **Snyk** (paid) was evaluated in CVS-28: reserve it for when we need auto-fix PRs,
+  license compliance, or container/IaC scanning.
+
+## Routing to Linear (follow-up)
+
+Keep the Security tab as the working surface. When we want tickets, add a small
+GitHub Action that files **only High/Critical** CodeQL/Dependabot alerts into
+Linear (label `source:security`), deduped by the alert's stable id — same
+server-side pattern as the System Health / Userback bridges. Don't auto-file
+low/medium (noise).

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ CVS). See the **Docs policy** in [`../AGENTS.md`](../AGENTS.md).
 - **features/ (infra only)** — [system-health-intake](features/system-health-intake.md),
   [linear-setup](features/linear-setup.md), [linear-initiatives](features/linear-initiatives.md),
   [userback-customer-requests](features/userback-customer-requests.md),
+  [security-scanning](features/security-scanning.md),
   [metrics-api](features/metrics-api.md)
 
 Anything product-facing (feature narratives, changelogs, methodology, PRD) belongs


### PR DESCRIPTION
CVS-28 **Path B** (owner picked the free route over paid Snyk): GitHub-native dependency + code scanning, zero setup, no billing.

- `.github/dependabot.yml` — weekly **npm SCA** + GitHub-Actions bumps (non-major grouped to cut noise).
- `.github/workflows/codeql.yml` — **JS/TS SAST** (`security-extended`, `build-mode: none`), on push/PR to `main` + weekly.
- `docs/features/security-scanning.md` — what's wired + the Linear-routing follow-up (route only High/Critical, deduped, same server-side pattern).

**Disjoint from Supabase advisors** (DB layer, CVS-127) — no cross-routing, no double-filing.

One repo-settings step for you: **Settings → Code security → enable Dependabot alerts + security updates** (the config drives version PRs; the toggle drives the vuln feed).

Ref: CVS-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)