### PR TITLE
feat(canvas): consolidate canvas controls into one toolbar (CVS-31)

### DIFF
--- a/src/features/canvas/components/mini-control/TopCanvasToolbar.tsx
+++ b/src/features/canvas/components/mini-control/TopCanvasToolbar.tsx
@@ -3,11 +3,13 @@ import {
   Eraser,
   Hand,
   Lasso,
+  Layers,
   MapPin,
   MessageSquarePlus,
   MousePointer,
   PenTool,
   Search,
+  SlidersHorizontal,
   Square,
 } from 'lucide-react';
 import AddNodeButton from './AddNodeButton';
@@ -49,6 +51,13 @@ interface TopCanvasToolbarProps {
       | 'whiteboardNode'
   ) => void;
   onAddFromCatalog?: (position?: { x: number; y: number }) => void;
+
+  // Organize cluster (folded in from the old top-right panel, CVS-31)
+  onToggleGroups?: () => void;
+  groupsActive?: boolean;
+  onToggleOperators?: () => void;
+  operatorsActive?: boolean;
+  exportSlot?: React.ReactNode;
 }
 
 export default function TopCanvasToolbar(props: TopCanvasToolbarProps) {
@@ -179,6 +188,42 @@ export default function TopCanvasToolbar(props: TopCanvasToolbarProps) {
           {/* Layout dropdown */}
           <LayoutDropdownButton />
           <FilterControls />
+          {/* Organize: groups + tools (operators) + export — folded in from the
+              old scattered top-right panel so the canvas has one toolbar (CVS-31) */}
+          {(props.onToggleGroups || props.onToggleOperators || props.exportSlot) && (
+            <>
+              <div className="mx-0.5 h-6 w-px bg-gray-200" aria-hidden />
+              {props.onToggleGroups && (
+                <WithTooltip label="Groups">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={getToolButtonClasses(!!props.groupsActive)}
+                    title="Groups"
+                    aria-pressed={!!props.groupsActive}
+                    onClick={props.onToggleGroups}
+                  >
+                    <Layers className="h-4 w-4" />
+                  </Button>
+                </WithTooltip>
+              )}
+              {props.onToggleOperators && (
+                <WithTooltip label="Tools">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className={getToolButtonClasses(!!props.operatorsActive)}
+                    title="Tools"
+                    aria-pressed={!!props.operatorsActive}
+                    onClick={props.onToggleOperators}
+                  >
+                    <SlidersHorizontal className="h-4 w-4" />
+                  </Button>
+                </WithTooltip>
+              )}
+              {props.exportSlot}
+            </>
+          )}
         </div>
       )}
 

--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -18,8 +18,7 @@ import {
 import '@xyflow/react/dist/style.css';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Eye, Layers, SlidersHorizontal } from 'lucide-react';
-import { Button } from '@/shared/components/ui/button';
+import { Eye } from 'lucide-react';
 
 // Extracted utilities and hooks
 import { useCanvasNodesStore } from '@/features/canvas/stores/useCanvasNodesStore';
@@ -2061,6 +2060,11 @@ function CanvasPageInner() {
                 currentLayoutDirection={state.currentLayoutDirection}
                 onAddCustomNode={handleAddCustomNode}
                 onAddFromCatalog={handleAddFromCatalog}
+                onToggleGroups={() => setShowGroupsPanel((v) => !v)}
+                groupsActive={showGroupsPanel}
+                onToggleOperators={() => setShowOperatorPanel((v) => !v)}
+                operatorsActive={showOperatorPanel}
+                exportSlot={<CanvasExportMenu />}
               />
             </Panel>
 
@@ -2087,33 +2091,10 @@ function CanvasPageInner() {
               </Panel>
             )}
 
-            {/* Top-right toggles: Groups (focus/filter) + Tools (operators) */}
-            {state.toolbarMode === 'edit' && (
+            {/* Groups fly-out — toggled from the consolidated toolbar (CVS-31) */}
+            {state.toolbarMode === 'edit' && showGroupsPanel && (
               <Panel position="top-right">
                 <div className="flex flex-col items-end gap-2">
-                  <div className="flex items-center gap-2">
-                    <CanvasExportMenu />
-                    <Button
-                      variant={showGroupsPanel ? 'default' : 'outline'}
-                      size="sm"
-                      onClick={() => setShowGroupsPanel((v) => !v)}
-                      className="h-8 gap-1.5 border bg-background/90 shadow-sm backdrop-blur"
-                      title={showGroupsPanel ? 'Hide groups' : 'Show groups'}
-                    >
-                      <Layers className="h-4 w-4" />
-                      {showGroupsPanel ? 'Hide groups' : 'Groups'}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setShowOperatorPanel((v) => !v)}
-                      className="h-8 gap-1.5 border bg-background/90 shadow-sm backdrop-blur"
-                      title={showOperatorPanel ? 'Hide tools' : 'Show tools'}
-                    >
-                      <SlidersHorizontal className="h-4 w-4" />
-                      {showOperatorPanel ? 'Hide tools' : 'Tools'}
-                    </Button>
-                  </div>
                   {showGroupsPanel && (
                     <GroupsPanel
                       groups={canvas?.groups || []}


### PR DESCRIPTION
Fixes **CVS-31** — in-canvas controls were split across two surfaces.

## Before
- `TopCanvasToolbar` (top-center): tools, auto-layout (`LayoutDropdownButton`), filter (`FilterControls`), search.
- Separate **top-right panel**: Export, **Groups** toggle, **Tools/operators** toggle.

## After — one toolbar
Folded the top-right cluster into `TopCanvasToolbar` behind a **divider** (Groups · Tools · Export), so all five clusters — **filter, search, auto-layout, groups, tools** — live in a single bar. The Groups fly-out and operator `ControlPanel` are unchanged; their toggles now live in the toolbar (`aria-pressed` reflects open state). Removed the scattered top-right button row and its now-unused imports.

## Acceptance criteria
- [x] Filter, search, auto-layout, groups, tools all in one toolbar
- [x] No function removed — everything still reachable
- [x] Logical grouping with a divider; consistent icons + tooltips
- [x] Keyboard-accessible (buttons + `aria-pressed`)

Pairs with **CVS-32** (relocate this consolidated bar to top-right) — next.

## Verification
type-check ✓, lint ✓ (0 errors), full Vitest ✓. Visual layout covered by the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)