### PR TITLE
feat(evidence): Repository create/edit is DB-backed — CVS-34 slice 3

### DIFF
--- a/src/features/evidence/pages/EvidenceRepositoryPage.tsx
+++ b/src/features/evidence/pages/EvidenceRepositoryPage.tsx
@@ -57,6 +57,10 @@ import {
 import { useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import EvidenceEditor from '../components/EvidenceEditor';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import { useAppStore } from '@/shared/stores/useAppStore';
+import { createProjectEvidence } from '@/shared/lib/supabase/services/evidence';
+import { updateEvidenceItem } from '@/shared/lib/supabase/services/relationships';
 
 const evidenceTypeOptions = [
   { value: 'Experiment', icon: FlaskConical, variant: 'blue' },
@@ -69,6 +73,8 @@ const evidenceTypeOptions = [
 export default function EvidenceRepositoryPage() {
   const { canvasId } = useParams();
   const isCanvasScoped = Boolean(canvasId);
+  const client = useClerkSupabase();
+  const { user } = useAppStore();
   const { canvas } = useCanvasStore();
   const confirm = useConfirm();
   const {
@@ -158,16 +164,38 @@ export default function EvidenceRepositoryPage() {
     setIsEditorOpen(true);
   };
 
-  const handleSaveEvidence = (
+  const handleSaveEvidence = async (
     evidence: EvidenceItem,
     options?: { autoSave?: boolean }
   ) => {
     if (selectedEvidence) {
-      // Update existing evidence
+      // Update existing evidence (store + DB)
       updateEvidence(selectedEvidence.id, evidence);
+      if (client) {
+        try {
+          await updateEvidenceItem(selectedEvidence.id, evidence, client);
+        } catch (e) {
+          console.error('Failed to persist evidence edit to DB', e);
+        }
+      }
     } else {
-      // Create new evidence
-      addEvidence(evidence);
+      // Create new evidence — persist to the DB (project-scoped) when we have a
+      // canvas/project context, so it's DB-backed rather than store-only and
+      // resolvable by id across surfaces (CVS-34 slice 3).
+      let created = evidence;
+      if (canvasId && client && user?.id) {
+        try {
+          created = await createProjectEvidence(
+            evidence,
+            canvasId,
+            user.id,
+            client
+          );
+        } catch (e) {
+          console.error('Failed to create evidence in DB; storing locally', e);
+        }
+      }
+      addEvidence(created);
     }
 
     // Only close dialog on manual save, not auto-save

--- a/src/shared/lib/supabase/services/evidence.ts
+++ b/src/shared/lib/supabase/services/evidence.ts
@@ -85,3 +85,33 @@ export async function createCardEvidence(
   if (error) throw new Error(error.message);
   return rowToEvidence(data);
 }
+
+/** Create a general project-scoped evidence item (no card / relationship). Used
+ *  by the Evidence Repository "New Evidence" so it's DB-backed, not store-only. */
+export async function createProjectEvidence(
+  evidence: EvidenceItem,
+  projectId: string,
+  userId: string,
+  client?: Client
+): Promise<EvidenceItem> {
+  const c = client || supabase();
+  const { data, error } = await c
+    .from('evidence_items')
+    .insert({
+      project_id: projectId,
+      title: evidence.title,
+      type: evidence.type,
+      date: evidence.date,
+      owner_id: evidence.owner || null,
+      link: evidence.link ?? null,
+      hypothesis: evidence.hypothesis ?? null,
+      summary: evidence.summary || evidence.title,
+      impact_on_confidence: evidence.impactOnConfidence ?? null,
+      content: (evidence.content ?? null) as Json,
+      created_by: userId,
+    })
+    .select('*')
+    .single();
+  if (error) throw new Error(error.message);
+  return rowToEvidence(data);
+}


### PR DESCRIPTION
**Slice 3 of CVS-34** — unify the create path so general evidence is DB-backed (builds on slices 1+2).

## Change
The Evidence Repository's **"New Evidence"** persisted to the Zustand store only → general (non-card/relationship) evidence never got a DB row (lost on reload, unresolvable by id).
- New **`createProjectEvidence`** service — project-scoped insert (no card/relationship), includes `content`.
- `handleSaveEvidence`: **create** → `createProjectEvidence` when canvas-scoped (uses the DB-generated id in the store); **edit** → `updateEvidenceItem` too. Store still holds the item for instant UI; the DB is the source of truth. Falls back to store-only when there's no canvas/project context.

## Result
New evidence created in the Repository now **survives reload** and is resolvable by id across preview / full page (with slice 2's DB load).

## Remaining (slice 3b / 4)
- `EvidencePage`'s brand-new path (navigate to a fresh `/evidence/:id`) — still store-only.
- Repository listing still merges store + relationship evidence (dedup by id is the final consolidation step).
- Custom `/node` `/chart` `/snapshot` blocks (slice 4).

## Verification
type-check ✓, lint ✓ (0 errors), full Vitest ✓. Create+reload persistence covered by the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)