### PR TITLE
fix(evidence): render populated fields instead of "No content available" (CVS-35)

### DIFF
--- a/src/features/evidence/components/EvidenceContentRenderer.tsx
+++ b/src/features/evidence/components/EvidenceContentRenderer.tsx
@@ -51,11 +51,33 @@ export default function EvidenceContentRenderer({
   }, [evidence.content]);
 
   if (!evidence.content) {
+    // No EditorJS notebook yet — render whatever structured fields are populated
+    // (summary / hypothesis / impact) rather than the bare placeholder, which
+    // wrongly showed even for populated Analysis-type evidence (CVS-35).
+    const sections = [
+      { label: "Summary", value: evidence.summary },
+      { label: "Hypothesis", value: evidence.hypothesis },
+      { label: "Impact on confidence", value: evidence.impactOnConfidence },
+    ].filter((s) => s.value && s.value.trim());
+
     return (
       <div className={`codex-editor codex-editor--readonly ${className}`}>
-        <p className="text-gray-500 italic">
-          {evidence.summary || "No content available"}
-        </p>
+        {sections.length > 0 ? (
+          <div className="space-y-2">
+            {sections.map((s) => (
+              <div key={s.label}>
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+                  {s.label}
+                </p>
+                <p className="whitespace-pre-wrap text-sm text-gray-700">
+                  {s.value}
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-gray-500 italic">No content available</p>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
Fixes **CVS-35** — a populated Evidence node (e.g. an Analysis card with summary + hypothesis) showed **"No content available"** on the canvas.

## Root cause
`EvidenceContentRenderer` renders the EditorJS notebook only when `evidence.content` is set; otherwise it fell back to `evidence.summary || "No content available"`. Analysis-type evidence has `summary`/`hypothesis` but no `content`, and when `summary` was empty the bare placeholder showed despite real data.

## Fix
When there's no `content`, render the populated structured fields — **Summary / Hypothesis / Impact on confidence** — as labelled text. Only show "No content available" when *all* are empty. `EvidenceNode` already passes the full `EvidenceItem`, so no field-mapping change was needed.

## Acceptance criteria
- [x] Populated evidence never shows "No content available" on the canvas card
- [x] Renders notebook content, or a meaningful summary/hypothesis fallback
- [x] Fixed for an Analysis-type item (summary + hypothesis)

## Verification
type-check ✓, lint ✓, full Vitest ✓. Visual covered by the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)