### PR TITLE
feat(cvs-168): impact trace resolver (strategy item → KPI → dashboard)

### DIFF
--- a/src/features/strategy/impact/impactTrace.test.ts
+++ b/src/features/strategy/impact/impactTrace.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { resolveImpactTrace, type TraceWidget } from './impactTrace';
+import type { MetricLink } from './types';
+import type { MetricCard, Relationship } from '@/shared/types';
+
+// --- fixture builders --------------------------------------------------------
+const card = (id: string, over: Partial<MetricCard> = {}): MetricCard => ({
+  id,
+  title: id,
+  description: '',
+  category: 'Data/Metric',
+  tags: [],
+  causalFactors: [],
+  dimensions: [],
+  position: { x: 0, y: 0 },
+  assignees: [],
+  createdAt: '',
+  updatedAt: '',
+  ...over,
+});
+
+const edge = (sourceId: string, targetId: string): Relationship => ({
+  id: `${sourceId}->${targetId}`,
+  sourceId,
+  targetId,
+  type: 'Deterministic',
+  confidence: 'High',
+  evidence: [],
+  createdAt: '',
+  updatedAt: '',
+});
+
+const link = (over: Partial<MetricLink>): MetricLink => ({
+  id: Math.random().toString(36).slice(2),
+  contractId: 'c',
+  role: 'target',
+  refSource: 'card',
+  trackedMetricId: null,
+  cardId: null,
+  ...over,
+});
+
+const widget = (id: string, config: TraceWidget['config']): TraceWidget => ({
+  id,
+  title: id,
+  config,
+});
+
+// Tree: checkout_cvr --> revenue --> north_star (KPI, terminal)
+const tree = [
+  card('checkout_cvr', { trackedMetricId: 'tm_cvr' }),
+  card('revenue'),
+  card('north_star', { category: 'Core/Value' }),
+  card('aov', { trackedMetricId: 'tm_aov' }),
+];
+const treeEdges = [edge('checkout_cvr', 'revenue'), edge('revenue', 'north_star')];
+
+describe('resolveImpactTrace — full path', () => {
+  it('resolves target, KPI roll-up path, and dashboard widget', () => {
+    const links = [
+      link({ role: 'target', refSource: 'tracked', trackedMetricId: 'tm_cvr' }),
+      link({ role: 'leading', refSource: 'card', cardId: 'revenue' }),
+      link({ role: 'guardrail', refSource: 'tracked', trackedMetricId: 'tm_aov' }),
+    ];
+    const widgets = [
+      widget('w1', { source: 'tracked', trackedMetricIds: ['tm_cvr'] }),
+      widget('w2', { source: 'card', cardIds: ['aov'] }),
+    ];
+    const trace = resolveImpactTrace({
+      strategyNodeId: 'action_1',
+      links,
+      cards: tree,
+      relationships: treeEdges,
+      widgets,
+    });
+
+    expect(trace.target?.card?.id).toBe('checkout_cvr');
+    expect(trace.target?.onCanvas).toBe(true);
+    expect(trace.kpiPath.map((c) => c.id)).toEqual(['checkout_cvr', 'revenue', 'north_star']);
+    expect(trace.kpi?.id).toBe('north_star');
+    expect(trace.target?.widgets.map((w) => w.id)).toEqual(['w1']);
+    // guardrail aov is shown on w2 (card-bound to a placement of tm_aov)
+    expect(trace.guardrails[0].widgets.map((w) => w.id)).toEqual(['w2']);
+    expect(trace.leading.map((l) => l.card?.id)).toEqual(['revenue']);
+    expect(trace.missing).toEqual({
+      noTarget: false,
+      targetNotOnCanvas: false,
+      noKpiPath: false,
+      noDashboard: false,
+    });
+  });
+});
+
+describe('resolveImpactTrace — partial path', () => {
+  it('target on canvas but no dashboard widget → noDashboard', () => {
+    const trace = resolveImpactTrace({
+      strategyNodeId: 'a',
+      links: [link({ role: 'target', refSource: 'card', cardId: 'checkout_cvr' })],
+      cards: tree,
+      relationships: treeEdges,
+      widgets: [],
+    });
+    expect(trace.kpi?.id).toBe('north_star');
+    expect(trace.missing.noDashboard).toBe(true);
+    expect(trace.missing.noKpiPath).toBe(false);
+  });
+
+  it('target is terminal (top-level) → noKpiPath true, kpi = target', () => {
+    const trace = resolveImpactTrace({
+      strategyNodeId: 'a',
+      links: [link({ role: 'target', refSource: 'card', cardId: 'north_star' })],
+      cards: tree,
+      relationships: treeEdges,
+    });
+    expect(trace.kpiPath.map((c) => c.id)).toEqual(['north_star']);
+    expect(trace.kpi?.id).toBe('north_star');
+    expect(trace.missing.noKpiPath).toBe(true);
+  });
+
+  it('picks the longest roll-up branch deterministically', () => {
+    // m0 --> m1 (terminal) and m0 --> m2 --> m3 (longer); expect the longer chain
+    const cards = [card('m0'), card('m1'), card('m2'), card('m3')];
+    const edges = [edge('m0', 'm1'), edge('m0', 'm2'), edge('m2', 'm3')];
+    const trace = resolveImpactTrace({
+      strategyNodeId: 'a',
+      links: [link({ role: 'target', refSource: 'card', cardId: 'm0' })],
+      cards,
+      relationships: edges,
+    });
+    expect(trace.kpiPath.map((c) => c.id)).toEqual(['m0', 'm2', 'm3']);
+  });
+
+  it('survives a cycle in the tree', () => {
+    const cards = [card('x'), card('y')];
+    const edges = [edge('x', 'y'), edge('y', 'x')];
+    const trace = resolveImpactTrace({
+      strategyNodeId: 'a',
+      links: [link({ role: 'target', refSource: 'card', cardId: 'x' })],
+      cards,
+      relationships: edges,
+    });
+    expect(trace.kpiPath.map((c) => c.id)).toEqual(['x', 'y']);
+  });
+});
+
+describe('resolveImpactTrace — missing path', () => {
+  it('no target link → noTarget', () => {
+    const trace = resolveImpactTrace({
+      strategyNodeId: 'a',
+      links: [link({ role: 'guardrail', refSource: 'card', cardId: 'aov' })],
+      cards: tree,
+      relationships: treeEdges,
+    });
+    expect(trace.target).toBeNull();
+    expect(trace.missing.noTarget).toBe(true);
+    expect(trace.kpiPath).toEqual([]);
+    expect(trace.kpi).toBeNull();
+  });
+
+  it('target tracked metric not placed on the canvas → targetNotOnCanvas', () => {
+    const trace = resolveImpactTrace({
+      strategyNodeId: 'a',
+      links: [link({ role: 'target', refSource: 'tracked', trackedMetricId: 'tm_not_here' })],
+      cards: tree,
+      relationships: treeEdges,
+    });
+    expect(trace.target?.onCanvas).toBe(false);
+    expect(trace.missing.targetNotOnCanvas).toBe(true);
+    expect(trace.missing.noKpiPath).toBe(true);
+    expect(trace.kpiPath).toEqual([]);
+  });
+});

