### PR TITLE
feat(canvas): node-type-aware toolbar via a capability manifest (CVS-67)

### DIFF
--- a/src/features/canvas/components/nodes/shared/EnhancedNodeToolbar.tsx
+++ b/src/features/canvas/components/nodes/shared/EnhancedNodeToolbar.tsx
@@ -25,6 +25,7 @@ import {
 import { Separator } from '@/shared/components/ui/separator';
 import { useCanvasStore } from '@/lib/stores';
 import { toast } from 'sonner';
+import { nodeToolbarHas, type NodeToolbarAction } from './nodeToolbarManifest';
 
 interface EnhancedNodeToolbarProps {
   isVisible: boolean;
@@ -75,16 +76,27 @@ export default function EnhancedNodeToolbar({
   onExport,
   onAddTag,
   onCreateLink,
-  showView = true,
-  showEdit = true,
-  showSettings = true,
-  showCopy = true,
-  showDelete = true,
+  showView,
+  showEdit,
+  showSettings,
+  showCopy,
+  showDelete,
   showMoreActions = true,
   nodeType,
   customActions = [],
 }: EnhancedNodeToolbarProps) {
   const [showMore, setShowMore] = React.useState(false);
+
+  // Node-type-aware visibility (CVS-67): when a show* flag isn't explicitly
+  // passed, derive it from the capability manifest for this node type (unknown
+  // types fall back to visible). This is what tailors each node's toolbar.
+  const resolveShow = (explicit: boolean | undefined, action: NodeToolbarAction) =>
+    explicit !== undefined ? explicit : nodeToolbarHas(nodeType, action);
+  const showViewR = resolveShow(showView, 'view');
+  const showEditR = resolveShow(showEdit, 'edit');
+  const showSettingsR = resolveShow(showSettings, 'settings');
+  const showCopyR = resolveShow(showCopy, 'duplicate');
+  const showDeleteR = resolveShow(showDelete, 'delete');
 
   // Core actions that are always visible
   const coreActions = [
@@ -92,7 +104,7 @@ export default function EnhancedNodeToolbar({
       icon: Eye,
       label: 'View Details',
       onClick: onView,
-      show: showView && onView,
+      show: showViewR && onView,
       variant: 'default' as const,
       className: 'hover:bg-blue-50 hover:text-blue-600',
     },
@@ -100,7 +112,7 @@ export default function EnhancedNodeToolbar({
       icon: Edit,
       label: 'Edit',
       onClick: onEdit,
-      show: showEdit && onEdit,
+      show: showEditR && onEdit,
       variant: 'default' as const,
       className: 'hover:bg-green-50 hover:text-green-600',
     },
@@ -108,7 +120,7 @@ export default function EnhancedNodeToolbar({
       icon: Settings,
       label: 'Settings',
       onClick: onSettings,
-      show: showSettings && onSettings,
+      show: showSettingsR && onSettings,
       variant: 'default' as const,
       className: 'hover:bg-purple-50 hover:text-purple-600',
     },
@@ -116,7 +128,7 @@ export default function EnhancedNodeToolbar({
       icon: Copy,
       label: 'Duplicate',
       onClick: onCopy,
-      show: showCopy && onCopy,
+      show: showCopyR && onCopy,
       variant: 'default' as const,
       className: 'hover:bg-gray-50 hover:text-gray-600',
     },
@@ -156,7 +168,7 @@ export default function EnhancedNodeToolbar({
     icon: Trash2,
     label: 'Delete',
     onClick: onDelete,
-    show: showDelete && onDelete,
+    show: showDeleteR && onDelete,
     variant: 'destructive' as const,
     className: 'hover:bg-red-50 hover:text-red-600',
   };

--- a/src/features/canvas/components/nodes/shared/nodeToolbarManifest.test.ts
+++ b/src/features/canvas/components/nodes/shared/nodeToolbarManifest.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getNodeToolbarActions,
+  nodeToolbarHas,
+  NODE_TOOLBAR_MANIFEST,
+} from './nodeToolbarManifest';
+
+describe('nodeToolbarManifest', () => {
+  it('does not put chart/data on a comment node', () => {
+    const comment = getNodeToolbarActions('comment')!;
+    expect(comment).not.toContain('chart');
+    expect(comment).not.toContain('data');
+    expect(comment).toContain('resolve');
+  });
+
+  it('hides settings on plain metric/value/action/hypothesis', () => {
+    for (const t of ['metric', 'value', 'action', 'hypothesis'] as const) {
+      expect(nodeToolbarHas(t, 'settings')).toBe(false);
+      expect(nodeToolbarHas(t, 'view')).toBe(true);
+      expect(nodeToolbarHas(t, 'delete')).toBe(true);
+    }
+  });
+
+  it('gives metric the chart + data + comment actions', () => {
+    expect(nodeToolbarHas('metric', 'chart')).toBe(true);
+    expect(nodeToolbarHas('metric', 'data')).toBe(true);
+    expect(nodeToolbarHas('metric', 'comment')).toBe(true);
+  });
+
+  it('every node type includes delete', () => {
+    for (const actions of Object.values(NODE_TOOLBAR_MANIFEST)) {
+      expect(actions).toContain('delete');
+    }
+  });
+
+  it('falls back to visible for unknown / missing types', () => {
+    expect(getNodeToolbarActions('mystery')).toBeNull();
+    expect(getNodeToolbarActions(undefined)).toBeNull();
+    expect(nodeToolbarHas('mystery', 'chart')).toBe(true); // unknown → don't hide
+    expect(nodeToolbarHas(undefined, 'view')).toBe(true);
+  });
+});

--- a/src/features/canvas/components/nodes/shared/nodeToolbarManifest.ts
+++ b/src/features/canvas/components/nodes/shared/nodeToolbarManifest.ts
@@ -1,0 +1,67 @@
+// Single source of truth for which floating-toolbar actions each node type
+// exposes (CVS-67). The per-node toolbar previously rendered a near-uniform
+// superset for every type; drive visibility from this capability map instead so
+// each node shows only the actions it supports (no chart/data on a comment node,
+// no settings on a plain metric, etc.).
+//
+// Owner-confirmed action sets. Actions a given toolbar can't yet render (it has
+// no handler wired) are simply omitted at render time — this map is the intent,
+// so wiring a new action later is a one-line manifest edit.
+
+export type NodeToolbarAction =
+  | 'view'
+  | 'edit'
+  | 'settings'
+  | 'duplicate'
+  | 'comment'
+  | 'chart'
+  | 'data'
+  | 'connect'
+  | 'resolve'
+  | 'config'
+  | 'delete';
+
+export type ToolbarNodeType =
+  | 'metric'
+  | 'metricCard'
+  | 'value'
+  | 'action'
+  | 'hypothesis'
+  | 'evidence'
+  | 'source'
+  | 'chart'
+  | 'comment'
+  | 'whiteboard';
+
+export const NODE_TOOLBAR_MANIFEST: Record<ToolbarNodeType, NodeToolbarAction[]> = {
+  metric: ['view', 'edit', 'duplicate', 'chart', 'data', 'comment', 'delete'],
+  metricCard: ['view', 'edit', 'duplicate', 'chart', 'data', 'comment', 'delete'],
+  value: ['view', 'edit', 'duplicate', 'comment', 'delete'],
+  action: ['view', 'edit', 'duplicate', 'comment', 'delete'],
+  hypothesis: ['view', 'edit', 'duplicate', 'comment', 'delete'],
+  evidence: ['view', 'edit', 'delete'],
+  source: ['connect', 'data', 'settings', 'delete'],
+  chart: ['config', 'settings', 'delete'],
+  comment: ['edit', 'resolve', 'delete'],
+  whiteboard: ['edit', 'delete'],
+};
+
+/**
+ * Actions for a node type, or `null` if the type is unknown (callers should then
+ * fall back to their existing behavior rather than hide everything).
+ */
+export function getNodeToolbarActions(
+  nodeType: string | undefined
+): NodeToolbarAction[] | null {
+  if (!nodeType) return null;
+  return NODE_TOOLBAR_MANIFEST[nodeType as ToolbarNodeType] ?? null;
+}
+
+/** Whether a node type's toolbar should show a given action (unknown type → true). */
+export function nodeToolbarHas(
+  nodeType: string | undefined,
+  action: NodeToolbarAction
+): boolean {
+  const actions = getNodeToolbarActions(nodeType);
+  return actions ? actions.includes(action) : true;
+}


### PR DESCRIPTION
Fixes **CVS-67** — the per-node floating toolbar showed a near-uniform superset for every node type.

## Root cause
All 4 node components (`MetricNode`/`ValueNode`/`ActionNode`/`HypothesisNode`) passed **identical** props to `EnhancedNodeToolbar` and no `show*` flags — only `nodeType` differed — so every node rendered the same view/edit/settings/duplicate/delete set.

## Change
- New **`nodeToolbarManifest.ts`** — a single source of truth mapping each node type to its owner-confirmed action set (metric = view·edit·dup·chart·data·comment·delete; value/action/hypothesis = view·edit·dup·comment·delete; source = connect·data·settings·delete; chart = config·settings·delete; comment = edit·resolve·delete; whiteboard = edit·delete).
- **`EnhancedNodeToolbar`** derives each `show*` from the manifest by `nodeType` when not explicitly overridden. Immediate effect: **Settings disappears** from plain metric/value/action/hypothesis toolbars (not in their set); view/edit/duplicate/delete remain; secondary share/export/tag stay in the `⋯` overflow.
- Unit-tested (`nodeToolbarManifest.test.ts`).

## Acceptance criteria
- [x] A single source of truth for the mapping (manifest), not per-node ad-hoc flags
- [x] Each node type shows only its supported core actions (settings hidden where not applicable)
- [x] Secondary actions stay in the `⋯` overflow
- [ ] *Follow-up:* wire the richer actions (comment/chart/data/connect/resolve) and migrate `MetricCard`'s own rich 9-icon toolbar + source/chart/comment/whiteboard node toolbars to read the manifest — the map already declares their sets.
- [ ] *Follow-up:* remove `@ts-nocheck` from `EnhancedNodeToolbar` as part of the type-debt sweep (CVS-64/72).

## Scope note
The 4 nodes' `view/edit/settings/copy` handlers are pre-existing stubs (only delete was wired, in CVS-61); wiring those is separate from *which actions show*, which is what this issue is about.

## Verification
type-check ✓, lint ✓ (0 errors), full Vitest ✓ (incl. 5 new manifest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)