### PR TITLE
CVS-38: node intersection detection + drop-target highlight

### DIFF
--- a/src/features/canvas/hooks/useNodeIntersection.test.ts
+++ b/src/features/canvas/hooks/useNodeIntersection.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { diffHighlight } from './useNodeIntersection';
+
+describe('diffHighlight', () => {
+  it('adds all targets when nothing was highlighted', () => {
+    expect(diffHighlight(new Set(), ['a', 'b'])).toEqual({
+      add: ['a', 'b'],
+      remove: [],
+    });
+  });
+
+  it('removes all when the drag leaves every target', () => {
+    expect(diffHighlight(new Set(['a', 'b']), [])).toEqual({
+      add: [],
+      remove: ['a', 'b'],
+    });
+  });
+
+  it('computes incremental add/remove as the drag moves', () => {
+    expect(diffHighlight(new Set(['a', 'b']), ['b', 'c'])).toEqual({
+      add: ['c'],
+      remove: ['a'],
+    });
+  });
+
+  it('is a no-op when the target set is unchanged', () => {
+    expect(diffHighlight(new Set(['a', 'b']), ['a', 'b'])).toEqual({
+      add: [],
+      remove: [],
+    });
+  });
+});

--- a/src/features/canvas/hooks/useNodeIntersection.ts
+++ b/src/features/canvas/hooks/useNodeIntersection.ts
@@ -1,0 +1,89 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { useReactFlow } from '@xyflow/react';
+
+const DROP_TARGET_CLASS = 'rf-node-drop-target';
+
+/**
+ * Pure set diff — which node ids gain/lose the drop-target highlight between
+ * the previous highlighted set and the next list. Exported for unit testing.
+ */
+export function diffHighlight(
+  prev: Set<string>,
+  next: string[]
+): { add: string[]; remove: string[] } {
+  const nextSet = new Set(next);
+  const add = next.filter((id) => !prev.has(id));
+  const remove = [...prev].filter((id) => !nextSet.has(id));
+  return { add, remove };
+}
+
+function nodeEl(id: string): Element | null {
+  const safe =
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+      ? CSS.escape(id)
+      : id;
+  return document.querySelector(`.react-flow__node[data-id="${safe}"]`);
+}
+
+export interface NodeIntersectionApi {
+  /**
+   * Call on node drag with the dragged node — highlights the nodes it overlaps
+   * and returns their ids.
+   */
+  handleDrag: (node: { id: string } | null | undefined) => string[];
+  /** Call on drag stop — clears every drop-target highlight. */
+  clear: () => void;
+  /** Ids currently highlighted (drop targets under the dragged node). */
+  getTargets: () => string[];
+}
+
+/**
+ * CVS-38 — detect nodes intersecting a dragged node (React Flow's
+ * `getIntersectingNodes`) and surface it as a drop-target highlight, plus a
+ * `getTargets()` / `onChange` callback for grouping + subflows (CVS-43).
+ *
+ * Highlights are applied by toggling a class directly on the rendered node DOM
+ * (not a per-frame `setNodes`) so dragging stays cheap on large canvases.
+ */
+export function useNodeIntersection(
+  onChange?: (ids: string[]) => void
+): NodeIntersectionApi {
+  const { getIntersectingNodes } = useReactFlow();
+  const highlighted = useRef<Set<string>>(new Set());
+
+  const apply = useCallback(
+    (ids: string[]) => {
+      const { add, remove } = diffHighlight(highlighted.current, ids);
+      if (!add.length && !remove.length) return;
+      for (const id of remove) nodeEl(id)?.classList.remove(DROP_TARGET_CLASS);
+      for (const id of add) nodeEl(id)?.classList.add(DROP_TARGET_CLASS);
+      highlighted.current = new Set(ids);
+      onChange?.(ids);
+    },
+    [onChange]
+  );
+
+  const handleDrag = useCallback(
+    (node: { id: string } | null | undefined): string[] => {
+      if (!node?.id) return [];
+      let hits: Array<{ id: string }> = [];
+      try {
+        hits = (getIntersectingNodes(node as never) as Array<{ id: string }>) || [];
+      } catch {
+        hits = [];
+      }
+      const ids = hits.map((n) => n.id);
+      apply(ids);
+      return ids;
+    },
+    [getIntersectingNodes, apply]
+  );
+
+  const clear = useCallback(() => apply([]), [apply]);
+  const getTargets = useCallback(() => [...highlighted.current], []);
+
+  return useMemo(
+    () => ({ handleDrag, clear, getTargets }),
+    [handleDrag, clear, getTargets]
+  );
+}