--- a/src/features/strategy/impact/impactTrace.ts
+++ b/src/features/strategy/impact/impactTrace.ts
@@ -1,0 +1,218 @@
+// Pure impact-trace resolver (CVS-168). Answers "why are we doing this, which
+// metric should move, and where will I see it?" by walking from a strategy
+// node's contract links → target/leading/guardrail metrics → the metric-tree
+// roll-up path to the KPI → dashboard widgets that show those metrics.
+//
+// NO I/O: callers pass the already-loaded contract links, canvas cards, tree
+// relationships, and dashboard widgets. Consumed by the impact panel (CVS-169),
+// dashboard badges (CVS-172), the trace view (CVS-173), and review (CVS-176).
+//
+// Edge convention (matches value propagation in feedDownstream.ts / runSimulation.ts):
+// a relationship source → target means source *drives* target. So a metric
+// "rolls up" to the KPI by walking FORWARD along outgoing edges to the terminal
+// downstream outcome (a metric node that drives nothing further).
+
+import type { MetricCard, Relationship } from '@/shared/types';
+import type { MetricLink, MetricLinkRole } from './types';
+
+/** Categories that participate in the metric-tree roll-up. */
+const METRIC_CATEGORIES = new Set(['Data/Metric', 'Core/Value']);
+
+/** Minimal widget shape (structurally matches DashboardWidget.config). */
+export interface TraceWidget {
+  id: string;
+  title: string | null;
+  config: {
+    source: 'tracked' | 'card';
+    trackedMetricIds?: string[];
+    cardIds?: string[];
+  };
+}
+
+export interface TraceWidgetRef {
+  id: string;
+  title: string | null;
+}
+
+/** A resolved metric reference from a contract link, placed on the tree/dashboards. */
+export interface TraceMetricRef {
+  role: MetricLinkRole;
+  refSource: MetricLink['refSource'];
+  trackedMetricId: string | null;
+  cardId: string | null;
+  /** The canvas placement resolved from the provided cards, if present. */
+  card: MetricCard | null;
+  label: string | null;
+  /** True when a placement exists in the provided cards (drawable on the tree). */
+  onCanvas: boolean;
+  /** Dashboard widgets that display this metric. */
+  widgets: TraceWidgetRef[];
+}
+
+export interface TraceMissing {
+  noTarget: boolean;
+  /** Target link exists but no placement was found in the provided cards. */
+  targetNotOnCanvas: boolean;
+  /** No ancestor metric above the target (target has no roll-up path). */
+  noKpiPath: boolean;
+  /** Neither target nor any guardrail is shown on a dashboard widget. */
+  noDashboard: boolean;
+}
+
+export interface ImpactTrace {
+  strategyNodeId: string;
+  target: TraceMetricRef | null;
+  leading: TraceMetricRef[];
+  guardrails: TraceMetricRef[];
+  /** Ordered path from the target card up to the KPI (inclusive). [] if no target on canvas. */
+  kpiPath: MetricCard[];
+  /** Terminal downstream outcome node (may equal the target if it is top-level). */
+  kpi: MetricCard | null;
+  missing: TraceMissing;
+}
+
+export interface TraceInput {
+  strategyNodeId: string;
+  links: MetricLink[];
+  cards: MetricCard[];
+  relationships: Relationship[];
+  widgets?: TraceWidget[];
+}
+
+/** All identifiers a ref can be matched by: its tracked id + every card placement id. */
+function refIdentifiers(
+  link: Pick<MetricLink, 'refSource' | 'trackedMetricId' | 'cardId'>,
+  cards: MetricCard[]
+): { trackedIds: Set<string>; cardIds: Set<string> } {
+  const trackedIds = new Set<string>();
+  const cardIds = new Set<string>();
+  if (link.refSource === 'card' && link.cardId) {
+    cardIds.add(link.cardId);
+    const card = cards.find((c) => c.id === link.cardId);
+    if (card?.trackedMetricId) trackedIds.add(card.trackedMetricId);
+  } else if (link.refSource === 'tracked' && link.trackedMetricId) {
+    trackedIds.add(link.trackedMetricId);
+    // every canvas placement of this tracked metric
+    for (const c of cards) {
+      if (c.trackedMetricId === link.trackedMetricId) cardIds.add(c.id);
+    }
+  }
+  return { trackedIds, cardIds };
+}
+
+/** Resolve the canvas card that best represents a ref (direct card, or a placement of a tracked metric). */
+function resolveCard(
+  link: Pick<MetricLink, 'refSource' | 'trackedMetricId' | 'cardId'>,
+  cards: MetricCard[]
+): MetricCard | null {
+  if (link.refSource === 'card' && link.cardId) {
+    return cards.find((c) => c.id === link.cardId) ?? null;
+  }
+  if (link.refSource === 'tracked' && link.trackedMetricId) {
+    return cards.find((c) => c.trackedMetricId === link.trackedMetricId) ?? null;
+  }
+  return null;
+}
+
+/** Widgets that display a given ref (by tracked id or card id). */
+function widgetsForRef(
+  link: Pick<MetricLink, 'refSource' | 'trackedMetricId' | 'cardId'>,
+  cards: MetricCard[],
+  widgets: TraceWidget[]
+): TraceWidgetRef[] {
+  const { trackedIds, cardIds } = refIdentifiers(link, cards);
+  const out: TraceWidgetRef[] = [];
+  for (const w of widgets) {
+    const wTracked = w.config?.trackedMetricIds ?? [];
+    const wCards = w.config?.cardIds ?? [];
+    const shows =
+      wTracked.some((id) => trackedIds.has(id)) || wCards.some((id) => cardIds.has(id));
+    if (shows) out.push({ id: w.id, title: w.title });
+  }
+  return out;
+}
+
+function toMetricRef(
+  link: MetricLink,
+  cards: MetricCard[],
+  widgets: TraceWidget[]
+): TraceMetricRef {
+  const card = resolveCard(link, cards);
+  return {
+    role: link.role,
+    refSource: link.refSource,
+    trackedMetricId: link.trackedMetricId,
+    cardId: link.cardId,
+    card,
+    label: card?.title ?? null,
+    onCanvas: !!card,
+    widgets: widgetsForRef(link, cards, widgets),
+  };
+}
+
+/**
+ * Walk forward (source → target) from a metric card to its terminal downstream
+ * outcome, returning the longest roll-up path (the KPI chain). Deterministic:
+ * ties break on the lowest next-card id. Cycle-safe.
+ */
+function rollUpPath(start: MetricCard, cards: MetricCard[], edges: Relationship[]): MetricCard[] {
+  const byId = new Map(cards.map((c) => [c.id, c]));
+  const outgoing = new Map<string, string[]>();
+  for (const e of edges) {
+    const s = byId.get(e.sourceId);
+    const t = byId.get(e.targetId);
+    if (!s || !t) continue;
+    if (!METRIC_CATEGORIES.has(s.category) || !METRIC_CATEGORIES.has(t.category)) continue;
+    const list = outgoing.get(e.sourceId) ?? [];
+    list.push(e.targetId);
+    outgoing.set(e.sourceId, list);
+  }
+
+  const memo = new Map<string, MetricCard[]>();
+  const walk = (id: string, visiting: Set<string>): MetricCard[] => {
+    const card = byId.get(id);
+    if (!card) return [];
+    if (memo.has(id)) return memo.get(id)!;
+    const nexts = (outgoing.get(id) ?? [])
+      .filter((n) => byId.has(n) && !visiting.has(n))
+      .sort();
+    let best: MetricCard[] = [];
+    visiting.add(id);
+    for (const n of nexts) {
+      const sub = walk(n, visiting);
+      if (sub.length > best.length) best = sub;
+    }
+    visiting.delete(id);
+    const path = [card, ...best];
+    memo.set(id, path);
+    return path;
+  };
+
+  return walk(start.id, new Set());
+}
+
+/** Build the full impact trace for a strategy node from already-loaded data. */
+export function resolveImpactTrace(input: TraceInput): ImpactTrace {
+  const { strategyNodeId, links, cards, relationships } = input;
+  const widgets = input.widgets ?? [];
+
+  const targetLinks = links.filter((l) => l.role === 'target');
+  const target = targetLinks.length ? toMetricRef(targetLinks[0], cards, widgets) : null;
+  const leading = links.filter((l) => l.role === 'leading').map((l) => toMetricRef(l, cards, widgets));
+  const guardrails = links.filter((l) => l.role === 'guardrail').map((l) => toMetricRef(l, cards, widgets));
+
+  const kpiPath = target?.card ? rollUpPath(target.card, cards, relationships) : [];
+  const kpi = kpiPath.length ? kpiPath[kpiPath.length - 1] : null;
+
+  const anyOnDashboard =
+    (target?.widgets.length ?? 0) > 0 || guardrails.some((g) => g.widgets.length > 0);
+
+  const missing: TraceMissing = {
+    noTarget: !target,
+    targetNotOnCanvas: !!target && !target.onCanvas,
+    noKpiPath: kpiPath.length < 2,
+    noDashboard: !anyOnDashboard,
+  };
+
+  return { strategyNodeId, target, leading, guardrails, kpiPath, kpi, missing };
+}


