### PR TITLE
CVS-158: shared card/sheet primitives

### DIFF
--- a/src/features/canvas/components/primitives/CompactTabs.tsx
+++ b/src/features/canvas/components/primitives/CompactTabs.tsx
@@ -1,0 +1,77 @@
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/shared/components/ui/tabs';
+import { cn } from '@/shared/utils';
+import type { ReactNode } from 'react';
+
+export interface CompactTab {
+  value: string;
+  label: ReactNode;
+  icon?: React.ElementType;
+  /** Optional inline content. Omit to render the panel yourself (controlled). */
+  content?: ReactNode;
+  disabled?: boolean;
+}
+
+interface CompactTabsProps {
+  tabs: CompactTab[];
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  className?: string;
+  listClassName?: string;
+  /** Stretch the tab list to fill its width (equal-width triggers). */
+  fill?: boolean;
+}
+
+/**
+ * One consistent tab style across the canvas surfaces (CVS-158) — a thin
+ * wrapper over the shadcn `Tabs` primitive so we stop hand-rolling `<button>`
+ * tab bars. Pass `content` per tab for inline panels, or omit it and render the
+ * active panel yourself (controlled `value`).
+ */
+export function CompactTabs({
+  tabs,
+  value,
+  defaultValue,
+  onValueChange,
+  className,
+  listClassName,
+  fill,
+}: CompactTabsProps) {
+  const hasContent = tabs.some((t) => t.content != null);
+  return (
+    <Tabs
+      value={value}
+      defaultValue={defaultValue ?? tabs[0]?.value}
+      onValueChange={onValueChange}
+      className={className}
+    >
+      <TabsList className={cn(fill && 'w-full', listClassName)}>
+        {tabs.map((t) => {
+          const Icon = t.icon;
+          return (
+            <TabsTrigger
+              key={t.value}
+              value={t.value}
+              disabled={t.disabled}
+              className={cn('gap-1.5', fill && 'flex-1')}
+            >
+              {Icon && <Icon className="h-3.5 w-3.5" />}
+              {t.label}
+            </TabsTrigger>
+          );
+        })}
+      </TabsList>
+      {hasContent &&
+        tabs.map((t) => (
+          <TabsContent key={t.value} value={t.value}>
+            {t.content}
+          </TabsContent>
+        ))}
+    </Tabs>
+  );
+}

--- a/src/features/canvas/components/primitives/NodeCardShell.tsx
+++ b/src/features/canvas/components/primitives/NodeCardShell.tsx
@@ -1,0 +1,108 @@
+import { Badge } from '@/shared/components/ui/badge';
+import { cn } from '@/shared/utils';
+import type { ReactNode } from 'react';
+
+interface NodeCardShellProps {
+  /** Accent hex (e.g. '#3b82f6') — tints the icon chip. Falls back to the primary token. */
+  accent?: string;
+  icon?: React.ElementType;
+  /** Short type label shown as a badge (e.g. "Metric", "Source"). */
+  typeLabel?: ReactNode;
+  title: ReactNode;
+  /** Extra header controls, right-aligned. */
+  headerRight?: ReactNode;
+  /** Badge/status row under the title. */
+  badges?: ReactNode;
+  /** Footer metadata (id, owner, timestamps). */
+  footer?: ReactNode;
+  selected?: boolean;
+  onDoubleClick?: () => void;
+  /** React Flow <Handle> elements. */
+  handles?: ReactNode;
+  /** Hover/selection toolbar (caller controls visibility). */
+  toolbar?: ReactNode;
+  width?: number;
+  className?: string;
+  children?: ReactNode;
+}
+
+/**
+ * The one node-card shell (CVS-158). Replaces the four near-identical hand-rolled
+ * PRD-node `<div>` shells and normalizes the Operator/Chart/Source widths/radii.
+ * Header (accent icon chip + type badge + title) · body slot · optional footer ·
+ * consistent selection ring, all on theme tokens (no `gray-*`/`blue-*`). Handles
+ * and the hover toolbar are slots so React Flow behavior stays with the node.
+ */
+export function NodeCardShell({
+  accent,
+  icon: Icon,
+  typeLabel,
+  title,
+  headerRight,
+  badges,
+  footer,
+  selected,
+  onDoubleClick,
+  handles,
+  toolbar,
+  width = 300,
+  className,
+  children,
+}: NodeCardShellProps) {
+  return (
+    <div className="relative" style={{ width }}>
+      {toolbar}
+      <div
+        onDoubleClick={onDoubleClick}
+        className={cn(
+          'overflow-hidden rounded-lg border bg-card shadow-sm transition-shadow',
+          selected
+            ? 'border-primary ring-2 ring-primary/40'
+            : 'border-border hover:shadow-md',
+          className
+        )}
+      >
+        <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
+          {Icon && (
+            <span
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
+              style={{
+                backgroundColor: accent ? `${accent}1a` : 'var(--muted)',
+                color: accent || 'var(--primary)',
+              }}
+            >
+              <Icon className="h-4 w-4" />
+            </span>
+          )}
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold leading-tight">
+              {title}
+            </div>
+          </div>
+          {typeLabel && (
+            <Badge variant="secondary" className="shrink-0 font-normal">
+              {typeLabel}
+            </Badge>
+          )}
+          {headerRight}
+        </div>
+
+        {(children || badges) && (
+          <div className="space-y-2 px-3 py-2">
+            {children}
+            {badges && (
+              <div className="flex flex-wrap items-center gap-1.5">{badges}</div>
+            )}
+          </div>
+        )}
+
+        {footer && (
+          <div className="flex items-center justify-between gap-2 border-t border-border/60 bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+            {footer}
+          </div>
+        )}
+      </div>
+      {handles}
+    </div>
+  );
+}

