### PR TITLE
feat(CVS-98): RLS-scoped programmatic API / service layer

### DIFF
--- a/docs/features/programmatic-api.md
+++ b/docs/features/programmatic-api.md
@@ -1,0 +1,48 @@
+# Programmatic API / service layer (`src/shared/lib/api`)
+
+The RLS-scoped, versioned programmatic surface for building and populating metric
+trees (CVS-98). It's the **foundation the MCP server wraps** (CVS-100/101) and is
+reusable in-app. Design authority: the MCP design doc in the product vault
+(`PRD/4. Product/3. MCP and Programmatic Building`, the CVS-97 spike).
+
+## Model
+
+Built on the **canonical** model — `metric_cards` + `relationships` + `projects`
+(canvases) + tracked-metric value series — by wrapping the existing services in
+`src/shared/lib/supabase/services/*`. It does **not** touch the parallel
+`@ts-nocheck` `value_nodes`/`metric_nodes` model.
+
+## RLS-scoping guarantee
+
+```ts
+import { createMetrimapApi } from '@/shared/lib/api';
+
+const api = createMetrimapApi(client, userId); // client = createClerkSupabaseClient(getToken)
+```
+
+The factory **requires** a Clerk-authenticated Supabase client and the
+authenticated `userId`, and throws otherwise. Every call runs under that user's
+RLS — the **service-role key must never be passed here**. `userId` is used for
+`created_by` attribution.
+
+## Surface (v1)
+
+| Group | Methods |
+|---|---|
+| `canvases` | `list()`, `get(id)`, `create({name, description?, isPublic?})`, `update(id, patch)`, `delete(id)` |
+| `nodes` | `create({projectId, title, category, …})`, `createMetric` / `createValue` / `createAction` / `createHypothesis` (category preset), `update(id, patch)`, `delete(id)`, `list(projectId)` |
+| `relationships` | `create({projectId, sourceId, targetId, type, confidence?, weight?, notes?})`, `delete(id)`, `list(projectId)` |
+| `tree` | `get(projectId)` → `{ cards, relationships }` (context so agents extend, not duplicate) |
+| `values` | `push({trackedMetricId, series, source?})` — upsert a tracked-metric series (two-tier value store) |
+
+- **Categories:** `Core/Value`, `Data/Metric`, `Work/Action`, `Ideas/Hypothesis`, `Metadata`.
+- **Relationship types:** `Deterministic`, `Probabilistic`, `Causal`, `Compositional`.
+- Inputs are validated with **Zod** (`src/shared/lib/api/schemas.ts`); invalid input throws a `ZodError` with a clear message.
+
+## Scope boundaries
+
+- **Ingest staging + column mapping** (`import_batches`/`import_rows`, TTL,
+  `map_and_materialize`) is **CVS-102** — this layer exposes the direct value
+  upsert only.
+- **Auth** (OAuth Connect + personal API keys) is CVS-99; the MCP **server**
+  scaffold is CVS-100. This issue is only the service layer they call.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ CVS). See the **Docs policy** in [`../AGENTS.md`](../AGENTS.md).
   [linear-setup](features/linear-setup.md), [linear-initiatives](features/linear-initiatives.md),
   [userback-customer-requests](features/userback-customer-requests.md),
   [security-scanning](features/security-scanning.md),
+  [programmatic-api](features/programmatic-api.md),
   [metrics-api](features/metrics-api.md)
 
 Anything product-facing (feature narratives, changelogs, methodology, PRD) belongs

--- a/src/shared/lib/api/index.ts
+++ b/src/shared/lib/api/index.ts
@@ -1,0 +1,4 @@
+// Metrimap programmatic API (CVS-98) — RLS-scoped facade over the domain
+// services, consumed by the MCP server and reusable in-app.
+export { createMetrimapApi, API_VERSION, type MetrimapApi } from './metrimapApi';
+export * as apiSchemas from './schemas';

