### PR TITLE
feat(CVS-100): MCP server scaffold — tool registry + dispatch + auth seam

### DIFF
--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -1,0 +1,91 @@
+# Metrimap MCP server (scaffold)
+
+The remote MCP server that exposes Metrimap's build/ingest tools to a user's own
+agent (Claude, Codex). Design authority: product vault
+`PRD/4. Product/3. MCP and Programmatic Building` (CVS-97). This doc covers the
+scaffold shipped in **CVS-100** and the transport/deploy that remains.
+
+## Layers
+
+```
+agent  ──MCP──▶  transport adapter (Streamable HTTP)   [deploy — this doc]
+                    │  resolve auth per request  ───────  AuthContextResolver (CVS-99)
+                    ▼
+                 tool registry + dispatch  ─────────────  src/shared/lib/api/mcp  (CVS-100 ✓)
+                    ▼
+                 createMetrimapApi(client, userId)  ─────  src/shared/lib/api  (CVS-98 ✓, RLS-scoped)
+                    ▼
+                 Supabase (RLS)
+```
+
+## Shipped in CVS-100 — `src/shared/lib/api/mcp`
+
+Transport-agnostic and unit-tested (no server/DB needed):
+
+- **`registry.ts`** — the tool registry: each tool has a name, agent-facing
+  description, Zod `inputSchema`, a `read`/`write` scope, and a handler that calls
+  the CVS-98 API. `dispatchTool(name, args, ctx)` validates input, enforces scope,
+  runs the handler, and raises **structured `McpToolError`s** (`invalid_input` /
+  `unauthenticated` / `forbidden` / `not_found` / `internal`). `listTools()` feeds
+  `tools/list`.
+- **`authContext.ts`** — the **auth seam**: `McpAuthContext { userId, client, scopes }`
+  and the `AuthContextResolver` type that **CVS-99** implements (OAuth token
+  exchange / API-key lookup → a Clerk-authenticated, RLS-scoped client). Until
+  then `unimplementedAuthResolver` refuses calls. The service-role key is never
+  used.
+- **`errors.ts`** — the structured error codes.
+
+Tools wired (representative; the finalized surface + polished descriptions are
+**CVS-101**): `list_canvases`, `get_tree`, `list_nodes`, `list_relationships`,
+`create_canvas`, `update_canvas`, `delete_canvas`, `create_metric`,
+`create_value`, `create_action`, `update_node`, `delete_node`,
+`create_relationship`, `delete_relationship`, `push_values`.
+
+## Transport + deploy — the remaining work (owner decision)
+
+**Blocked on:** (1) a **hosting decision** and (2) the **auth resolver (CVS-99)**.
+
+Hosting options (design doc §2 — confirm in build):
+- **Vercel function/edge** under `api/` on `mcp.canvasm.app` — lightest; co-deployed.
+- **Small dedicated Node service** — more control, separate lifecycle.
+
+Reference transport adapter (uses the official MCP SDK; **not yet added as a
+dependency** because hosting isn't chosen — add `@modelcontextprotocol/sdk` in the
+chosen host):
+
+```ts
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { listTools, dispatchTool, McpToolError } from '@/shared/lib/api/mcp';
+
+const resolveAuth = /* CVS-99 AuthContextResolver */;
+
+export async function handler(req, res) {
+  const server = new McpServer({ name: 'metrimap', version: '0.1.0' });
+  for (const t of listTools()) {
+    server.registerTool(t.name, { title: t.title, description: t.description, inputSchema: t.inputSchema },
+      async (args) => {
+        const ctx = await resolveAuth(req);                 // per-request, RLS-scoped
+        try { return { content: [{ type: 'text', text: JSON.stringify(await dispatchTool(t.name, args, ctx)) }] }; }
+        catch (e) { const code = e instanceof McpToolError ? e.code : 'internal';
+          return { isError: true, content: [{ type: 'text', text: `${code}: ${(e as Error).message}` }] }; }
+      });
+  }
+  const transport = new StreamableHTTPServerTransport({ /* session opts */ });
+  await server.connect(transport);
+  await transport.handleRequest(req, res);
+}
+```
+
+Plus a `GET /health` returning `{ ok: true, version }`.
+
+### Once deployed
+Reachable at `https://mcp.canvasm.app/mcp`, addable via
+`claude mcp add --transport http metrimap https://mcp.canvasm.app/mcp` and the
+claude.ai connector. Add request logging + a `mcp_audit_log` (CVS-104).
+
+## Status vs acceptance criteria
+- [x] Tool registry wired to the API layer; structured errors — **done + tested**.
+- [x] Per-request auth **context** modelled (resolver seam) — resolver impl = CVS-99.
+- [ ] Server reachable at a stable URL — needs the hosting decision + adapter deploy.
+- [ ] Deploy + logs — same.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ CVS). See the **Docs policy** in [`../AGENTS.md`](../AGENTS.md).
   [userback-customer-requests](features/userback-customer-requests.md),
   [security-scanning](features/security-scanning.md),
   [programmatic-api](features/programmatic-api.md),
