### PR TITLE
CVS-159: modernize Source/Chart/Operator cards onto NodeCardShell

### DIFF
--- a/src/features/canvas/components/nodes/chart-node.tsx
+++ b/src/features/canvas/components/nodes/chart-node.tsx
@@ -3,15 +3,12 @@
 import { resolveChartSeries } from '@/features/canvas/utils/chartData';
 import { useCanvasStore } from '@/lib/stores';
 import { Button } from '@/shared/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@/shared/components/ui/card';
 import { MetricChart, type ChartType } from '@/shared/components/charts/MetricChart';
+import {
+  EmptyState,
+  NodeCardShell,
+} from '@/features/canvas/components/primitives';
 import type { MetricCard } from '@/shared/types';
-import { cn } from '@/shared/utils';
 import { type NodeProps } from '@xyflow/react';
 import { FourSideHandles } from './FourSideHandles';
 import {
@@ -25,6 +22,17 @@ import {
 import { memo, useMemo, useState } from 'react';
 import { useOpenConfigOnDoubleClick } from '@/features/canvas/hooks/useOpenConfigOnDoubleClick';
 import { ChartNodeSettings } from './chart-node-settings';
+
+// Bottom drag pill — the node's React Flow drag handle (.drag-handle__custom).
+const DragPill = () => (
+  <div className="drag-handle__custom flex cursor-grab justify-center active:cursor-grabbing">
+    <div className="flex items-center gap-1 rounded-full border border-border/50 bg-muted/80 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-muted/90">
+      <GripVertical className="h-3 w-3" />
+      <span className="select-none font-medium">Drag</span>
+      <GripVertical className="h-3 w-3" />
+    </div>
+  </div>
+);
 
 export type { ChartType };
 
@@ -69,69 +77,50 @@ const ChartNodeInner = memo(({ id, data, selected }: NodeProps) => {
   const TypeIcon = TYPE_ICON[chartType];
 
   const emptySlot = (
-    <div className="h-[200px] flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-muted/30 text-center">
-      <TypeIcon className="h-6 w-6 text-muted-foreground" />
-      <p className="text-sm text-muted-foreground px-6">
-        Connect a metric card to this node, or pick series in&nbsp;
-        <Settings2 className="inline h-3.5 w-3.5 -mt-0.5" /> settings.
-      </p>
-    </div>
+    <EmptyState
+      icon={TypeIcon}
+      title="No data yet"
+      description="Connect a metric card to this node, or pick series in settings."
+      className="h-[200px]"
+    />
   );
 
   return (
     <>
-      <Card
-        className={cn(
-          'w-[380px] rounded-xl border-2 bg-card shadow-lg transition-shadow',
-          selected ? 'ring-2 ring-primary border-primary/40' : 'border-border'
-        )}
+      <NodeCardShell
+        icon={TypeIcon}
+        title={title}
+        width={380}
+        selected={!!selected}
+        handles={<FourSideHandles />}
+        dragHandle={<DragPill />}
+        headerRight={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="nodrag h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+            onClick={(e) => {
+              e.stopPropagation();
+              setSettingsOpen(true);
+            }}
+            title="Chart settings"
+          >
+            <Settings2 className="h-4 w-4" />
+          </Button>
+        }
       >
-        <FourSideHandles />
-        <CardHeader className="pb-2">
-          <CardTitle className="flex items-center justify-between gap-2 text-sm">
-            <span className="flex items-center gap-2 truncate">
-              <TypeIcon className="h-4 w-4 text-muted-foreground" />
-              <span className="truncate font-semibold">{title}</span>
-            </span>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
-              onClick={(e) => {
-                e.stopPropagation();
-                setSettingsOpen(true);
-              }}
-              title="Chart settings"
-            >
-              <Settings2 className="h-4 w-4" />
-            </Button>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="pb-2">
-          <MetricChart
-            chartType={chartType}
-            config={config}
-            series={series}
-            rows={rows}
-            pie={pie}
-            hasData={hasData}
-            showLegend={showLegend}
-            idPrefix={id}
-            emptySlot={emptySlot}
-          />
-        </CardContent>
-
-        {/* Drag handle */}
-        <div className="border-t border-border/30 bg-muted/20 p-2">
-          <div className="drag-handle__custom flex cursor-grab justify-center active:cursor-grabbing">
-            <div className="flex items-center gap-1 rounded-full border border-border/50 bg-muted/80 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-muted/90">
-              <GripVertical className="h-3 w-3" />
-              <span className="select-none font-medium">Drag</span>
-              <GripVertical className="h-3 w-3" />
-            </div>
-          </div>
-        </div>
-      </Card>
+        <MetricChart
+          chartType={chartType}
+          config={config}
+          series={series}
+          rows={rows}
+          pie={pie}
+          hasData={hasData}
+          showLegend={showLegend}
+          idPrefix={id}
+          emptySlot={emptySlot}
+        />
+      </NodeCardShell>
 
       <ChartNodeSettings
         nodeId={id}

--- a/src/features/canvas/components/nodes/operator-node.tsx
+++ b/src/features/canvas/components/nodes/operator-node.tsx
@@ -4,12 +4,9 @@ import { memo } from 'react';
 import { type NodeProps } from '@xyflow/react';
 import { FourSideHandles } from './FourSideHandles';
 import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@/shared/components/ui/card';
-import { Badge } from '@/shared/components/ui/badge';
+  NodeCardShell,
+  EmptyState,
+} from '@/features/canvas/components/primitives';
 import {
   Activity,
   Calculator,
@@ -18,20 +15,19 @@ import {
   Sigma,
   ToggleLeft,
 } from 'lucide-react';
-import { cn } from '@/shared/utils';
 import { useOperatorPreviewStore } from '@/features/canvas/stores/useOperatorPreviewStore';
 import { normalizeOperatorData } from '@/features/canvas/utils/operatorMigration';
 import type { OperatorNodeData } from '@/features/canvas/types/operator';
 
 const TYPE_META: Record<
   OperatorNodeData['operationType'],
-  { icon: typeof Calculator; color: string; label: string }
+  { icon: typeof Calculator; accent: string; label: string }
 > = {
-  formula: { icon: Calculator, color: 'bg-blue-500', label: 'Formula' },
-  aggregate: { icon: Sigma, color: 'bg-indigo-500', label: 'Aggregate' },
-  gate: { icon: Filter, color: 'bg-amber-500', label: 'Gate' },
-  toggle: { icon: ToggleLeft, color: 'bg-green-500', label: 'Toggle' },
-  statistical: { icon: Activity, color: 'bg-purple-500', label: 'Statistical' },
+  formula: { icon: Calculator, accent: '#3b82f6', label: 'Formula' },
+  aggregate: { icon: Sigma, accent: '#6366f1', label: 'Aggregate' },
+  gate: { icon: Filter, accent: '#f59e0b', label: 'Gate' },
+  toggle: { icon: ToggleLeft, accent: '#22c55e', label: 'Toggle' },
+  statistical: { icon: Activity, accent: '#a855f7', label: 'Statistical' },
 };
 
 function formatValue(v: number | undefined): string {
@@ -65,85 +61,72 @@ function opSummary(data: OperatorNodeData): string {
   }
 }
 
+const DragPill = () => (
+  <div className="drag-handle__custom flex cursor-grab justify-center active:cursor-grabbing">
+    <div className="flex items-center gap-1 rounded-full border border-border/50 bg-muted/80 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-muted/90">
+      <GripVertical className="h-3 w-3" />
+      <span className="select-none font-medium">Drag</span>
+      <GripVertical className="h-3 w-3" />
+    </div>
+  </div>
+);
+
 const OperatorNodeInner = memo(({ id, data, selected }: NodeProps) => {
   const op = normalizeOperatorData(data as any) as OperatorNodeData;
   const output = useOperatorPreviewStore((s) => s.operatorValues[id]);
 
   const meta = TYPE_META[op.operationType] ?? TYPE_META.formula;
-  const Icon = meta.icon;
   const inputs = op.inputs || [];
 
   return (
-    <Card
-      className={cn(
-        'min-w-[230px] bg-white dark:bg-white-300 border-2 rounded-lg shadow-lg transition-all duration-200',
-        selected && 'ring-2 ring-blue-500',
-        op.isActive ? 'opacity-100' : 'opacity-60'
-      )}
+    <NodeCardShell
+      icon={meta.icon}
+      accent={meta.accent}
+      title={op.label || 'Operator'}
+      typeLabel={meta.label}
+      width={248}
+      selected={!!selected}
+      className={op.isActive ? undefined : 'opacity-60'}
+      handles={<FourSideHandles />}
+      dragHandle={<DragPill />}
     >
-      <FourSideHandles />
-
-      <CardHeader className="pb-2">
-        <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-sm font-medium truncate">
-            {op.label || 'Operator'}
-          </CardTitle>
-          <Badge variant="secondary" className="shrink-0 text-xs">
-            <span className={cn('mr-1 inline-block h-2 w-2 rounded-full', meta.color)} />
-            <Icon className="mr-1 h-3 w-3" />
-            {meta.label}
-          </Badge>
+      {/* Named input chips */}
+      {inputs.length > 0 ? (
+        <div className="flex flex-wrap gap-1">
+          {inputs.map((inp) => (
+            <span
+              key={inp.key}
+              className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
+              title={inp.label}
+            >
+              <span className="font-semibold text-foreground">{inp.key}</span>
+              <span className="max-w-[90px] truncate">{inp.label}</span>
+            </span>
+          ))}
         </div>
-      </CardHeader>
+      ) : (
+        <EmptyState
+          compact
+          title="No inputs"
+          description="Connect a card or source"
+        />
+      )}
 
-      <CardContent className="pt-0 space-y-2">
-        {/* Named input chips */}
-        {inputs.length > 0 ? (
-          <div className="flex flex-wrap gap-1">
-            {inputs.map((inp) => (
-              <span
-                key={inp.key}
-                className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
-                title={inp.label}
-              >
-                <span className="font-semibold text-foreground">{inp.key}</span>
-                <span className="max-w-[90px] truncate">{inp.label}</span>
-              </span>
-            ))}
-          </div>
-        ) : (
-          <div className="text-[10px] text-muted-foreground/70 italic">
-            No inputs — connect a card or source
-          </div>
-        )}
-
-        {/* Operation summary */}
-        <div className="rounded bg-muted/50 px-2 py-1 font-mono text-[11px] text-foreground/80 truncate">
-          {opSummary(op)}
-        </div>
-
-        {/* Live output */}
-        <div className="flex items-center justify-between">
-          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-            Output
-          </span>
-          <span className="text-sm font-bold tabular-nums">
-            {formatValue(output)}
-          </span>
-        </div>
-      </CardContent>
-
-      {/* Drag handle */}
-      <div className="p-2 border-t border-border/30 bg-muted/20">
-        <div className="drag-handle__custom flex justify-center cursor-grab active:cursor-grabbing">
-          <div className="flex items-center gap-1 px-3 py-1.5 bg-muted/80 backdrop-blur-sm rounded-full text-xs text-muted-foreground hover:bg-muted/90 transition-colors border border-border/50 shadow-sm">
-            <GripVertical className="w-3 h-3" />
-            <span className="font-medium select-none">Drag</span>
-            <GripVertical className="w-3 h-3" />
-          </div>
-        </div>
+      {/* Operation summary */}
+      <div className="rounded bg-muted/50 px-2 py-1 font-mono text-[11px] text-foreground/80 truncate">
+        {opSummary(op)}
       </div>
-    </Card>
+
+      {/* Live output */}
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          Output
+        </span>
+        <span className="text-sm font-bold tabular-nums">
+          {formatValue(output)}
+        </span>
+      </div>
+    </NodeCardShell>
   );
 });
 

--- a/src/features/canvas/components/nodes/source-node/source-node.tsx
+++ b/src/features/canvas/components/nodes/source-node/source-node.tsx
@@ -1,14 +1,10 @@
 'use client';
 
-import { Badge } from '@/shared/components/ui/badge';
 import { Button } from '@/shared/components/ui/button';
 import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '@/shared/components/ui/card';
-import { cn } from '@/shared/utils';
+  EmptyState,
+  NodeCardShell,
+} from '@/features/canvas/components/primitives';
 import type { SourceNodeData } from '@/features/canvas/utils/sourceResolver';
 import { type NodeProps } from '@xyflow/react';
 import { FourSideHandles } from '../FourSideHandles';
@@ -21,16 +17,27 @@ import {
   Settings2,
   Sparkles,
 } from 'lucide-react';
-import React, { memo, useState } from 'react';
+import { memo, useState } from 'react';
 import { useOpenConfigOnDoubleClick } from '@/features/canvas/hooks/useOpenConfigOnDoubleClick';
 import { SourceConfigSheet } from './source-config-sheet';
 
-const originIconMap: Record<string, React.ReactNode> = {
-  warehouse: <Database className="w-4 h-4" />,
-  file: <FileSpreadsheet className="w-4 h-4" />,
-  manual: <PenLine className="w-4 h-4" />,
-  generate: <Sparkles className="w-4 h-4" />,
+const ORIGIN_ICON: Record<string, React.ElementType> = {
+  warehouse: Database,
+  file: FileSpreadsheet,
+  manual: PenLine,
+  generate: Sparkles,
 };
+
+// Source keeps a decorative (unclassed) drag pill — the whole card drags.
+const DragPill = () => (
+  <div className="flex cursor-grab justify-center active:cursor-grabbing">
+    <div className="flex items-center gap-1 rounded-full border border-border/50 bg-muted/80 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-muted/90">
+      <GripVertical className="h-3 w-3" />
+      <span className="select-none font-medium">Drag</span>
+      <GripVertical className="h-3 w-3" />
+    </div>
+  </div>
+);
 
 export const SourceNode = memo(({ id, data, selected }: NodeProps) => {
   const d = (data || {}) as SourceNodeData;
@@ -45,25 +52,18 @@ export const SourceNode = memo(({ id, data, selected }: NodeProps) => {
 
   return (
     <>
-      <Card
-        className={cn(
-          'w-72 bg-white dark:bg-white-300 border-2 rounded-lg shadow-lg transition-all duration-200',
-          selected && 'ring-2 ring-blue-500'
-        )}
+      <NodeCardShell
+        icon={ORIGIN_ICON[origin] ?? Database}
+        title={d.title || 'Data Source'}
+        typeLabel={<span className="capitalize">{origin}</span>}
+        width={288}
+        selected={!!selected}
+        handles={<FourSideHandles />}
+        dragHandle={<DragPill />}
       >
-        <FourSideHandles />
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm flex items-center justify-between">
-            <span>{d.title || 'Data Source'}</span>
-            <Badge variant="secondary" className="gap-1">
-              {originIconMap[origin] ?? <Database className="w-4 h-4" />}
-              <span className="capitalize">{origin}</span>
-            </Badge>
-          </CardTitle>
-        </CardHeader>
         {d.stale && (
           <div
-            className="mx-3 mb-2 flex items-center gap-1.5 rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-[11px] text-amber-700"
+            className="flex items-center gap-1.5 rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-[11px] text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-300"
             title={d.lastError || 'Source connection unavailable'}
           >
             <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
@@ -75,62 +75,52 @@ export const SourceNode = memo(({ id, data, selected }: NodeProps) => {
             </span>
           </div>
         )}
-        <CardContent>
-          {series && series.length > 0 ? (
-            <div className="space-y-2">
-              <div className="text-xs text-muted-foreground space-y-1">
-                {series.slice(-3).map((p, idx) => (
-                  <div key={idx} className="flex justify-between">
-                    <span className="font-mono">{p.period}</span>
-                    <span className="font-semibold text-foreground">
-                      {p.value}
-                    </span>
-                  </div>
-                ))}
-                <div className="text-[10px] text-muted-foreground/70">
-                  {series.length} points
-                  {d.refreshedAt
-                    ? ` · ${new Date(d.refreshedAt).toLocaleDateString()}`
-                    : ''}
+
+        {series && series.length > 0 ? (
+          <>
+            <div className="space-y-1 text-xs text-muted-foreground">
+              {series.slice(-3).map((p, idx) => (
+                <div key={idx} className="flex justify-between">
+                  <span className="font-mono">{p.period}</span>
+                  <span className="font-semibold text-foreground">
+                    {p.value}
+                  </span>
                 </div>
+              ))}
+              <div className="text-[10px] text-muted-foreground/70">
+                {series.length} points
+                {d.refreshedAt
+                  ? ` · ${new Date(d.refreshedAt).toLocaleDateString()}`
+                  : ''}
               </div>
-              <Button
-                size="sm"
-                variant="outline"
-                className="w-full nodrag"
-                onClick={() => setShowConfig(true)}
-              >
-                <Settings2 className="w-3 h-3 mr-2" />
-                Configure
-              </Button>
             </div>
-          ) : (
-            <div className="h-24 flex flex-col items-center justify-center text-muted-foreground border-2 border-dashed border-border rounded gap-2">
-              <span className="text-xs">
-                {hasLegacySample ? 'Legacy source — reconfigure' : 'No data yet'}
-              </span>
+            <Button
+              size="sm"
+              variant="outline"
+              className="nodrag w-full"
+              onClick={() => setShowConfig(true)}
+            >
+              <Settings2 className="mr-2 h-3 w-3" />
+              Configure
+            </Button>
+          </>
+        ) : (
+          <EmptyState
+            compact
+            title={hasLegacySample ? 'Legacy source — reconfigure' : 'No data yet'}
+            action={
               <Button
                 size="sm"
                 className="nodrag"
                 onClick={() => setShowConfig(true)}
               >
-                <Settings2 className="w-3 h-3 mr-2" />
+                <Settings2 className="mr-2 h-3 w-3" />
                 Configure source
               </Button>
-            </div>
-          )}
-        </CardContent>
-        {/* Drag handle */}
-        <div className="p-3 border-t border-border/30 bg-muted/20">
-          <div className="flex justify-center cursor-grab active:cursor-grabbing">
-            <div className="flex items-center gap-1 px-3 py-1.5 bg-muted/80 backdrop-blur-sm rounded-full text-xs text-muted-foreground hover:bg-muted/90 transition-colors border border-border/50 shadow-sm">
-              <GripVertical className="w-3 h-3" />
-              <span className="font-medium select-none">Drag</span>
-              <GripVertical className="w-3 h-3" />
-            </div>
-          </div>
-        </div>
-      </Card>
+            }
+          />
+        )}
+      </NodeCardShell>
 
       <SourceConfigSheet
         open={showConfig}

--- a/src/features/canvas/components/primitives/NodeCardShell.tsx
+++ b/src/features/canvas/components/primitives/NodeCardShell.tsx
@@ -19,6 +19,8 @@ interface NodeCardShellProps {
   onDoubleClick?: () => void;
   /** React Flow <Handle> elements. */
   handles?: ReactNode;
+  /** Bottom drag-handle bar (e.g. a `.drag-handle__custom` pill). */
+  dragHandle?: ReactNode;
   /** Hover/selection toolbar (caller controls visibility). */
   toolbar?: ReactNode;
   width?: number;
@@ -44,6 +46,7 @@ export function NodeCardShell({
   selected,
   onDoubleClick,
   handles,
+  dragHandle,
   toolbar,
   width = 300,
   className,
@@ -99,6 +102,12 @@ export function NodeCardShell({
         {footer && (
           <div className="flex items-center justify-between gap-2 border-t border-border/60 bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
             {footer}
+          </div>
+        )}
+
+        {dragHandle && (
+          <div className="border-t border-border/40 bg-muted/20 p-2">
+            {dragHandle}
           </div>
         )}
       </div>


### PR DESCRIPTION
Closes CVS-159. **First migration onto the CVS-158 primitives — proof surface.**

> ⚠️ **Build-for-review — please eyeball before merging.** The logic compiles and tests pass, but this is a *visual* change I can't verify without a browser. Check the deploy preview (or run locally) before merging.

## Changes
- Chart / Operator / Source node cards → **NodeCardShell** (consistent header: accent icon chip + type badge + title · body · drag bar · selection ring), replacing 3 divergent Card layouts.
- Empty states → shared **EmptyState** primitive.
- **Fixes hardcoded colors:** operator/source used `bg-white dark:bg-white-300` + `ring-blue-500` → theme tokens (proper dark mode).
- **Drag preserved exactly:** each card keeps its own pill (`.drag-handle__custom` for chart/operator; unclassed for source) via a new `NodeCardShell` `dragHandle` slot. Settings sheets, handles, and double-click unchanged.

## Acceptance criteria
- [x] Source/Chart/Operator cards use the shared shell
- [~] No layout regressions — **needs your visual check** (manual test CVS-16x)
- [x] type-check clean · 0 lint errors · 166 tests pass

Config-sheet modernization (source-config-sheet / chart-node-settings → SheetShell) is the remaining part of CVS-159 — follow-up once the card direction is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)