--- a/src/shared/lib/api/metrimapApi.test.ts
+++ b/src/shared/lib/api/metrimapApi.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the domain services so we can assert the facade validates inputs and
+// delegates with the mapped args + the injected (RLS-scoped) client.
+vi.mock('@/shared/lib/supabase/services/projects', () => ({
+  getUserProjects: vi.fn(),
+  getProjectById: vi.fn(),
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+}));
+vi.mock('@/shared/lib/supabase/services/metric-cards', () => ({
+  createMetricCard: vi.fn(),
+  updateMetricCard: vi.fn(),
+  deleteMetricCard: vi.fn(),
+  getProjectMetricCards: vi.fn(async () => [{ id: 'c1' }]),
+}));
+vi.mock('@/shared/lib/supabase/services/relationships', () => ({
+  createRelationship: vi.fn(),
+  deleteRelationship: vi.fn(),
+  getProjectRelationships: vi.fn(async () => [{ id: 'r1' }]),
+}));
+vi.mock('@/shared/lib/supabase/services/trackedMetrics', () => ({
+  writeMetricValues: vi.fn(),
+}));
+
+import { createMetrimapApi, API_VERSION } from './metrimapApi';
+import * as projects from '@/shared/lib/supabase/services/projects';
+import * as cards from '@/shared/lib/supabase/services/metric-cards';
+import * as rels from '@/shared/lib/supabase/services/relationships';
+import * as tracked from '@/shared/lib/supabase/services/trackedMetrics';
+
+const client = { __authed: true } as never;
+const USER = 'user_123';
+const PROJECT = '11111111-1111-1111-1111-111111111111';
+const NODE_A = '22222222-2222-2222-2222-222222222222';
+const NODE_B = '33333333-3333-3333-3333-333333333333';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('createMetrimapApi — RLS-scoping guards', () => {
+  it('throws without an authenticated client', () => {
+    expect(() => createMetrimapApi(null as never, USER)).toThrow(/authenticated Supabase client/i);
+  });
+  it('throws without a userId', () => {
+    expect(() => createMetrimapApi(client, '  ')).toThrow(/userId/i);
+  });
+  it('is versioned', () => {
+    expect(createMetrimapApi(client, USER).version).toBe(API_VERSION);
+  });
+});
+
+describe('canvases', () => {
+  it('create maps to createProject with created_by + defaults, passing the client', () => {
+    const api = createMetrimapApi(client, USER);
+    api.canvases.create({ name: 'My Tree' });
+    expect(projects.createProject).toHaveBeenCalledWith(
+      { name: 'My Tree', description: null, is_public: false, created_by: USER },
+      client
+    );
+  });
+  it('create rejects an empty name (validation)', () => {
+    const api = createMetrimapApi(client, USER);
+    expect(() => api.canvases.create({ name: '' })).toThrow();
+  });
+  it('update maps isPublic -> is_public and omits absent fields', () => {
+    const api = createMetrimapApi(client, USER);
+    api.canvases.update(PROJECT, { isPublic: true });
+    expect(projects.updateProject).toHaveBeenCalledWith(PROJECT, { is_public: true }, client);
+  });
+});
+
+describe('nodes', () => {
+  it('createMetric builds a Data/Metric card and delegates with projectId + userId + client', () => {
+    const api = createMetrimapApi(client, USER);
+    api.nodes.createMetric({ projectId: PROJECT, title: 'MRR' });
+    expect(cards.createMetricCard).toHaveBeenCalledTimes(1);
+    const [card, projectId, userId, passedClient] = vi.mocked(cards.createMetricCard).mock.calls[0];
+    expect(card).toMatchObject({ title: 'MRR', category: 'Data/Metric', causalFactors: [], dimensions: [] });
+    expect(projectId).toBe(PROJECT);
+    expect(userId).toBe(USER);
+    expect(passedClient).toBe(client);
+  });
+  it('createAction / createValue set their categories', () => {
+    const api = createMetrimapApi(client, USER);
+    api.nodes.createValue({ projectId: PROJECT, title: 'Profit' });
+    api.nodes.createAction({ projectId: PROJECT, title: 'Ship feature' });
+    expect(vi.mocked(cards.createMetricCard).mock.calls[0][0].category).toBe('Core/Value');
+    expect(vi.mocked(cards.createMetricCard).mock.calls[1][0].category).toBe('Work/Action');
+  });
+  it('create rejects an unknown category', () => {
+    const api = createMetrimapApi(client, USER);
+    expect(() =>
+      api.nodes.create({ projectId: PROJECT, title: 'x', category: 'Nope' } as never)
+    ).toThrow();
+  });
+});
+
+describe('relationships', () => {
+  it('create builds a typed relationship with defaults and delegates', () => {
+    const api = createMetrimapApi(client, USER);
+    api.relationships.create({ projectId: PROJECT, sourceId: NODE_A, targetId: NODE_B, type: 'Causal' });
+    const [rel, projectId, userId] = vi.mocked(rels.createRelationship).mock.calls[0];
+    expect(rel).toMatchObject({ sourceId: NODE_A, targetId: NODE_B, type: 'Causal', confidence: 'Medium', evidence: [] });
+    expect(projectId).toBe(PROJECT);
+    expect(userId).toBe(USER);
+  });
+  it('create rejects an invalid relationship type', () => {
+    const api = createMetrimapApi(client, USER);
+    expect(() =>
+      api.relationships.create({ projectId: PROJECT, sourceId: NODE_A, targetId: NODE_B, type: 'Bogus' } as never)
+    ).toThrow();
+  });
+});
+
+describe('tree.get', () => {
+  it('composes cards + relationships for a project', async () => {
+    const api = createMetrimapApi(client, USER);
+    const tree = await api.tree.get(PROJECT);
+    expect(tree).toEqual({ projectId: PROJECT, cards: [{ id: 'c1' }], relationships: [{ id: 'r1' }] });
+    expect(cards.getProjectMetricCards).toHaveBeenCalledWith(PROJECT, client);
+    expect(rels.getProjectRelationships).toHaveBeenCalledWith(PROJECT, client);
+  });
+});
+
+describe('values.push', () => {
+  it('fills change_percent/trend defaults and upserts the series', () => {
+    const api = createMetrimapApi(client, USER);
+    api.values.push({ trackedMetricId: PROJECT, series: [{ period: '2026-01', value: 10 }], source: 'agent' });
+    expect(tracked.writeMetricValues).toHaveBeenCalledWith(
+      PROJECT,
+      [{ period: '2026-01', value: 10, change_percent: 0, trend: 'neutral' }],
+      'agent',
+      client
+    );
+  });
+  it('rejects an empty series', () => {
+    const api = createMetrimapApi(client, USER);
+    expect(() => api.values.push({ trackedMetricId: PROJECT, series: [] })).toThrow();
+  });
+});