### PR DESCRIPTION
Closes **CVS-168** (Strategy impact — Milestone 1). **Stacked on [#59](https://github.com/nadeemramli/metrimap/pull/59)** (CVS-167) — review/merge that first; base auto-retargets to `main` after.

## What
Pure, I/O-free `resolveImpactTrace()` (`features/strategy/impact/impactTrace.ts`) — the shared read path for the impact panel (CVS-169), dashboard badges (CVS-172), trace view (CVS-173), and review (CVS-176).

Given already-loaded data (contract links, canvas cards, tree relationships, dashboard widgets) it returns:
- **target / leading / guardrail** refs, each resolved to its canvas placement + the **widgets that show it** (matched by tracked id or card id);
- the **KPI roll-up path** from the target metric — a forward walk on `source → target` edges (driver→outcome, matching `feedDownstream`/`runSimulation`), taking the longest branch, cycle-safe, deterministic;
- explicit **missing-path flags**: `noTarget`, `targetNotOnCanvas`, `noKpiPath`, `noDashboard`.

## Verification
- `type-check` ✅ · `lint` ✅ · `vitest` ✅ **15/15** (7 new fixture tests: full path, no-dashboard, terminal target, branching, cycle, no-target, target-not-on-canvas).

No visual trace UI in this issue (that's CVS-173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)