+  [mcp-server](features/mcp-server.md),
   [metrics-api](features/metrics-api.md)
 
 Anything product-facing (feature narratives, changelogs, methodology, PRD) belongs

--- a/src/shared/lib/api/mcp/authContext.ts
+++ b/src/shared/lib/api/mcp/authContext.ts
@@ -1,0 +1,40 @@
+// Per-request auth context for the MCP server (CVS-100). This is the SEAM the
+// auth issue (CVS-99, OAuth "Connect" + personal API key) fills in: it resolves
+// an incoming request to a specific user + a Clerk-authenticated Supabase client,
+// so every tool call runs under that user's RLS. The service-role key is never
+// used here.
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import { McpToolError } from './errors';
+
+export type McpScope = 'read' | 'write';
+
+export interface McpAuthContext {
+  /** Authenticated user id (Clerk) — drives created_by + RLS. */
+  userId: string;
+  /** RLS-scoped client from createClerkSupabaseClient — never service-role. */
+  client: SupabaseClient<Database>;
+  /** Optional per-connection scopes; when omitted, all tools are allowed. */
+  scopes?: McpScope[];
+}
+
+/** Minimal request shape the resolver needs (headers carry the bearer/API key). */
+export interface McpRequestLike {
+  headers: Record<string, string | undefined>;
+}
+
+/** CVS-99 implements this (OAuth token exchange / API-key lookup → user + client). */
+export type AuthContextResolver = (
+  req: McpRequestLike
+) => Promise<McpAuthContext>;
+
+/**
+ * Placeholder resolver until CVS-99 lands. Wiring a real resolver is what makes
+ * the server multi-tenant; until then the scaffold refuses to serve tool calls.
+ */
+export const unimplementedAuthResolver: AuthContextResolver = async () => {
+  throw new McpToolError(
+    'unauthenticated',
+    'MCP auth is not wired yet — implement the AuthContextResolver in CVS-99 (OAuth Connect + personal API key).'
+  );
+};

--- a/src/shared/lib/api/mcp/errors.ts
+++ b/src/shared/lib/api/mcp/errors.ts
@@ -1,0 +1,19 @@
+// Structured errors for the MCP tool layer (CVS-100). The transport adapter maps
+// these codes to MCP/JSON-RPC error responses so agents get actionable failures.
+export type McpErrorCode =
+  | 'invalid_input'
+  | 'unauthenticated'
+  | 'forbidden'
+  | 'not_found'
+  | 'internal';
+
+export class McpToolError extends Error {
+  readonly code: McpErrorCode;
+  readonly details?: unknown;
+  constructor(code: McpErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = 'McpToolError';
+    this.code = code;
+    this.details = details;
+  }
+}

--- a/src/shared/lib/api/mcp/index.ts
+++ b/src/shared/lib/api/mcp/index.ts
@@ -1,0 +1,12 @@
+// MCP scaffold (CVS-100): transport-agnostic tool registry + dispatch + auth seam
+// over the RLS-scoped programmatic API (CVS-98). The Streamable-HTTP transport +
+// deploy is documented in docs/features/mcp-server.md; auth resolver is CVS-99.
+export { TOOLS, listTools, dispatchTool, type McpTool } from './registry';
+export { McpToolError, type McpErrorCode } from './errors';
+export {
+  unimplementedAuthResolver,
+  type McpAuthContext,
+  type McpScope,
+  type McpRequestLike,
+  type AuthContextResolver,
+} from './authContext';

