### PR TITLE
feat(cvs-167): store Strategy impact contracts + metric links

### DIFF
--- a/src/features/strategy/impact/impactContract.test.ts
+++ b/src/features/strategy/impact/impactContract.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeExpectedDelta,
+  groupLinksByRole,
+  isMeasurable,
+  isValidLinkInput,
+  metricRefKey,
+  targetLink,
+} from './impactContract';
+import type { ImpactContract, MetricLink } from './types';
+
+const link = (over: Partial<MetricLink>): MetricLink => ({
+  id: 'l',
+  contractId: 'c',
+  role: 'target',
+  refSource: 'tracked',
+  trackedMetricId: 'tm-1',
+  cardId: null,
+  ...over,
+});
+
+const contract = (over: Partial<ImpactContract> = {}): ImpactContract => ({
+  id: 'c',
+  workspaceId: 'org-1',
+  projectId: 'p-1',
+  strategyNodeId: 'node-1',
+  expectedDirection: null,
+  expectedDeltaValue: null,
+  expectedDeltaUnit: null,
+  baselineStart: null,
+  baselineEnd: null,
+  measureStart: null,
+  measureEnd: null,
+  baselineIsManual: false,
+  confidence: null,
+  impactStatus: 'draft',
+  ownerLabel: null,
+  resultNote: null,
+  createdBy: 'u',
+  createdAt: '2026-07-04T00:00:00Z',
+  updatedAt: '2026-07-04T00:00:00Z',
+  ...over,
+});
+
+describe('metricRefKey', () => {
+  it('keys tracked and card refs distinctly', () => {
+    expect(metricRefKey({ refSource: 'tracked', trackedMetricId: 'a' })).toBe('tracked:a');
+    expect(metricRefKey({ refSource: 'card', cardId: 'a' })).toBe('card:a');
+  });
+  it('returns null when the matching ref is missing', () => {
+    expect(metricRefKey({ refSource: 'tracked', cardId: 'a' })).toBeNull();
+    expect(metricRefKey({ refSource: 'card', trackedMetricId: 'a' })).toBeNull();
+  });
+});
+
+describe('isValidLinkInput', () => {
+  it('accepts exactly one ref matching refSource', () => {
+    expect(isValidLinkInput({ role: 'target', refSource: 'tracked', trackedMetricId: 't' })).toBe(true);
+    expect(isValidLinkInput({ role: 'leading', refSource: 'card', cardId: 'c' })).toBe(true);
+  });
+  it('rejects mismatched, both, or empty refs', () => {
+    expect(isValidLinkInput({ role: 'target', refSource: 'tracked', cardId: 'c' })).toBe(false);
+    expect(isValidLinkInput({ role: 'target', refSource: 'card', cardId: 'c', trackedMetricId: 't' })).toBe(false);
+    expect(isValidLinkInput({ role: 'target', refSource: 'tracked' })).toBe(false);
+  });
+});
+
+describe('groupLinksByRole / targetLink', () => {
+  it('buckets by role and finds the target', () => {
+    const links = [
+      link({ id: '1', role: 'target' }),
+      link({ id: '2', role: 'leading', refSource: 'card', trackedMetricId: null, cardId: 'x' }),
+      link({ id: '3', role: 'guardrail' }),
+      link({ id: '4', role: 'leading', refSource: 'card', trackedMetricId: null, cardId: 'y' }),
+    ];
+    const grouped = groupLinksByRole(links);
+    expect(grouped.target).toHaveLength(1);
+    expect(grouped.leading.map((l) => l.id)).toEqual(['2', '4']);
+    expect(grouped.guardrail).toHaveLength(1);
+    expect(targetLink(links)?.id).toBe('1');
+  });
+  it('returns null target when none present', () => {
+    expect(targetLink([link({ role: 'guardrail' })])).toBeNull();
+  });
+});
+
+describe('describeExpectedDelta', () => {
+  it('formats percent, absolute, stabilize, and bare direction', () => {
+    expect(describeExpectedDelta(contract({ expectedDirection: 'increase', expectedDeltaValue: 5, expectedDeltaUnit: 'percent' }))).toBe('+5%');
+    expect(describeExpectedDelta(contract({ expectedDirection: 'decrease', expectedDeltaValue: 3, expectedDeltaUnit: 'absolute' }))).toBe('-3 absolute');
+    expect(describeExpectedDelta(contract({ expectedDirection: 'stabilize' }))).toBe('stabilize');
+    expect(describeExpectedDelta(contract({ expectedDirection: 'increase' }))).toBe('increase');
+    expect(describeExpectedDelta(contract())).toBeNull();
+  });
+});
+
+describe('isMeasurable', () => {
+  it('requires a target, a baseline, and a measurement window', () => {
+    const links = [link({ role: 'target' })];
+    expect(isMeasurable(contract({ baselineStart: '2026-06', measureStart: '2026-07' }), links)).toBe(true);
+    expect(isMeasurable(contract({ baselineIsManual: true, measureStart: '2026-07' }), links)).toBe(true);
+    expect(isMeasurable(contract({ measureStart: '2026-07' }), links)).toBe(false); // no baseline
+    expect(isMeasurable(contract({ baselineStart: '2026-06' }), links)).toBe(false); // no window
+    expect(isMeasurable(contract({ baselineStart: '2026-06', measureStart: '2026-07' }), [])).toBe(false); // no target
+  });
+});

