### PR TITLE
feat(notifications): publish notifications for the live bell badge (CVS-78)

### DIFF
--- a/supabase/migrations/20260707120000_realtime_notifications.sql
+++ b/supabase/migrations/20260707120000_realtime_notifications.sql
@@ -1,0 +1,18 @@
+-- =====================================================================
+-- REALTIME publication: notifications (Metrimap, CVS-78)
+-- The NotificationInbox bell already subscribes to INSERTs on
+-- public.notifications to show a live unread badge, but postgres_changes only
+-- fires for tables in the supabase_realtime publication — notifications was
+-- missing, so the badge only refreshed on mount. Add it (idempotent). RLS still
+-- applies at the realtime layer, so each user only receives their own rows.
+-- =====================================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public' AND tablename = 'notifications'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.notifications;
+  END IF;
+END $$;


### PR DESCRIPTION
Fixes **CVS-78** — live unread badge on the notification bell.

## Finding
The client side already exists: `NotificationInbox` subscribes to `notifications` INSERTs (`user_id=eq.<self>`) and bumps the badge live (mark-read decrements). The only missing piece was the **`supabase_realtime` publication** — `postgres_changes` won't fire otherwise.

Checking prod: `notifications` is **already in the publication** (verified via `pg_publication_tables`), so the badge works there — **but no repo migration captured it** (prod/repo drift). A fresh or rebuilt env would silently lose the live badge.

## Change
Idempotent migration `20260707120000_realtime_notifications.sql` adds `public.notifications` to `supabase_realtime` (guarded, matches the existing `20260703170000_realtime_publication.sql` style). No-op on prod; correct for new envs. RLS still scopes realtime to each user's own rows.

## Acceptance criteria
- [x] Bell shows a live unread badge from `notifications` inserts (client subscription present)
- [x] `notifications` is in the `supabase_realtime` publication (prod ✓; now codified in a migration)

## Verification
type-check ✓, lint ✓, full Vitest ✓. Live-badge behavior covered by the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)