--- a/src/shared/lib/api/mcp/registry.test.ts
+++ b/src/shared/lib/api/mcp/registry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Shared fake API so we can assert the registry dispatches to the CVS-98 layer.
+const { fakeApi } = vi.hoisted(() => ({
+  fakeApi: {
+    canvases: {
+      list: vi.fn(async () => ['c1']),
+      get: vi.fn(async () => ({ id: 'p' })),
+      create: vi.fn(async () => ({ id: 'new' })),
+      update: vi.fn(async () => ({ id: 'p' })),
+      delete: vi.fn(async () => undefined),
+    },
+    nodes: {
+      createMetric: vi.fn(async () => ({ id: 'n' })),
+      createValue: vi.fn(async () => ({ id: 'v' })),
+      createAction: vi.fn(async () => ({ id: 'a' })),
+      update: vi.fn(async () => ({ id: 'n' })),
+      delete: vi.fn(async () => undefined),
+      list: vi.fn(async () => []),
+    },
+    relationships: {
+      create: vi.fn(async () => ({ id: 'r' })),
+      delete: vi.fn(async () => undefined),
+      list: vi.fn(async () => []),
+    },
+    tree: { get: vi.fn(async (pid: string) => ({ projectId: pid, cards: [], relationships: [] })) },
+    values: { push: vi.fn(async () => undefined) },
+  },
+}));
+
+vi.mock('../metrimapApi', () => ({ createMetrimapApi: vi.fn(() => fakeApi) }));
+
+import { TOOLS, listTools, dispatchTool } from './registry';
+import { McpToolError } from './errors';
+import type { McpAuthContext } from './authContext';
+
+const ctx = (scopes?: ('read' | 'write')[]): McpAuthContext => ({
+  userId: 'u1',
+  client: {} as never,
+  scopes,
+});
+const PROJECT = '11111111-1111-1111-1111-111111111111';
+const NODE_A = '22222222-2222-2222-2222-222222222222';
+const NODE_B = '33333333-3333-3333-3333-333333333333';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('registry metadata', () => {
+  it('exposes uniquely-named tools, each with a description + schema', () => {
+    const names = TOOLS.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+    for (const t of TOOLS) {
+      expect(t.description.length).toBeGreaterThan(0);
+      expect(t.inputSchema).toBeDefined();
+      expect(['read', 'write']).toContain(t.scope);
+    }
+    expect(names).toEqual(expect.arrayContaining(['list_canvases', 'create_canvas', 'get_tree', 'create_metric', 'create_relationship', 'push_values']));
+  });
+  it('listTools mirrors the registry', () => {
+    expect(listTools().map((t) => t.name)).toEqual(TOOLS.map((t) => t.name));
+  });
+});
+
+describe('dispatchTool', () => {
+  it('routes a valid call to the API layer and returns the result', async () => {
+    const out = await dispatchTool('create_canvas', { name: 'My Tree' }, ctx());
+    expect(fakeApi.canvases.create).toHaveBeenCalledWith({ name: 'My Tree' });
+    expect(out).toEqual({ id: 'new' });
+  });
+
+  it('routes create_metric to nodes.createMetric', async () => {
+    await dispatchTool('create_metric', { projectId: PROJECT, title: 'MRR' }, ctx());
+    expect(fakeApi.nodes.createMetric).toHaveBeenCalledWith({ projectId: PROJECT, title: 'MRR' });
+  });
+
+  it('routes get_tree to tree.get', async () => {
+    const out = await dispatchTool('get_tree', { projectId: PROJECT }, ctx());
+    expect(fakeApi.tree.get).toHaveBeenCalledWith(PROJECT);
+    expect(out).toMatchObject({ projectId: PROJECT });
+  });
+
+  it('splits id + patch for update_node', async () => {
+    await dispatchTool('update_node', { id: NODE_A, title: 'renamed' }, ctx());
+    expect(fakeApi.nodes.update).toHaveBeenCalledWith(NODE_A, { title: 'renamed' });
+  });
+
+  it('throws not_found for an unknown tool', async () => {
+    await expect(dispatchTool('nope', {}, ctx())).rejects.toMatchObject({
+      name: 'McpToolError',
+      code: 'not_found',
+    });
+  });
+
+  it('throws invalid_input (with issues) for bad args', async () => {
+    const err = (await dispatchTool('create_canvas', { name: '' }, ctx()).catch(
+      (e) => e
+    )) as McpToolError;
+    expect(err).toBeInstanceOf(McpToolError);
+    expect(err.code).toBe('invalid_input');
+    expect(err.details).toBeTruthy();
+    expect(fakeApi.canvases.create).not.toHaveBeenCalled();
+  });
+
+  it('enforces the write scope', async () => {
+    await expect(dispatchTool('create_canvas', { name: 'x' }, ctx(['read']))).rejects.toMatchObject({
+      code: 'forbidden',
+    });
+    // read tools are allowed with only the read scope
+    await expect(dispatchTool('list_canvases', {}, ctx(['read']))).resolves.toEqual(['c1']);
+  });
+
+  it('wraps downstream failures as internal', async () => {
+    fakeApi.relationships.create.mockRejectedValueOnce(new Error('db exploded'));
+    const err = (await dispatchTool(
+      'create_relationship',
+      { projectId: PROJECT, sourceId: NODE_A, targetId: NODE_B, type: 'Causal' },
+      ctx()
+    ).catch((e) => e)) as McpToolError;
+    expect(err).toBeInstanceOf(McpToolError);
+    expect(err.code).toBe('internal');
+    expect(err.message).toMatch(/db exploded/);
+  });
+});

