### PR TITLE
CVS-39: animate node positions on auto-layout

### DIFF
--- a/src/features/canvas/components/mini-control/LayoutDropdownButton.tsx
+++ b/src/features/canvas/components/mini-control/LayoutDropdownButton.tsx
@@ -20,6 +20,7 @@ import {
   applyAutoLayoutWithValidation,
   AUTO_LAYOUT_ALGORITHMS,
 } from '@/shared/utils/autoLayout';
+import { animateLayout } from '@/features/canvas/utils/layoutAnimation';
 import { useReactFlow } from '@xyflow/react';
 import { LayoutGrid, Settings } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -109,6 +110,8 @@ export default function LayoutDropdownButton() {
           'nodes'
         );
 
+        // Ease nodes into their new positions instead of jumping (CVS-39).
+        animateLayout();
         // Update ReactFlow state first for immediate visual feedback
         rf?.setNodes?.(layoutedNodes as any);
 

--- a/src/features/canvas/components/mini-control/UnifiedLayoutControls.tsx
+++ b/src/features/canvas/components/mini-control/UnifiedLayoutControls.tsx
@@ -29,6 +29,7 @@ import {
   applyAutoLayoutWithValidation,
   AUTO_LAYOUT_ALGORITHMS,
 } from '@/shared/utils/autoLayout';
+import { animateLayout } from '@/features/canvas/utils/layoutAnimation';
 import { ControlButton, useReactFlow } from '@xyflow/react';
 import { LayoutGrid, Play, Settings } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
@@ -91,6 +92,8 @@ export default function UnifiedLayoutControls() {
           );
         }
 