--- a/src/shared/lib/api/metrimapApi.ts
+++ b/src/shared/lib/api/metrimapApi.ts
@@ -1,0 +1,196 @@
+// Metrimap programmatic API / service layer (CVS-98).
+//
+// A stable, versioned, RLS-scoped facade over the existing Supabase services —
+// the foundation the MCP server (CVS-100/101) wraps and the app can reuse. It is
+// built on the CANONICAL model: metric_cards + relationships + projects, with
+// tracked-metric value series. It does NOT touch the parallel @ts-nocheck
+// value_nodes/metric_nodes model.
+//
+// RLS-scoping guarantee: the factory REQUIRES a Clerk-authenticated Supabase
+// client (createClerkSupabaseClient) + the authenticated userId. Every call runs
+// under that user's RLS. The service-role key must never be passed here.
+//
+// Design authority: product vault "PRD/4. Product/3. MCP and Programmatic
+// Building" (the CVS-97 spike). Ingest staging/mapping (import_batches, TTL) is
+// CVS-102; this layer exposes the direct value upsert only.
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import type { MetricCard, MetricValue, Relationship } from '@/shared/types';
+
+import {
+  CreateCanvasInput,
+  CreateNodeInput,
+  CreateRelationshipInput,
+  CreateTypedNodeInput,
+  PushValuesInput,
+  UpdateCanvasInput,
+  UpdateNodeInput,
+  type CreateNodeInputT,
+  type CreateTypedNodeInputT,
+} from './schemas';
+
+import {
+  createProject,
+  deleteProject,
+  getProjectById,
+  getUserProjects,
+  updateProject,
+} from '@/shared/lib/supabase/services/projects';
+import {
+  createMetricCard,
+  deleteMetricCard,
+  getProjectMetricCards,
+  updateMetricCard,
+} from '@/shared/lib/supabase/services/metric-cards';
+import {
+  createRelationship,
+  deleteRelationship,
+  getProjectRelationships,
+} from '@/shared/lib/supabase/services/relationships';
+import { writeMetricValues } from '@/shared/lib/supabase/services/trackedMetrics';
+
+export const API_VERSION = 'v1' as const;
+
+type Client = SupabaseClient<Database>;
+
+const nowIso = () => new Date().toISOString();
+const newId = () => crypto.randomUUID();
+
+/**
+ * Build the RLS-scoped programmatic API bound to one authenticated user.
+ * @param client Clerk-authenticated Supabase client (never the service-role key).
+ * @param userId the authenticated user's id, for created_by attribution.
+ */
+export function createMetrimapApi(client: Client, userId: string) {
+  if (!client) {
+    throw new Error(
+      'createMetrimapApi requires an authenticated Supabase client (RLS-scoped). The service-role key must never be used here.'
+    );
+  }
+  if (!userId || !userId.trim()) {
+    throw new Error(
+      'createMetrimapApi requires the authenticated userId for attribution.'
+    );
+  }
+
+  const createNode = (input: CreateNodeInputT) => {
+    const v = CreateNodeInput.parse(input);
+    const card: MetricCard = {
+      id: newId(),
+      title: v.title,
+      description: v.description ?? '',
+      category: v.category,
+      tags: [],
+      causalFactors: [],
+      dimensions: [],
+      assignees: v.assignees ?? [],
+      position: v.position ?? { x: 0, y: 0 },
+      formula: v.formula,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+    return createMetricCard(card, v.projectId, userId, client);
+  };
+
+  const typedNode =
+    (category: MetricCard['category']) => (input: CreateTypedNodeInputT) => {
+      const v = CreateTypedNodeInput.parse(input);
+      return createNode({ ...v, category });
+    };
+
+  return {
+    version: API_VERSION,
+
+    canvases: {
+      list: () => getUserProjects(userId, client),
+      get: (id: string) => getProjectById(id, client),
+      create: (input: unknown) => {
+        const v = CreateCanvasInput.parse(input);
+        return createProject(
+          {
+            name: v.name,
+            description: v.description ?? null,
+            is_public: v.isPublic ?? false,
+            created_by: userId,
+          },
+          client
+        );
+      },
+      update: (id: string, patch: unknown) => {
+        const v = UpdateCanvasInput.parse(patch);
+        return updateProject(
+          id,
+          {
+            ...(v.name !== undefined ? { name: v.name } : {}),
+            ...(v.description !== undefined ? { description: v.description } : {}),
+            ...(v.isPublic !== undefined ? { is_public: v.isPublic } : {}),
+          },
+          client
+        );
+      },
+      delete: (id: string) => deleteProject(id, client),
+    },
+
+    nodes: {
+      create: createNode,
+      // Named helpers map to metric_cards categories (design-doc tool surface).
+      createMetric: typedNode('Data/Metric'),
+      createValue: typedNode('Core/Value'),
+      createAction: typedNode('Work/Action'),
+      createHypothesis: typedNode('Ideas/Hypothesis'),
+      update: (id: string, patch: unknown) => {
+        const v = UpdateNodeInput.parse(patch);
+        return updateMetricCard(id, v as Partial<MetricCard>, client);
+      },
+      delete: (id: string) => deleteMetricCard(id, client),
+      list: (projectId: string) => getProjectMetricCards(projectId, client),
+    },
+
+    relationships: {
+      create: (input: unknown) => {
+        const v = CreateRelationshipInput.parse(input);
+        const rel: Relationship = {
+          id: newId(),
+          sourceId: v.sourceId,
+          targetId: v.targetId,
+          type: v.type,
+          confidence: v.confidence ?? 'Medium',
+          weight: v.weight,
+          evidence: [],
+          notes: v.notes,
+          createdAt: nowIso(),
+          updatedAt: nowIso(),
+        };
+        return createRelationship(rel, v.projectId, userId, client);
+      },
+      delete: (id: string) => deleteRelationship(id, client),
+      list: (projectId: string) => getProjectRelationships(projectId, client),
+    },
+
+    // get_tree: full structure so agents extend rather than duplicate.
+    tree: {
+      get: async (projectId: string) => ({
+        projectId,
+        cards: await getProjectMetricCards(projectId, client),
+        relationships: await getProjectRelationships(projectId, client),
+      }),
+    },
+
+    values: {
+      // Upsert a tracked-metric series (two-tier value store). Full staging +
+      // column mapping is CVS-102.
+      push: (input: unknown) => {
+        const v = PushValuesInput.parse(input);
+        const series: MetricValue[] = v.series.map((s) => ({
+          period: s.period,
+          value: s.value,
+          change_percent: s.change_percent ?? 0,
+          trend: s.trend ?? 'neutral',
+        }));
+        return writeMetricValues(v.trackedMetricId, series, v.source, client);
+      },
+    },
+  };
+}
+
+export type MetrimapApi = ReturnType<typeof createMetrimapApi>;

--- a/src/shared/lib/api/schemas.ts
+++ b/src/shared/lib/api/schemas.ts
@@ -1,0 +1,100 @@
+// Zod input schemas for the programmatic Metrimap API (CVS-98). These define the
+// stable, validated surface the MCP server (and the app) call — one place for
+// input validation so agents get clear errors. Kept intentionally small/flat;
+// the facade maps these to the existing domain services.
+import { z } from 'zod';
+
+export const CARD_CATEGORIES = [
+  'Core/Value',
+  'Data/Metric',
+  'Work/Action',
+  'Ideas/Hypothesis',
+  'Metadata',
+] as const;
+
+export const RELATIONSHIP_TYPES = [
+  'Deterministic',
+  'Probabilistic',
+  'Causal',
+  'Compositional',
+] as const;
+
+export const CONFIDENCE_LEVELS = ['High', 'Medium', 'Low'] as const;
+
+const zPosition = z.object({ x: z.number(), y: z.number() });
+
+// --- Canvases (projects) ---
+export const CreateCanvasInput = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  isPublic: z.boolean().optional(),
+});
+
+export const UpdateCanvasInput = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(2000).optional(),
+    isPublic: z.boolean().optional(),
+  })
+  .refine((o) => Object.keys(o).length > 0, {
+    message: 'Provide at least one field to update',
+  });
+
+// --- Nodes (metric_cards) ---
+export const CreateNodeInput = z.object({
+  projectId: z.string().uuid(),
+  title: z.string().min(1).max(200),
+  category: z.enum(CARD_CATEGORIES),
+  description: z.string().max(4000).optional(),
+  position: zPosition.optional(),
+  formula: z.string().max(2000).optional(),
+  assignees: z.array(z.string()).max(50).optional(),
+});
+
+// Convenience inputs where the category is implied by the method.
+export const CreateTypedNodeInput = CreateNodeInput.omit({ category: true });
+
+export const UpdateNodeInput = z
+  .object({
+    title: z.string().min(1).max(200).optional(),
+    description: z.string().max(4000).optional(),
+    category: z.enum(CARD_CATEGORIES).optional(),
+    formula: z.string().max(2000).optional(),
+    position: zPosition.optional(),
+  })
+  .refine((o) => Object.keys(o).length > 0, {
+    message: 'Provide at least one field to update',
+  });
+
+// --- Relationships ---
+export const CreateRelationshipInput = z.object({
+  projectId: z.string().uuid(),
+  sourceId: z.string().uuid(),
+  targetId: z.string().uuid(),
+  type: z.enum(RELATIONSHIP_TYPES),
+  confidence: z.enum(CONFIDENCE_LEVELS).optional(),
+  weight: z.number().min(0).max(1).optional(),
+  notes: z.string().max(2000).optional(),
+});
+
+// --- Values (tracked-metric series) ---
+export const MetricValueInput = z.object({
+  period: z.string().min(1),
+  value: z.number(),
+  change_percent: z.number().optional(),
+  trend: z.enum(['up', 'down', 'neutral']).optional(),
+});
+
+export const PushValuesInput = z.object({
+  trackedMetricId: z.string().uuid(),
+  series: z.array(MetricValueInput).min(1).max(1000),
+  source: z.string().max(200).optional(),
+});
+
+export type CreateCanvasInputT = z.infer<typeof CreateCanvasInput>;
+export type UpdateCanvasInputT = z.infer<typeof UpdateCanvasInput>;
+export type CreateNodeInputT = z.infer<typeof CreateNodeInput>;
+export type CreateTypedNodeInputT = z.infer<typeof CreateTypedNodeInput>;
+export type UpdateNodeInputT = z.infer<typeof UpdateNodeInput>;
+export type CreateRelationshipInputT = z.infer<typeof CreateRelationshipInput>;
+export type PushValuesInputT = z.infer<typeof PushValuesInput>;