--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -76,6 +76,7 @@ import {
 import { getAvailableFilterOptions } from '@/shared/utils/filterUtils';
 import { useCanvasEvents } from '../hooks/useCanvasEvents';
 import { useCanvasKeyboard } from '../hooks/useCanvasKeyboard';
+import { useNodeIntersection } from '../hooks/useNodeIntersection';
 import { useCanvasPageState } from '../hooks/useCanvasPageState';
 import { useCanvasStateMachine } from '../hooks/useCanvasStateMachine';
 import { useCanvasViewportSync } from '../hooks/useCanvasViewportSync';
@@ -490,6 +491,12 @@ function CanvasPageInner() {
     fitView,
     screenToFlowPosition,
   } = useReactFlow() as any;
+
+  // CVS-38 — drop-target highlight while dragging a node over others.
+  const {
+    handleDrag: highlightIntersections,
+    clear: clearIntersections,
+  } = useNodeIntersection();
 
   // Auto-layout handler
   const handleApplyLayout = useCallback(
@@ -1204,6 +1211,8 @@ function CanvasPageInner() {
 
   const handleNodeDrag = useCallback(
     (_: any, node: any) => {
+      // Surface nodes the dragged node overlaps as drop-target highlights.
+      highlightIntersections(node);
       if (node?.id && node?.position) {
         if (node.type === 'metricCard') {
           useCanvasStore.getState().updateNodePosition(node.id, node.position);
@@ -1236,11 +1245,19 @@ function CanvasPageInner() {
         }
       }
     },
-    [state, updateEvidencePosition, updateCanvasNodePosition, updateNewNode]
+    [
+      state,
+      updateEvidencePosition,
+      updateCanvasNodePosition,
+      updateNewNode,
+      highlightIntersections,
+    ]
   );
 
   const handleNodeDragStop = useCallback(
     (_: any, node: any) => {
+      // Clear any drop-target highlights from the drag.
+      clearIntersections();
       // A moved node invalidates the ELK-routed channels of its incident edges —
       // drop those so they fall back to smoothstep until the next auto-layout.
       if (node?.id) {
@@ -1333,6 +1350,7 @@ function CanvasPageInner() {
       updateEvidencePosition,
       updateCanvasNodePosition,
       updateNewNode,
+      clearIntersections,
     ]
   );
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -382,3 +382,13 @@ body[data-scroll-locked='1'] .sheet-content {
 .react-flow__edge:not(.rf-edge-dimmed) {
   transition: opacity 0.25s ease;
 }
+
+/* ── Drop-target highlight (CVS-38) ─────────────────────────────────
+   While a node is dragged over others, the overlapped nodes get a ring so
+   the user can see valid drop targets (foundation for grouping/subflows). */
+.react-flow__node.rf-node-drop-target {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
+  border-radius: 10px;
+  transition: outline-color 0.12s ease;
+}


### PR DESCRIPTION
Closes CVS-38.

Detect when a dragged node overlaps others and surface it as a drop-target highlight — the foundation for drop-into-group / subflows (CVS-43).

## Changes
- **`useNodeIntersection` hook** — on node drag, React Flow `getIntersectingNodes` → toggles a `rf-node-drop-target` class on the overlapped node DOM (no per-frame `setNodes`, so it stays cheap during drag); cleared on drag stop. Exposes `getTargets()` + an `onChange` callback for grouping to consume.
- **Pure `diffHighlight` helper** — unit-tested (4 cases).
- Wired into `CanvasPage` `handleNodeDrag` / `handleNodeDragStop`.
- Highlight ring styled next to the existing `rf-node-dimmed` rules.

## Acceptance criteria
- [x] Intersecting nodes detected on drag (`getIntersectingNodes`)
- [x] Intersection surfaced (highlight + `getTargets`/`onChange` callback) for grouping + subflows
- [x] Performant during drag (DOM class-toggle diff, not full re-render)

Verify: type-check clean · CanvasPage 0 lint errors (pre-existing warnings only) · 116 tests pass (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)