+        // Ease nodes into their new positions instead of jumping (CVS-39).
+        animateLayout();
         rf?.setNodes?.(layoutedNodes as any);
 
         setTimeout(() => {

--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -77,6 +77,10 @@ import { getAvailableFilterOptions } from '@/shared/utils/filterUtils';
 import { useCanvasEvents } from '../hooks/useCanvasEvents';
 import { useCanvasKeyboard } from '../hooks/useCanvasKeyboard';
 import { useNodeIntersection } from '../hooks/useNodeIntersection';
+import {
+  animateLayout,
+  cancelLayoutAnimation,
+} from '../utils/layoutAnimation';
 import { useCanvasPageState } from '../hooks/useCanvasPageState';
 import { useCanvasStateMachine } from '../hooks/useCanvasStateMachine';
 import { useCanvasViewportSync } from '../hooks/useCanvasViewportSync';
@@ -528,6 +532,8 @@ function CanvasPageInner() {
         );
 
         setRoutedEdgePoints(edgePoints);
+        // Ease nodes into their new layout positions (CVS-39).
+        animateLayout();
         setNodes(layoutedFlow);
 
         // Persist the new card/node positions (mirror drag-stop routing) so the
@@ -1125,6 +1131,8 @@ function CanvasPageInner() {
   >({});
   const handleNodeDragStart = useCallback(
     (_: any, node: any) => {
+      // A drag must never lag behind a lingering layout transition.
+      cancelLayoutAnimation();
       const sel = new Set(useCanvasStore.getState().selectedNodeIds || []);
       const snap: Record<
         string,

--- a/src/features/canvas/utils/layoutAnimation.test.ts
+++ b/src/features/canvas/utils/layoutAnimation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { shouldAnimateLayout } from './layoutAnimation';
+
+describe('shouldAnimateLayout', () => {
+  it('animates when reduced-motion is not preferred', () => {
+    expect(shouldAnimateLayout({ matches: false })).toBe(true);
+  });
+
+  it('skips animation when the user prefers reduced motion', () => {
+    expect(shouldAnimateLayout({ matches: true })).toBe(false);
+  });
+
+  it('animates when no media query is available', () => {
+    expect(shouldAnimateLayout(null)).toBe(true);
+    expect(shouldAnimateLayout(undefined)).toBe(true);
+  });
+});

--- a/src/features/canvas/utils/layoutAnimation.ts
+++ b/src/features/canvas/utils/layoutAnimation.ts
@@ -1,0 +1,55 @@
+// Node position animation (CVS-39). Auto-layout updates node positions in one
+// step; to make that a smooth transition instead of an instant jump we briefly
+// toggle a class on the React Flow root that enables `transition: transform` on
+// nodes (see `.rf-animate-layout` in styles/index.css). The store still commits
+// each new position once (one autosave entry per node) — CSS does the tween, so
+// there's no per-frame setNodes fighting the controlled node state or the
+// autosave writer.
+
+const ANIMATE_CLASS = 'rf-animate-layout';
+const DEFAULT_DURATION = 320;
+
+/** Whether to animate given a reduced-motion media query (null = animate). */
+export function shouldAnimateLayout(
+  mql?: { matches: boolean } | null
+): boolean {
+  return !mql?.matches;
+}
+
+let clearTimer: ReturnType<typeof setTimeout> | null = null;
+
+function root(): Element | null {
+  return typeof document === 'undefined'
+    ? null
+    : document.querySelector('.react-flow');
+}
+
+/**
+ * Enable the layout transition for `duration` ms, then remove it. Call right
+ * before applying auto-layout positions. No-op when the user prefers reduced
+ * motion or there's no canvas mounted.
+ */
+export function animateLayout(duration = DEFAULT_DURATION): void {
+  const mql =
+    typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : null;
+  if (!shouldAnimateLayout(mql)) return;
+  const el = root();
+  if (!el) return;
+  el.classList.add(ANIMATE_CLASS);
+  if (clearTimer) clearTimeout(clearTimer);
+  clearTimer = setTimeout(() => {
+    el.classList.remove(ANIMATE_CLASS);
+    clearTimer = null;
+  }, duration);
+}
+
+/** Immediately stop animating (e.g. when a drag starts) so it never lags input. */
+export function cancelLayoutAnimation(): void {
+  if (clearTimer) {
+    clearTimeout(clearTimer);
+    clearTimer = null;
+  }
+  root()?.classList.remove(ANIMATE_CLASS);
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -392,3 +392,16 @@ body[data-scroll-locked='1'] .sheet-content {
   border-radius: 10px;
   transition: outline-color 0.12s ease;
 }
+
+/* ── Layout position animation (CVS-39) ─────────────────────────────
+   Enabled only transiently around an auto-layout apply (class toggled by
+   layoutAnimation.ts) so node moves ease into place instead of jumping;
+   never active during drag. Disabled entirely for reduced-motion. */
+.rf-animate-layout .react-flow__node {
+  transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .rf-animate-layout .react-flow__node {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes CVS-39.

Auto-layout moved nodes in an instant jump. Ease them into place — without a per-frame `setNodes` loop that would fight the controlled nodes / autosave.

## Approach
- `layoutAnimation` util briefly toggles an `rf-animate-layout` class on the React Flow root around a layout apply, enabling `transition: transform` on nodes → **CSS does the tween**. The store still commits each new position once, so autosave is unchanged (no per-frame writes).
- Respects **`prefers-reduced-motion`** (skips entirely, incl. a CSS `@media` fallback).
- **Cancelled on drag start** so a lingering transition never lags input.
- Wired into all three layout-apply paths: `CanvasPage.handleApplyLayout`, `LayoutDropdownButton`, `UnifiedLayoutControls`.
- Unit-tested the reduced-motion gate.

## Acceptance criteria
- [x] Nodes animate to new positions on auto-layout
- [x] Smooth (CSS transform transition; no rAF/setNodes churn) + respects reduced-motion
- [x] Doesn't interfere with dragging (cancelled on drag start) or edge routing (positions still committed to the store)

Verify: type-check clean · 0 lint errors · 132 tests pass (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)