--- a/src/shared/lib/api/mcp/registry.ts
+++ b/src/shared/lib/api/mcp/registry.ts
@@ -1,0 +1,226 @@
+// MCP tool registry + dispatch (CVS-100). Transport-agnostic: maps MCP tool
+// names to the RLS-scoped programmatic API (CVS-98). The transport adapter
+// (Streamable HTTP, deployed separately — see docs/features/mcp-server.md) turns
+// this registry into `tools/list` + `tools/call`. The FULL/finalized tool surface
+// + polished descriptions are CVS-101; this is a representative wiring proving the
+// registry → API → RLS path with structured errors.
+import { z } from 'zod';
+import { createMetrimapApi } from '../metrimapApi';
+import {
+  CreateCanvasInput,
+  CreateRelationshipInput,
+  CreateTypedNodeInput,
+  PushValuesInput,
+} from '../schemas';
+import type { McpAuthContext, McpScope } from './authContext';
+import { McpToolError } from './errors';
+
+export interface McpTool {
+  name: string;
+  title: string;
+  description: string;
+  scope: McpScope;
+  inputSchema: z.ZodTypeAny;
+  handler: (args: unknown, ctx: McpAuthContext) => Promise<unknown>;
+}
+
+function defineTool<S extends z.ZodTypeAny>(t: {
+  name: string;
+  title: string;
+  description: string;
+  scope: McpScope;
+  inputSchema: S;
+  handler: (args: z.infer<S>, ctx: McpAuthContext) => Promise<unknown>;
+}): McpTool {
+  return t as unknown as McpTool;
+}
+
+const api = (ctx: McpAuthContext) => createMetrimapApi(ctx.client, ctx.userId);
+
+const idInput = z.object({ id: z.string().uuid() });
+const projectIdInput = z.object({ projectId: z.string().uuid() });
+const updateInput = z.object({ id: z.string().uuid() }).passthrough();
+
+export const TOOLS: McpTool[] = [
+  // --- Read ---
+  defineTool({
+    name: 'list_canvases',
+    title: 'List canvases',
+    description:
+      "List the authenticated user's metric-tree canvases (projects). Returns ids to use in other tools.",
+    scope: 'read',
+    inputSchema: z.object({}).strict(),
+    handler: (_a, ctx) => api(ctx).canvases.list(),
+  }),
+  defineTool({
+    name: 'get_tree',
+    title: 'Get tree',
+    description:
+      'Read a canvas\'s full structure — all metric cards + typed relationships. Call this before adding nodes so you EXTEND the existing tree instead of duplicating it.',
+    scope: 'read',
+    inputSchema: projectIdInput,
+    handler: (a, ctx) => api(ctx).tree.get(a.projectId),
+  }),
+  defineTool({
+    name: 'list_nodes',
+    title: 'List nodes',
+    description: 'List all metric cards (nodes) on a canvas.',
+    scope: 'read',
+    inputSchema: projectIdInput,
+    handler: (a, ctx) => api(ctx).nodes.list(a.projectId),
+  }),
+  defineTool({
+    name: 'list_relationships',
+    title: 'List relationships',
+    description: 'List all typed relationships on a canvas.',
+    scope: 'read',
+    inputSchema: projectIdInput,
+    handler: (a, ctx) => api(ctx).relationships.list(a.projectId),
+  }),
+  // --- Write: canvases ---
+  defineTool({
+    name: 'create_canvas',
+    title: 'Create canvas',
+    description: 'Create a new metric-tree canvas (project). Returns the canvas id.',
+    scope: 'write',
+    inputSchema: CreateCanvasInput,
+    handler: (a, ctx) => api(ctx).canvases.create(a),
+  }),
+  defineTool({
+    name: 'update_canvas',
+    title: 'Update canvas',
+    description: 'Update a canvas (name, description, isPublic).',
+    scope: 'write',
+    inputSchema: updateInput,
+    handler: ({ id, ...patch }, ctx) => api(ctx).canvases.update(id, patch),
+  }),
+  defineTool({
+    name: 'delete_canvas',
+    title: 'Delete canvas',
+    description: 'Delete a canvas and its contents.',
+    scope: 'write',
+    inputSchema: idInput,
+    handler: (a, ctx) => api(ctx).canvases.delete(a.id),
+  }),
+  // --- Write: nodes (category via named tool) ---
+  defineTool({
+    name: 'create_metric',
+    title: 'Create metric node',
+    description:
+      'Create a Data/Metric card (a measured driver). Provide projectId + title. Returns the node id for chaining into create_relationship.',
+    scope: 'write',
+    inputSchema: CreateTypedNodeInput,
+    handler: (a, ctx) => api(ctx).nodes.createMetric(a),
+  }),
+  defineTool({
+    name: 'create_value',
+    title: 'Create value node',
+    description:
+      'Create a Core/Value card (an outcome / value node — e.g. Profit). Returns the node id.',
+    scope: 'write',
+    inputSchema: CreateTypedNodeInput,
+    handler: (a, ctx) => api(ctx).nodes.createValue(a),
+  }),
+  defineTool({
+    name: 'create_action',
+    title: 'Create action node',
+    description:
+      'Create a Work/Action card (an initiative / task that moves a metric). Returns the node id.',
+    scope: 'write',
+    inputSchema: CreateTypedNodeInput,
+    handler: (a, ctx) => api(ctx).nodes.createAction(a),
+  }),
+  defineTool({
+    name: 'update_node',
+    title: 'Update node',
+    description: 'Update a metric card (title, description, category, formula, position).',
+    scope: 'write',
+    inputSchema: updateInput,
+    handler: ({ id, ...patch }, ctx) => api(ctx).nodes.update(id, patch),
+  }),
+  defineTool({
+    name: 'delete_node',
+    title: 'Delete node',
+    description: 'Delete a metric card.',
+    scope: 'write',
+    inputSchema: idInput,
+    handler: (a, ctx) => api(ctx).nodes.delete(a.id),
+  }),
+  // --- Write: relationships ---
+  defineTool({
+    name: 'create_relationship',
+    title: 'Create relationship',
+    description:
+      'Connect two nodes with a typed relationship (Deterministic / Probabilistic / Causal / Compositional). Provide projectId, sourceId, targetId, type.',
+    scope: 'write',
+    inputSchema: CreateRelationshipInput,
+    handler: (a, ctx) => api(ctx).relationships.create(a),
+  }),
+  defineTool({
+    name: 'delete_relationship',
+    title: 'Delete relationship',
+    description: 'Delete a relationship.',
+    scope: 'write',
+    inputSchema: idInput,
+    handler: (a, ctx) => api(ctx).relationships.delete(a.id),
+  }),
+  // --- Write: values ---
+  defineTool({
+    name: 'push_values',
+    title: 'Push values',
+    description:
+      'Upsert a tracked metric\'s value series (one row per period). Staging + column mapping for raw CSV is a separate tool (CVS-102).',
+    scope: 'write',
+    inputSchema: PushValuesInput,
+    handler: (a, ctx) => api(ctx).values.push(a),
+  }),
+];
+
+const BY_NAME = new Map(TOOLS.map((t) => [t.name, t]));
+
+/** Metadata for MCP `tools/list` (the adapter converts inputSchema → JSON schema). */
+export function listTools() {
+  return TOOLS.map(({ name, title, description, scope, inputSchema }) => ({
+    name,
+    title,
+    description,
+    scope,
+    inputSchema,
+  }));
+}
+
+/**
+ * Validate + run one tool call under the caller's auth context. Throws
+ * McpToolError (structured) for unknown tool / bad scope / invalid input /
+ * downstream failure — the transport maps these to MCP error responses.
+ */
+export async function dispatchTool(
+  name: string,
+  rawArgs: unknown,
+  ctx: McpAuthContext
+): Promise<unknown> {
+  const tool = BY_NAME.get(name);
+  if (!tool) throw new McpToolError('not_found', `Unknown tool: ${name}`);
+
+  if (tool.scope === 'write' && ctx.scopes && !ctx.scopes.includes('write')) {
+    throw new McpToolError('forbidden', `Tool "${name}" requires the write scope`);
+  }
+
+  let args: unknown;
+  try {
+    args = tool.inputSchema.parse(rawArgs ?? {});
+  } catch (e) {
+    throw new McpToolError(
+      'invalid_input',
+      `Invalid input for "${name}"`,
+      e instanceof z.ZodError ? e.issues : String(e)
+    );
+  }
+
+  try {
+    return await tool.handler(args, ctx);
+  } catch (e) {
+    if (e instanceof McpToolError) throw e;
+    throw new McpToolError('internal', e instanceof Error ? e.message : String(e));
+  }
+}