### PR DESCRIPTION
The **foundation the MCP wraps** (per the vault design doc / CVS-97 spike): a versioned, Zod-validated, **RLS-scoped** facade over the existing domain services on the canonical model (`metric_cards` + `relationships` + `projects` + tracked-metric values). Not the `@ts-nocheck` `value_nodes` model.

## RLS-scoping guarantee
`createMetrimapApi(client, userId)` **requires** a Clerk-authenticated client + the userId and throws otherwise — every call runs under that user's RLS; the **service-role key is never passed here**. `userId` drives `created_by`.

## Surface (v1)
- `canvases` — list / get / create / update / delete
- `nodes` — create + `createMetric`/`createValue`/`createAction`/`createHypothesis` (category presets) / update / delete / list
- `relationships` — create (typed: Deterministic/Probabilistic/Causal/Compositional) / delete / list
- `tree.get(projectId)` → `{ cards, relationships }` (context so agents extend, not duplicate)
- `values.push({trackedMetricId, series, source?})` — tracked-metric series upsert

## Files
`src/shared/lib/api/{schemas,metrimapApi,index}.ts` + **14 unit tests** (validation + RLS-guards + delegation via mocked services) + `docs/features/programmatic-api.md`.

## Scope boundaries
Ingest staging/mapping = **CVS-102**; auth (OAuth + API keys) = CVS-99; MCP server scaffold = CVS-100. This is only the service layer they call.

Verify: `npm run type-check`, `npx eslint`, `npx vitest run` (**146 passing**) all green.

Ref: CVS-98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)