### PR TITLE
feat(canvas): anchor the consolidated toolbar top-right (CVS-32)

### DIFF
--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -2018,9 +2018,9 @@ function CanvasPageInner() {
               </Panel>
             )}
 
-            {/* Top toolbar */}
+            {/* Top toolbar — anchored top-right (CVS-32) */}
             <Panel
-              position="top-center"
+              position="top-right"
               className="pointer-events-auto"
               style={{ zIndex: 1010 }}
             >
@@ -2091,9 +2091,10 @@ function CanvasPageInner() {
               </Panel>
             )}
 
-            {/* Groups fly-out — toggled from the consolidated toolbar (CVS-31) */}
+            {/* Groups fly-out — toggled from the consolidated toolbar; offset
+                below the now top-right toolbar so they don't overlap (CVS-32) */}
             {state.toolbarMode === 'edit' && showGroupsPanel && (
-              <Panel position="top-right">
+              <Panel position="top-right" style={{ marginTop: 72 }}>
                 <div className="flex flex-col items-end gap-2">
                   {showGroupsPanel && (
                     <GroupsPanel


### PR DESCRIPTION
Fixes **CVS-32** — relocate the **consolidated** canvas toolbar (from CVS-31) bottom-area/top-center → **top-right**.

## Change
- `TopCanvasToolbar`'s Panel moves from `top-center` → `top-right`.
- The **Groups fly-out** also anchors top-right, so it's offset **below** the toolbar (`marginTop: 72`) — no overlap.
- No collision with the operator panel (top-left), zoom `<Controls>` (bottom-left), the wayfinding indicator, or node content. No MiniMap is mounted.

## Acceptance criteria
- [x] Toolbar anchored top-right, stable across zoom/pan/resize (React Flow Panel)
- [x] No overlap with other overlays or node content
- [x] Keyboard focus order unchanged (same DOM, moved anchor)

Follows **CVS-31** (consolidation), which is merged.

## Verification
type-check ✓, lint ✓ (0 errors), full Vitest ✓. Visual placement covered by the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)