### PR TITLE
CVS-42: harden undo/redo command stack (apply-suppression + canUndo/canRedo)

### DIFF
--- a/src/features/canvas/stores/useCanvasHistoryStore.test.ts
+++ b/src/features/canvas/stores/useCanvasHistoryStore.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useCanvasHistoryStore } from './useCanvasHistoryStore';
+
+const store = () => useCanvasHistoryStore.getState();
+const noop = { undo: () => {}, redo: () => {} };
+
+beforeEach(() => {
+  useCanvasHistoryStore.setState({
+    undoStack: [],
+    redoStack: [],
+    isApplying: false,
+  });
+});
+
+describe('useCanvasHistoryStore', () => {
+  it('moves entries between stacks on undo/redo', async () => {
+    const log: string[] = [];
+    store().push({
+      label: 'a',
+      undo: () => void log.push('undo-a'),
+      redo: () => void log.push('redo-a'),
+    });
+    expect(store().canUndo()).toBe(true);
+    expect(store().canRedo()).toBe(false);
+
+    await store().undo();
+    expect(log).toEqual(['undo-a']);
+    expect(store().canUndo()).toBe(false);
+    expect(store().canRedo()).toBe(true);
+
+    await store().redo();
+    expect(log).toEqual(['undo-a', 'redo-a']);
+    expect(store().canUndo()).toBe(true);
+  });
+
+  it('clears the redo stack on a fresh push', async () => {
+    store().push({ label: 'a', ...noop });
+    await store().undo();
+    expect(store().canRedo()).toBe(true);
+    store().push({ label: 'b', ...noop });
+    expect(store().canRedo()).toBe(false);
+  });
+
+  it('suppresses capture during an undo apply (no feedback loop)', async () => {
+    store().push({
+      label: 'x',
+      // Reversal that itself tries to record history — must be ignored.
+      undo: () => store().push({ label: 'reentrant', ...noop }),
+      redo: () => {},
+    });
+    await store().undo();
+    expect(store().redoStack.map((e) => e.label)).toEqual(['x']);
+    expect(store().undoStack).toEqual([]);
+  });
+
+  it('caps the undo stack at 50', () => {
+    for (let i = 0; i < 60; i++) store().push({ label: String(i), ...noop });
+    expect(store().undoStack.length).toBe(50);
+    expect(store().undoStack[0].label).toBe('10');
+  });
+});

--- a/src/features/canvas/stores/useCanvasHistoryStore.ts
+++ b/src/features/canvas/stores/useCanvasHistoryStore.ts
@@ -1,6 +1,11 @@
-// Undo/redo stacks for canvas actions. Each entry knows how to reverse itself
-// (undo) and re-apply itself (redo). Scoped to add / paste / duplicate / delete.
-// Not persisted; cleared per canvas.
+// Undo/redo command stack for canvas actions. Each entry knows how to reverse
+// itself (undo) and re-apply itself (redo). Covers add / paste / duplicate /
+// delete / move / edge create+delete. Not persisted; cleared per canvas.
+//
+// While an undo/redo entry is applying, `push` is suppressed: entries route
+// their reversal back through the normal store mutations (so autosave
+// re-persists), and those mutations must NOT capture a fresh history entry, or
+// undo/redo would feed back on itself (CVS-42, locked decision).
 
 import { create } from 'zustand';
 
@@ -13,10 +18,14 @@ export interface HistoryEntry {
 interface CanvasHistoryState {
   undoStack: HistoryEntry[];
   redoStack: HistoryEntry[];
+  /** True while an undo/redo entry is running — capture is suppressed. */
+  isApplying: boolean;
   push: (entry: HistoryEntry) => void;
   undo: () => Promise<void>;
   redo: () => Promise<void>;
   clear: () => void;
+  canUndo: () => boolean;
+  canRedo: () => boolean;
 }
 
 const MAX = 50;
@@ -24,39 +33,53 @@ const MAX = 50;
 export const useCanvasHistoryStore = create<CanvasHistoryState>((set, get) => ({
   undoStack: [],
   redoStack: [],
-  // A fresh action invalidates the redo stack.
-  push: (entry) =>
+  isApplying: false,
+  // A fresh action invalidates the redo stack. Suppressed during an
+  // undo/redo apply so reversals don't capture themselves.
+  push: (entry) => {
+    if (get().isApplying) return;
     set((s) => ({
       undoStack: [...s.undoStack, entry].slice(-MAX),
       redoStack: [],
-    })),
+    }));
+  },
   undo: async () => {
+    if (get().isApplying) return;
     const { undoStack } = get();
     const entry = undoStack[undoStack.length - 1];
     if (!entry) return;
     set((s) => ({
       undoStack: s.undoStack.slice(0, -1),
       redoStack: [...s.redoStack, entry].slice(-MAX),
+      isApplying: true,
     }));
     try {
       await entry.undo();
     } catch (err) {
       console.error('❌ Undo failed:', err);
+    } finally {
+      set({ isApplying: false });
     }
   },
   redo: async () => {
+    if (get().isApplying) return;
     const { redoStack } = get();
     const entry = redoStack[redoStack.length - 1];
     if (!entry) return;
     set((s) => ({
       redoStack: s.redoStack.slice(0, -1),
       undoStack: [...s.undoStack, entry].slice(-MAX),
+      isApplying: true,
     }));
     try {
       await entry.redo();
     } catch (err) {
       console.error('❌ Redo failed:', err);
+    } finally {
+      set({ isApplying: false });
     }
   },
   clear: () => set({ undoStack: [], redoStack: [] }),
+  canUndo: () => get().undoStack.length > 0,
+  canRedo: () => get().redoStack.length > 0,
 }));


### PR DESCRIPTION
Part of CVS-42 (per the locked decision: extend the command stack, not zundo).

**Context:** the command stack already captures add/paste/delete, node moves, and edge create/delete (prior work). The clearly-missing locked-decision requirement was the **apply-suppression guard**.

## Changes
- **`isApplying` flag** — `push` is suppressed while an undo/redo entry runs, so a reversal that routes back through the normal store mutations can't capture itself (no feedback loop / duplicate entries). `undo`/`redo` are also non-re-entrant.
- **`canUndo()` / `canRedo()`** selectors — enables the toolbar buttons (landing in CVS-31).
- Unit-tested (4 cases): stack transitions, redo invalidation, apply-suppression, 50-cap.

## Remaining (follow-up — see issue comment)
Property-edit and resize undo, and the toolbar buttons (CVS-31), are not in this PR. Recommend a follow-up sub-issue.

Verify: type-check clean · 0 lint errors · 129 tests pass (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)