### PR DESCRIPTION
The MCP scaffold over the CVS-98 API — the transport-agnostic core, unit-tested, with the transport/deploy documented as the remaining owner step.

## Shipped — `src/shared/lib/api/mcp`
- **`registry.ts`** — v1 tools (`list_canvases`, `get_tree`, `create_canvas`, `create_metric`/`create_value`/`create_action`, `update_node`/`delete_node`, `create_relationship`/`delete_relationship`, `push_values`, …) → `createMetrimapApi`. `dispatchTool` validates (Zod), enforces `read`/`write` scope, and raises **structured `McpToolError`s**. `listTools()` feeds `tools/list`.
- **`authContext.ts`** — the **auth seam** (`AuthContextResolver`) that CVS-99 implements (OAuth/API-key → RLS-scoped Clerk client). Until then it refuses calls; service-role key never used.
- **`errors.ts`** — structured error codes. **+ 10 unit tests.**
- **`docs/features/mcp-server.md`** — architecture + a reference Streamable-HTTP adapter + the **hosting decision** (Vercel function vs dedicated Node).

## Status vs ACs
- [x] Tool registry wired to the API layer; structured errors — done + tested.
- [x] Per-request auth **context** modelled (resolver seam) — resolver impl = CVS-99.
- [ ] Server reachable at a stable URL / deploy + logs — **needs the hosting decision + CVS-99 auth** (documented; `@modelcontextprotocol/sdk` added in the chosen host, not the SPA bundle).

Finalized tool surface + polished descriptions = CVS-101.

Verify: type-check + eslint + `vitest run` (**156 passing**, 10 new) green.

Ref: CVS-100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)