--- a/src/features/strategy/impact/impactContract.ts
+++ b/src/features/strategy/impact/impactContract.ts
@@ -1,0 +1,80 @@
+// Pure helpers for the Strategy impact contract. No I/O — safe to unit test and
+// to reuse from the impact panel (CVS-169), board columns (CVS-170), and the
+// trace resolver (CVS-168).
+
+import type {
+  ImpactContract,
+  MetricLink,
+  MetricLinkInput,
+  MetricLinkRole,
+  MetricRefSource,
+} from './types';
+
+/** Stable identity for a metric reference, e.g. `tracked:<uuid>` / `card:<uuid>`. */
+export function metricRefKey(ref: {
+  refSource: MetricRefSource;
+  trackedMetricId?: string | null;
+  cardId?: string | null;
+}): string | null {
+  if (ref.refSource === 'tracked') return ref.trackedMetricId ? `tracked:${ref.trackedMetricId}` : null;
+  if (ref.refSource === 'card') return ref.cardId ? `card:${ref.cardId}` : null;
+  return null;
+}
+
+/**
+ * Mirrors the DB CHECK constraint: exactly one ref column populated and it must
+ * match `refSource`. Guards inserts before they hit Postgres.
+ */
+export function isValidLinkInput(input: MetricLinkInput): boolean {
+  const hasTracked = !!input.trackedMetricId;
+  const hasCard = !!input.cardId;
+  if (input.refSource === 'tracked') return hasTracked && !hasCard;
+  if (input.refSource === 'card') return hasCard && !hasTracked;
+  return false;
+}
+
+/** Bucket links by role, preserving order within each role. */
+export function groupLinksByRole(
+  links: MetricLink[]
+): Record<MetricLinkRole, MetricLink[]> {
+  const out: Record<MetricLinkRole, MetricLink[]> = {
+    target: [],
+    leading: [],
+    guardrail: [],
+  };
+  for (const link of links) {
+    if (out[link.role]) out[link.role].push(link);
+  }
+  return out;
+}
+
+/** The primary target metric of a bet (first `target` link), or null. */
+export function targetLink(links: MetricLink[]): MetricLink | null {
+  return links.find((l) => l.role === 'target') ?? null;
+}
+
+/** Human-readable expected delta, e.g. `+5%`, `-3 (absolute)`, `stabilize`. */
+export function describeExpectedDelta(contract: ImpactContract): string | null {
+  const { expectedDirection, expectedDeltaValue, expectedDeltaUnit } = contract;
+  if (!expectedDirection) return null;
+  if (expectedDirection === 'stabilize') return 'stabilize';
+  if (expectedDeltaValue == null) {
+    return expectedDirection === 'increase' ? 'increase' : 'decrease';
+  }
+  const sign = expectedDirection === 'increase' ? '+' : '-';
+  const magnitude = Math.abs(expectedDeltaValue);
+  if (expectedDeltaUnit === 'percent') return `${sign}${magnitude}%`;
+  const unit = expectedDeltaUnit ? ` ${expectedDeltaUnit}` : '';
+  return `${sign}${magnitude}${unit}`;
+}
+
+/**
+ * A contract is "measurable" once it has a target metric plus a baseline and a
+ * measurement window — the minimum the delta engine (CVS-174) needs.
+ */
+export function isMeasurable(contract: ImpactContract, links: MetricLink[]): boolean {
+  const hasTarget = links.some((l) => l.role === 'target');
+  const hasBaseline = !!contract.baselineStart || contract.baselineIsManual;
+  const hasWindow = !!contract.measureStart;
+  return hasTarget && hasBaseline && hasWindow;
+}