--- a/src/features/canvas/components/primitives/SheetShell.tsx
+++ b/src/features/canvas/components/primitives/SheetShell.tsx
@@ -1,0 +1,96 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+} from '@/shared/components/ui/sheet';
+import { cn } from '@/shared/utils';
+import type { ReactNode } from 'react';
+
+interface SheetShellProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  /** Small label above the title (type/status). */
+  eyebrow?: ReactNode;
+  /** Right-aligned header controls (e.g. a status pill or menu). */
+  headerActions?: ReactNode;
+  /** Optional tab bar rendered under the header (pass a <CompactTabs/>). */
+  tabs?: ReactNode;
+  /** Sticky footer — always visible (save/cancel never scroll off-screen). */
+  footer?: ReactNode;
+  /** Sheet width in px (default 640). */
+  width?: number;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * The one right-side detail/settings sheet shell (CVS-158). Generalizes
+ * `NodePanelShell`: static header (eyebrow / title / subtitle / actions), an
+ * optional tab bar, a scrolling body, and — the key fix — a **sticky footer**
+ * so save/cancel are always visible instead of buried at the end of a tab body.
+ * Retires the `fixed inset-0` centered-modal variant.
+ */
+export function SheetShell({
+  open,
+  onOpenChange,
+  title,
+  subtitle,
+  eyebrow,
+  headerActions,
+  tabs,
+  footer,
+  width = 640,
+  className,
+  children,
+}: SheetShellProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        style={{ width, maxWidth: '100vw' }}
+        className={cn('flex flex-col gap-0 overflow-hidden p-0', className)}
+      >
+        <div className="shrink-0 border-b px-5 pb-3 pt-5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              {eyebrow && (
+                <div className="mb-1 text-xs font-medium text-muted-foreground">
+                  {eyebrow}
+                </div>
+              )}
+              <SheetTitle className="truncate text-lg font-semibold leading-tight">
+                {title || 'Details'}
+              </SheetTitle>
+              {subtitle ? (
+                <SheetDescription className="mt-0.5 text-sm text-muted-foreground">
+                  {subtitle}
+                </SheetDescription>
+              ) : (
+                <SheetDescription className="sr-only">
+                  Details panel
+                </SheetDescription>
+              )}
+            </div>
+            {headerActions && (
+              <div className="flex shrink-0 items-center gap-1.5">
+                {headerActions}
+              </div>
+            )}
+          </div>
+          {tabs && <div className="mt-3">{tabs}</div>}
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
+
+        {footer && (
+          <div className="shrink-0 border-t bg-background px-5 py-3">
+            {footer}
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/features/canvas/components/primitives/TagTokenInput.tsx
+++ b/src/features/canvas/components/primitives/TagTokenInput.tsx
@@ -1,0 +1,119 @@
+import { Badge } from '@/shared/components/ui/badge';
+import { cn } from '@/shared/utils';
+import { X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+interface TagTokenInputProps {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  /** Optional suggestions filtered against the current query. */
+  suggestions?: string[];
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  /** Max tags; further input is ignored once reached. */
+  max?: number;
+}
+
+/**
+ * Compact tokenized tag field (CVS-158) — controlled, presentational, and light.
+ * Unlike the heavy `enhanced-tag-input` it owns no data fetching: the caller
+ * supplies `suggestions`. Add on Enter/comma, remove with the token's × or
+ * Backspace on an empty query.
+ */
+export function TagTokenInput({
+  value,
+  onChange,
+  suggestions = [],
+  placeholder = 'Add tag…',
+  disabled,
+  className,
+  max,
+}: TagTokenInputProps) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const atMax = max != null && value.length >= max;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return suggestions
+      .filter((s) => !value.includes(s) && (!q || s.toLowerCase().includes(q)))
+      .slice(0, 8);
+  }, [suggestions, value, query]);
+
+  const add = (raw: string) => {
+    const tag = raw.trim();
+    if (!tag || value.includes(tag) || atMax) return;
+    onChange([...value, tag]);
+    setQuery('');
+    setOpen(false);
+  };
+
+  const remove = (tag: string) => onChange(value.filter((t) => t !== tag));
+
+  return (
+    <div className={cn('relative', className)}>
+      <div
+        className={cn(
+          'flex flex-wrap items-center gap-1.5 rounded-md border border-input bg-transparent px-2 py-1.5 text-sm focus-within:ring-2 focus-within:ring-ring/40',
+          disabled && 'pointer-events-none opacity-60'
+        )}
+      >
+        {value.map((tag) => (
+          <Badge key={tag} variant="secondary" className="gap-1 font-normal">
+            {tag}
+            <button
+              type="button"
+              onClick={() => remove(tag)}
+              className="rounded-sm hover:text-destructive"
+              aria-label={`Remove ${tag}`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        ))}
+        <input
+          value={query}
+          disabled={disabled || atMax}
+          placeholder={atMax ? '' : value.length ? '' : placeholder}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 120)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ',') {
+              e.preventDefault();
+              add(query);
+            } else if (e.key === 'Backspace' && !query && value.length) {
+              remove(value[value.length - 1]);
+            }
+          }}
+          className="min-w-[6rem] flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+
+      {open && filtered.length > 0 && (
+        <ul className="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-md border border-border bg-popover p-1 shadow-md">
+          {filtered.map((s) => (
+            <li key={s}>
+              <button
+                type="button"
+                // onMouseDown (not onClick) so it fires before the input blur.
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  add(s);
+                }}
+                className="w-full rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent"
+              >
+                {s}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/features/canvas/components/primitives/index.ts
+++ b/src/features/canvas/components/primitives/index.ts
@@ -1,0 +1,7 @@
+// Shared canvas card/sheet surface primitives (CVS-158). Downstream card/sheet
+// modernization (CVS-159–165) migrates onto these instead of hand-rolling.
+export { NodeCardShell } from './NodeCardShell';
+export { SheetShell } from './SheetShell';
+export { CompactTabs, type CompactTab } from './CompactTabs';
+export { TagTokenInput } from './TagTokenInput';
+export { EmptyState, LoadingState, ErrorState } from './states';

--- a/src/features/canvas/components/primitives/primitives.test.tsx
+++ b/src/features/canvas/components/primitives/primitives.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  CompactTabs,
+  EmptyState,
+  ErrorState,
+  NodeCardShell,
+  TagTokenInput,
+} from './index';
+
+function TagHarness({ initial = [] as string[], suggestions = [] as string[] }) {
+  const [tags, setTags] = useState<string[]>(initial);
+  return (
+    <TagTokenInput value={tags} onChange={setTags} suggestions={suggestions} />
+  );
+}
+
+describe('TagTokenInput', () => {
+  it('adds a tag on Enter and removes it via the token button', () => {
+    render(<TagHarness />);
+    const input = screen.getByPlaceholderText('Add tag…');
+    fireEvent.change(input, { target: { value: 'growth' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(screen.getByText('growth')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Remove growth'));
+    expect(screen.queryByText('growth')).not.toBeInTheDocument();
+  });
+
+  it('does not add duplicates', () => {
+    render(<TagHarness initial={['a']} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(screen.getAllByText('a')).toHaveLength(1);
+  });
+});
+
+describe('CompactTabs', () => {
+  it('shows the first panel by default and switches on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <CompactTabs
+        tabs={[
+          { value: 'one', label: 'One', content: <p>First panel</p> },
+          { value: 'two', label: 'Two', content: <p>Second panel</p> },
+        ]}
+      />
+    );
+    expect(screen.getByText('First panel')).toBeVisible();
+    await user.click(screen.getByRole('tab', { name: 'Two' }));
+    expect(await screen.findByText('Second panel')).toBeVisible();
+  });
+});
+
+describe('EmptyState / ErrorState', () => {
+  it('renders an empty state with an action', () => {
+    render(<EmptyState title="No widgets" action={<button>Add</button>} />);
+    expect(screen.getByText('No widgets')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+  });
+
+  it('calls onRetry from the error state', () => {
+    const onRetry = vi.fn();
+    render(<ErrorState onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});
+
+describe('NodeCardShell', () => {
+  it('renders title, type badge, and footer', () => {
+    render(
+      <NodeCardShell title="Revenue" typeLabel="Metric" footer={<span>id-123</span>}>
+        <p>body</p>
+      </NodeCardShell>
+    );
+    expect(screen.getByText('Revenue')).toBeInTheDocument();
+    expect(screen.getByText('Metric')).toBeInTheDocument();
+    expect(screen.getByText('id-123')).toBeInTheDocument();
+    expect(screen.getByText('body')).toBeInTheDocument();
+  });
+});

--- a/src/features/canvas/components/primitives/states.tsx
+++ b/src/features/canvas/components/primitives/states.tsx
@@ -1,0 +1,97 @@
+import { Button } from '@/shared/components/ui/button';
+import { Skeleton } from '@/shared/components/ui/skeleton';
+import { cn } from '@/shared/utils';
+import { AlertTriangle } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+// Shared empty / loading / error states (CVS-158). Sized to fit inside a card
+// or sheet body — no fixed heights, so they never create huge blank panels.
+
+interface EmptyStateProps {
+  icon?: React.ElementType;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+  compact?: boolean;
+}
+
+/** Dashed-border empty slot with an optional primary action. */
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  className,
+  compact,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-muted/30 text-center',
+        compact ? 'p-4' : 'p-8',
+        className
+      )}
+    >
+      {Icon && <Icon className="h-6 w-6 text-muted-foreground" />}
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      {description && (
+        <p className="max-w-xs text-xs text-muted-foreground">{description}</p>
+      )}
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  );
+}
+
+/** Skeleton rows for loading a card/sheet body. */
+export function LoadingState({
+  rows = 3,
+  className,
+}: {
+  rows?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn('space-y-2', className)} aria-busy="true">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-4 w-full" />
+      ))}
+    </div>
+  );
+}
+
+interface ErrorStateProps {
+  title?: string;
+  description?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+/** Inline error with an optional retry — states what went wrong, not an apology. */
+export function ErrorState({
+  title = 'Something went wrong',
+  description,
+  onRetry,
+  className,
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex flex-col items-center justify-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center',
+        className
+      )}
+    >
+      <AlertTriangle className="h-6 w-6 text-destructive" />
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      {description && (
+        <p className="max-w-xs text-xs text-muted-foreground">{description}</p>
+      )}
+      {onRetry && (
+        <Button variant="outline" size="sm" className="mt-1" onClick={onRetry}>
+          Try again
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes CVS-158. Foundation for the card/sheet modernization (CVS-159–165), per the CVS-157 audit.

## New primitives (`src/features/canvas/components/primitives/`)
- **NodeCardShell** — one node-card frame (accent icon chip, type badge, title, body/footer slots, selection ring, handle + toolbar slots). Replaces the 4 hand-rolled PRD-node shells + normalizes Operator/Chart/Source.
- **SheetShell** — generalizes `NodePanelShell` with a **sticky footer** (fixes off-screen save/cancel) + optional tab bar; retires the `fixed inset-0` centered modal.
- **CompactTabs** — one wrapper over shadcn `Tabs` (replaces hand-rolled `<button>` tab bars).
- **TagTokenInput** — compact, controlled token field (light; caller supplies suggestions) vs the heavy `enhanced-tag-input`.
- **EmptyState / LoadingState / ErrorState** — standard in-card/sheet states.

All theme-token based (no `gray-*`/`blue-*`), composed from existing shadcn ui.

## Scope note
This **creates** the primitives + proves them with render/behavior tests (6). It intentionally does **not** migrate live surfaces — that's CVS-159–163, and the **visual QA at desktop/narrow widths is CVS-164** (nothing renders them live yet, so I didn't want an unverifiable regression). No manual-test sub-issue for that reason.

## Acceptance criteria
- [x] New shared primitives exist + documented (JSDoc on each, barrel `index.ts`)
- [x] Consistent spacing/radius/typography/focus (tokens; shared shells)
- [x] Sticky footer + scroll regions don't create blank panels/off-screen buttons (SheetShell layout)
- [~] Verified at narrower widths — responsive constraints built in; visual QA lands in CVS-164
- [x] Existing surfaces *can* migrate (SheetShell generalizes NodePanelShell; NodeCardShell matches the current anatomy)

Verify: type-check clean · 0 lint errors · 162 tests pass (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)