--- a/src/features/strategy/impact/types.ts
+++ b/src/features/strategy/impact/types.ts
@@ -1,0 +1,74 @@
+// Strategy impact contract model — the measurable "bet" a Work/Action or
+// Ideas/Hypothesis card can carry. See CVS-166 "Decision (locked)" and the
+// migration 20260709120000_strategy_impact.sql. Scope = workspace-wide.
+
+export type MetricRefSource = 'tracked' | 'card';
+export type MetricLinkRole = 'target' | 'leading' | 'guardrail';
+export type ExpectedDirection = 'increase' | 'decrease' | 'stabilize';
+export type Confidence = 'low' | 'medium' | 'high';
+export type ImpactStatus =
+  | 'draft'
+  | 'planned'
+  | 'measuring'
+  | 'won'
+  | 'lost'
+  | 'inconclusive';
+
+export const METRIC_LINK_ROLES: MetricLinkRole[] = ['target', 'leading', 'guardrail'];
+export const EXPECTED_DIRECTIONS: ExpectedDirection[] = ['increase', 'decrease', 'stabilize'];
+export const CONFIDENCE_LEVELS: Confidence[] = ['low', 'medium', 'high'];
+export const IMPACT_STATUSES: ImpactStatus[] = [
+  'draft',
+  'planned',
+  'measuring',
+  'won',
+  'lost',
+  'inconclusive',
+];
+
+/** A persisted metric reference on a contract (target / leading / guardrail). */
+export interface MetricLink {
+  id: string;
+  contractId: string;
+  role: MetricLinkRole;
+  refSource: MetricRefSource;
+  trackedMetricId: string | null;
+  cardId: string | null;
+}
+
+/** A metric reference before persistence (no id / contract_id yet). */
+export interface MetricLinkInput {
+  role: MetricLinkRole;
+  refSource: MetricRefSource;
+  trackedMetricId?: string | null;
+  cardId?: string | null;
+}
+
+/** The impact contract owned by one strategy node (Action or Hypothesis). */
+export interface ImpactContract {
+  id: string;
+  workspaceId: string | null;
+  /** Origin canvas; nullable so a bet outlives the canvas it was drawn on. */
+  projectId: string | null;
+  strategyNodeId: string;
+  expectedDirection: ExpectedDirection | null;
+  expectedDeltaValue: number | null;
+  expectedDeltaUnit: string | null;
+  baselineStart: string | null;
+  baselineEnd: string | null;
+  measureStart: string | null;
+  measureEnd: string | null;
+  baselineIsManual: boolean;
+  confidence: Confidence | null;
+  impactStatus: ImpactStatus;
+  ownerLabel: string | null;
+  resultNote: string | null;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ImpactContractWithLinks {
+  contract: ImpactContract;
+  links: MetricLink[];
+}

--- a/src/shared/lib/supabase/services/strategyImpact.ts
+++ b/src/shared/lib/supabase/services/strategyImpact.ts
@@ -1,0 +1,211 @@
+// Client access layer for Strategy impact contracts + metric links. Rows are
+// workspace-scoped (RLS: creator OR org-member; see the strategy_impact
+// migration). One contract per strategy node (Action/Hypothesis card); target/
+// leading/guardrail metric refs live in strategy_metric_links. Callers may inject
+// a Clerk-authed client so RLS applies; otherwise the anon singleton is used.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '../client';
+import type { Database } from '../types';
+import type {
+  ImpactContract,
+  ImpactStatus,
+  MetricLink,
+  MetricLinkInput,
+} from '@/features/strategy/impact/types';
+import { isValidLinkInput } from '@/features/strategy/impact/impactContract';
+
+type Client = SupabaseClient<Database>;
+
+const CONTRACT_COLS =
+  'id, workspace_id, project_id, strategy_node_id, expected_direction, expected_delta_value, expected_delta_unit, baseline_start, baseline_end, measure_start, measure_end, baseline_is_manual, confidence, impact_status, owner_label, result_note, created_by, created_at, updated_at';
+
+const LINK_COLS = 'id, contract_id, role, ref_source, tracked_metric_id, card_id';
+
+type ContractRow = Database['public']['Tables']['strategy_impact_contracts']['Row'];
+type LinkRow = Database['public']['Tables']['strategy_metric_links']['Row'];
+
+function rowToContract(r: ContractRow): ImpactContract {
+  return {
+    id: r.id,
+    workspaceId: r.workspace_id,
+    projectId: r.project_id,
+    strategyNodeId: r.strategy_node_id,
+    expectedDirection: r.expected_direction as ImpactContract['expectedDirection'],
+    expectedDeltaValue: r.expected_delta_value,
+    expectedDeltaUnit: r.expected_delta_unit,
+    baselineStart: r.baseline_start,
+    baselineEnd: r.baseline_end,
+    measureStart: r.measure_start,
+    measureEnd: r.measure_end,
+    baselineIsManual: r.baseline_is_manual,
+    confidence: r.confidence as ImpactContract['confidence'],
+    impactStatus: r.impact_status as ImpactStatus,
+    ownerLabel: r.owner_label,
+    resultNote: r.result_note,
+    createdBy: r.created_by,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+function rowToLink(r: LinkRow): MetricLink {
+  return {
+    id: r.id,
+    contractId: r.contract_id,
+    role: r.role as MetricLink['role'],
+    refSource: r.ref_source as MetricLink['refSource'],
+    trackedMetricId: r.tracked_metric_id,
+    cardId: r.card_id,
+  };
+}
+
+/** The contract for a single strategy node, or null if the node has no bet. */
+export async function getContractForNode(
+  strategyNodeId: string,
+  client?: Client
+): Promise<ImpactContract | null> {
+  const c = client || supabase();
+  const { data, error } = await c
+    .from('strategy_impact_contracts')
+    .select(CONTRACT_COLS)
+    .eq('strategy_node_id', strategyNodeId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return data ? rowToContract(data as ContractRow) : null;
+}
+
+/** Every contract originating on a canvas (uses project_id for the canvas filter). */
+export async function listContractsForProject(
+  projectId: string,
+  client?: Client
+): Promise<ImpactContract[]> {
+  const c = client || supabase();
+  const { data, error } = await c
+    .from('strategy_impact_contracts')
+    .select(CONTRACT_COLS)
+    .eq('project_id', projectId);
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((r) => rowToContract(r as ContractRow));
+}
+
+/** Every contract the caller can see (RLS scopes to their workspace). Portfolio view. */
+export async function listContractsForWorkspace(client?: Client): Promise<ImpactContract[]> {
+  const c = client || supabase();
+  const { data, error } = await c
+    .from('strategy_impact_contracts')
+    .select(CONTRACT_COLS);
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((r) => rowToContract(r as ContractRow));
+}
+
+export interface UpsertContractInput {
+  strategyNodeId: string;
+  projectId?: string | null;
+  expectedDirection?: ImpactContract['expectedDirection'];
+  expectedDeltaValue?: number | null;
+  expectedDeltaUnit?: string | null;
+  baselineStart?: string | null;
+  baselineEnd?: string | null;
+  measureStart?: string | null;
+  measureEnd?: string | null;
+  baselineIsManual?: boolean;
+  confidence?: ImpactContract['confidence'];
+  impactStatus?: ImpactStatus;
+  ownerLabel?: string | null;
+  resultNote?: string | null;
+}
+
+/**
+ * Create or update the contract for a node. Keyed on strategy_node_id (unique),
+ * so this is idempotent — editing a node's bet upserts the single row.
+ */
+export async function upsertContract(
+  input: UpsertContractInput,
+  client?: Client
+): Promise<ImpactContract> {
+  const c = client || supabase();
+  const row: Database['public']['Tables']['strategy_impact_contracts']['Insert'] = {
+    strategy_node_id: input.strategyNodeId,
+    updated_at: new Date().toISOString(),
+  };
+  if (input.projectId !== undefined) row.project_id = input.projectId;
+  if (input.expectedDirection !== undefined) row.expected_direction = input.expectedDirection;
+  if (input.expectedDeltaValue !== undefined) row.expected_delta_value = input.expectedDeltaValue;
+  if (input.expectedDeltaUnit !== undefined) row.expected_delta_unit = input.expectedDeltaUnit;
+  if (input.baselineStart !== undefined) row.baseline_start = input.baselineStart;
+  if (input.baselineEnd !== undefined) row.baseline_end = input.baselineEnd;
+  if (input.measureStart !== undefined) row.measure_start = input.measureStart;
+  if (input.measureEnd !== undefined) row.measure_end = input.measureEnd;
+  if (input.baselineIsManual !== undefined) row.baseline_is_manual = input.baselineIsManual;
+  if (input.confidence !== undefined) row.confidence = input.confidence;
+  if (input.impactStatus !== undefined) row.impact_status = input.impactStatus;
+  if (input.ownerLabel !== undefined) row.owner_label = input.ownerLabel;
+  if (input.resultNote !== undefined) row.result_note = input.resultNote;
+
+  const { data, error } = await c
+    .from('strategy_impact_contracts')
+    .upsert(row, { onConflict: 'strategy_node_id' })
+    .select(CONTRACT_COLS)
+    .single();
+  if (error) throw new Error(error.message);
+  return rowToContract(data as ContractRow);
+}
+
+export async function deleteContract(id: string, client?: Client): Promise<void> {
+  const c = client || supabase();
+  const { error } = await c.from('strategy_impact_contracts').delete().eq('id', id);
+  if (error) throw new Error(error.message);
+}
+
+/** Read the metric links (target/leading/guardrail) for a contract. */
+export async function getMetricLinks(
+  contractId: string,
+  client?: Client
+): Promise<MetricLink[]> {
+  const c = client || supabase();
+  const { data, error } = await c
+    .from('strategy_metric_links')
+    .select(LINK_COLS)
+    .eq('contract_id', contractId);
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((r) => rowToLink(r as LinkRow));
+}
+
+/**
+ * Replace a contract's metric links wholesale (delete-then-insert). Simpler than
+ * diffing, and the set is small. Validates each input against the DB CHECK first.
+ */
+export async function setMetricLinks(
+  contractId: string,
+  links: MetricLinkInput[],
+  client?: Client
+): Promise<MetricLink[]> {
+  const invalid = links.find((l) => !isValidLinkInput(l));
+  if (invalid) {
+    throw new Error(
+      `Invalid metric link: ref_source '${invalid.refSource}' must have exactly its matching id`
+    );
+  }
+  const c = client || supabase();
+  const { error: delError } = await c
+    .from('strategy_metric_links')
+    .delete()
+    .eq('contract_id', contractId);
+  if (delError) throw new Error(delError.message);
+
+  if (!links.length) return [];
+  const rows = links.map((l) => ({
+    contract_id: contractId,
+    role: l.role,
+    ref_source: l.refSource,
+    tracked_metric_id: l.refSource === 'tracked' ? l.trackedMetricId ?? null : null,
+    card_id: l.refSource === 'card' ? l.cardId ?? null : null,
+  }));
+  const { data, error } = await c
+    .from('strategy_metric_links')
+    .insert(rows)
+    .select(LINK_COLS);
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((r) => rowToLink(r as LinkRow));
+}

--- a/src/shared/lib/supabase/types.ts
+++ b/src/shared/lib/supabase/types.ts
@@ -439,6 +439,145 @@ export type Database = {
           },
         ]
       }
+      strategy_impact_contracts: {
+        Row: {
+          baseline_end: string | null
+          baseline_is_manual: boolean
+          baseline_start: string | null
+          confidence: string | null
+          created_at: string
+          created_by: string
+          expected_delta_unit: string | null
+          expected_delta_value: number | null
+          expected_direction: string | null
+          id: string
+          impact_status: string
+          measure_end: string | null
+          measure_start: string | null
+          owner_label: string | null
+          project_id: string | null
+          result_note: string | null
+          strategy_node_id: string
+          updated_at: string
+          workspace_id: string | null
+        }
+        Insert: {
+          baseline_end?: string | null
+          baseline_is_manual?: boolean
+          baseline_start?: string | null
+          confidence?: string | null
+          created_at?: string
+          created_by?: string
+          expected_delta_unit?: string | null
+          expected_delta_value?: number | null
+          expected_direction?: string | null
+          id?: string
+          impact_status?: string
+          measure_end?: string | null
+          measure_start?: string | null
+          owner_label?: string | null
+          project_id?: string | null
+          result_note?: string | null
+          strategy_node_id: string
+          updated_at?: string
+          workspace_id?: string | null
+        }
+        Update: {
+          baseline_end?: string | null
+          baseline_is_manual?: boolean
+          baseline_start?: string | null
+          confidence?: string | null
+          created_at?: string
+          created_by?: string
+          expected_delta_unit?: string | null
+          expected_delta_value?: number | null
+          expected_direction?: string | null
+          id?: string
+          impact_status?: string
+          measure_end?: string | null
+          measure_start?: string | null
+          owner_label?: string | null
+          project_id?: string | null
+          result_note?: string | null
+          strategy_node_id?: string
+          updated_at?: string
+          workspace_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "strategy_impact_contracts_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "strategy_impact_contracts_strategy_node_id_fkey"
+            columns: ["strategy_node_id"]
+            isOneToOne: true
+            referencedRelation: "metric_cards"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      strategy_metric_links: {
+        Row: {
+          card_id: string | null
+          contract_id: string
+          created_at: string
+          created_by: string
+          id: string
+          ref_source: string
+          role: string
+          tracked_metric_id: string | null
+          workspace_id: string | null
+        }
+        Insert: {
+          card_id?: string | null
+          contract_id: string
+          created_at?: string
+          created_by?: string
+          id?: string
+          ref_source: string
+          role: string
+          tracked_metric_id?: string | null
+          workspace_id?: string | null
+        }
+        Update: {
+          card_id?: string | null
+          contract_id?: string
+          created_at?: string
+          created_by?: string
+          id?: string
+          ref_source?: string
+          role?: string
+          tracked_metric_id?: string | null
+          workspace_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "strategy_metric_links_contract_id_fkey"
+            columns: ["contract_id"]
+            isOneToOne: false
+            referencedRelation: "strategy_impact_contracts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "strategy_metric_links_tracked_metric_id_fkey"
+            columns: ["tracked_metric_id"]
+            isOneToOne: false
+            referencedRelation: "tracked_metrics"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "strategy_metric_links_card_id_fkey"
+            columns: ["card_id"]
+            isOneToOne: false
+            referencedRelation: "metric_cards"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       tracked_metrics: {
         Row: {
           created_at: string

--- a/supabase/migrations/20260709120000_strategy_impact.sql
+++ b/supabase/migrations/20260709120000_strategy_impact.sql
@@ -1,0 +1,143 @@
+-- =====================================================================
+-- STRATEGY IMPACT — measurable "impact contracts" for Action/Hypothesis nodes.
+-- Turns the Strategy page from a task board into the operating layer between
+-- the metric tree and the dashboard: every work card can carry a bet
+-- (target/leading/guardrail metrics, expected delta, baseline + measurement
+-- window, confidence, result). See CVS-166 "Decision (locked)" and the vault
+-- doc PRD/4. Product/6. Strategy Impact and Dashboard Trace.md.
+--
+-- SCOPE = workspace-wide (Clerk org): rows carry workspace_id defaulting to
+-- requesting_org_id(), RLS = creator OR org-member (mirrors tracked_metrics /
+-- metric_values). project_id keeps the ORIGIN canvas for a canvas filter +
+-- lineage (nullable; a bet survives its canvas). One contract per node.
+-- =====================================================================
+BEGIN;
+
+-- --- Impact contract: the measurable bet attached to a work card --------------
+CREATE TABLE IF NOT EXISTS public.strategy_impact_contracts (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id         text DEFAULT public.requesting_org_id(),
+  -- origin canvas (nullable → bet outlives the canvas; used for the canvas filter)
+  project_id           uuid REFERENCES public.projects(id) ON DELETE SET NULL,
+  -- the Action/Hypothesis card that owns the bet (category enforced app-side)
+  strategy_node_id     uuid NOT NULL REFERENCES public.metric_cards(id) ON DELETE CASCADE,
+  expected_direction   text CHECK (expected_direction IN ('increase', 'decrease', 'stabilize')),
+  expected_delta_value double precision,
+  expected_delta_unit  text,               -- 'percent' | 'absolute' | free unit label
+  baseline_start       text,               -- canonical 'YYYY-MM'
+  baseline_end         text,
+  measure_start        text,
+  measure_end          text,
+  baseline_is_manual   boolean NOT NULL DEFAULT false,
+  confidence           text CHECK (confidence IN ('low', 'medium', 'high')),
+  impact_status        text NOT NULL DEFAULT 'draft'
+                         CHECK (impact_status IN ('draft', 'planned', 'measuring', 'won', 'lost', 'inconclusive')),
+  owner_label          text,
+  result_note          text,
+  created_by           text NOT NULL DEFAULT public.requesting_user_id(),
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  updated_at           timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (strategy_node_id)                 -- one contract per work card
+);
+
+ALTER TABLE public.strategy_impact_contracts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS strategy_impact_contracts_select ON public.strategy_impact_contracts;
+CREATE POLICY strategy_impact_contracts_select ON public.strategy_impact_contracts
+  FOR SELECT USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+DROP POLICY IF EXISTS strategy_impact_contracts_insert ON public.strategy_impact_contracts;
+CREATE POLICY strategy_impact_contracts_insert ON public.strategy_impact_contracts
+  FOR INSERT WITH CHECK (
+    created_by = public.requesting_user_id()
+    AND (workspace_id IS NULL OR workspace_id = public.requesting_org_id())
+  );
+
+DROP POLICY IF EXISTS strategy_impact_contracts_update ON public.strategy_impact_contracts;
+CREATE POLICY strategy_impact_contracts_update ON public.strategy_impact_contracts
+  FOR UPDATE USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  ) WITH CHECK (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+DROP POLICY IF EXISTS strategy_impact_contracts_delete ON public.strategy_impact_contracts;
+CREATE POLICY strategy_impact_contracts_delete ON public.strategy_impact_contracts
+  FOR DELETE USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+CREATE INDEX IF NOT EXISTS idx_strategy_impact_contracts_node      ON public.strategy_impact_contracts(strategy_node_id);
+CREATE INDEX IF NOT EXISTS idx_strategy_impact_contracts_project   ON public.strategy_impact_contracts(project_id);
+CREATE INDEX IF NOT EXISTS idx_strategy_impact_contracts_workspace ON public.strategy_impact_contracts(workspace_id);
+
+DROP TRIGGER IF EXISTS update_strategy_impact_contracts_updated_at ON public.strategy_impact_contracts;
+CREATE TRIGGER update_strategy_impact_contracts_updated_at
+  BEFORE UPDATE ON public.strategy_impact_contracts
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- --- Metric links: target / leading / guardrail refs (many per contract) ------
+-- A ref points EITHER at a catalogued tracked metric (workspace-scoped, the
+-- preferred cross-canvas anchor) OR a canvas metric card (canvas-local).
+CREATE TABLE IF NOT EXISTS public.strategy_metric_links (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  contract_id       uuid NOT NULL REFERENCES public.strategy_impact_contracts(id) ON DELETE CASCADE,
+  workspace_id      text DEFAULT public.requesting_org_id(),
+  role              text NOT NULL CHECK (role IN ('target', 'leading', 'guardrail')),
+  ref_source        text NOT NULL CHECK (ref_source IN ('tracked', 'card')),
+  tracked_metric_id uuid REFERENCES public.tracked_metrics(id) ON DELETE CASCADE,
+  card_id           uuid REFERENCES public.metric_cards(id) ON DELETE CASCADE,
+  created_by        text NOT NULL DEFAULT public.requesting_user_id(),
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  -- exactly one ref column populated, matching ref_source
+  CONSTRAINT strategy_metric_links_ref_ck CHECK (
+    (ref_source = 'tracked' AND tracked_metric_id IS NOT NULL AND card_id IS NULL)
+    OR (ref_source = 'card' AND card_id IS NOT NULL AND tracked_metric_id IS NULL)
+  )
+);
+
+ALTER TABLE public.strategy_metric_links ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS strategy_metric_links_select ON public.strategy_metric_links;
+CREATE POLICY strategy_metric_links_select ON public.strategy_metric_links
+  FOR SELECT USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+DROP POLICY IF EXISTS strategy_metric_links_insert ON public.strategy_metric_links;
+CREATE POLICY strategy_metric_links_insert ON public.strategy_metric_links
+  FOR INSERT WITH CHECK (
+    created_by = public.requesting_user_id()
+    AND (workspace_id IS NULL OR workspace_id = public.requesting_org_id())
+  );
+
+DROP POLICY IF EXISTS strategy_metric_links_update ON public.strategy_metric_links;
+CREATE POLICY strategy_metric_links_update ON public.strategy_metric_links
+  FOR UPDATE USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  ) WITH CHECK (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+DROP POLICY IF EXISTS strategy_metric_links_delete ON public.strategy_metric_links;
+CREATE POLICY strategy_metric_links_delete ON public.strategy_metric_links
+  FOR DELETE USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+CREATE INDEX IF NOT EXISTS idx_strategy_metric_links_contract  ON public.strategy_metric_links(contract_id);
+CREATE INDEX IF NOT EXISTS idx_strategy_metric_links_tracked   ON public.strategy_metric_links(tracked_metric_id);
+CREATE INDEX IF NOT EXISTS idx_strategy_metric_links_card      ON public.strategy_metric_links(card_id);
+CREATE INDEX IF NOT EXISTS idx_strategy_metric_links_workspace ON public.strategy_metric_links(workspace_id);
+
+COMMIT;


### PR DESCRIPTION
Closes part of **CVS-167** (Strategy impact — Milestone 1: Impact contract foundation). Builds on the **CVS-166** locked decision.

## What
Persistence layer for measurable Strategy **impact contracts** on Action/Hypothesis cards.

- **Migration** `20260709120000_strategy_impact.sql`:
  - `strategy_impact_contracts` — one per node (`UNIQUE(strategy_node_id)`), **workspace-scoped RLS** (creator OR org-member, mirroring `tracked_metrics`/`metric_values`) + nullable origin `project_id` for the canvas filter; `updated_at` trigger.
  - `strategy_metric_links` — target/leading/guardrail refs, each pointing at **either** a `tracked_metric_id` **or** a canvas `card_id` (CHECK enforces exactly one, matching `ref_source`).
- **Service** `services/strategyImpact.ts` — `getContractForNode`, `listContractsForProject`, `listContractsForWorkspace`, `upsertContract` (idempotent on node), `deleteContract`, `getMetricLinks`, `setMetricLinks` (validates then delete-insert). Mirrors `services/dashboards.ts`; optional injected Clerk client so RLS applies.
- **Domain + pure helpers** `features/strategy/impact/{types,impactContract}.ts` — model + link validation, role grouping, expected-delta formatting, measurability check. Unit-tested (8 tests).
- **Types** hand-patched into `types.ts` (Row/Insert/Update for both tables).

## Scope decisions (from CVS-166)
Workspace-wide scope; both Action & Hypothesis own contracts; the metric-ref primitive mirrors the dashboard widget `{ source: 'tracked' | 'card' }` union.

## Verification
- `npm run type-check` ✅ · `npm run lint` (new files) ✅ · `npx vitest run …/impactContract.test.ts` ✅ (8/8).
- ⚠️ **Migration not applied to prod** — DB/security change; owner applies + runs `test:rls` cross-workspace isolation per the manual-test sub-issue.

No UI in this issue (blocked downstream: CVS-168 resolver, CVS-169 panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)