### PR TITLE
feat(CVS-104): MCP hardening — rate limit, payload caps, audit log

### DIFF
--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -41,6 +41,41 @@ Tools wired (finalized in **CVS-101**): `list_canvases`, `get_tree`, `list_nodes
 `update_node`, `delete_node`, `create_relationship`, `delete_relationship`,
 `push_values`, `layout_tree` (Dagre auto-layout so pushed trees render sensibly).
 
+## Security & abuse controls (CVS-104)
+
+Injected into `dispatchTool(name, args, ctx, guards)` so they stay transport-
+agnostic and unit-tested; the deployed server always supplies them:
+
+- **RLS everywhere** — every tool runs through `createMetrimapApi(client, userId)`;
+  the client is the caller's Clerk-scoped client, so no cross-tenant access and
+  the service-role key is never used.
+- **Scopes** — tools declare `read`/`write`; `dispatchTool` rejects a `write` tool
+  when the connection lacks the `write` scope (`forbidden`). Per-key scopes come
+  from CVS-89.
+- **Rate limiting** — `RateLimiter` (token bucket) keyed by user → `rate_limited`.
+  In-memory per instance; a multi-instance deploy should back it with
+  Postgres/Redis.
+- **Payload caps** — `enforcePayloadSize` (default 2 MB, above the 1 MB CSV Zod
+  cap) → `payload_too_large`; per-tool Zod schemas cap the rest.
+- **Audit log** — `supabaseAuditSink` writes every call (who/what/when/outcome/
+  duration) to `public.mcp_audit_log` (RLS-scoped, append-only), best-effort so
+  logging never fails a call.
+- **Safe failure** — a rejected call (bad scope/input/rate/size) runs no handler,
+  so a tree is never partially corrupted; downstream errors surface as structured
+  `McpToolError`s.
+
+Wire them in the adapter:
+
+```ts
+import { RateLimiter, supabaseAuditSink, DEFAULT_MAX_PAYLOAD_BYTES } from '@/shared/lib/api/mcp';
+const rateLimiter = new RateLimiter(120, 2); // 120 burst, 2/s sustained per user
+// per request, after resolving ctx:
+const guards = { rateLimiter, maxPayloadBytes: DEFAULT_MAX_PAYLOAD_BYTES, audit: supabaseAuditSink(ctx.client) };
+await dispatchTool(t.name, args, ctx, guards);
+```
+
+Remaining before public exposure: a **load/security review** (AC) once deployed.
+
 ## Transport + deploy — the remaining work (owner decision)
 
 **Blocked on:** (1) a **hosting decision** and (2) the **auth resolver (CVS-99)**.
@@ -66,7 +101,8 @@ export async function handler(req, res) {
     server.registerTool(t.name, { title: t.title, description: t.description, inputSchema: t.inputSchema },
       async (args) => {
         const ctx = await resolveAuth(req);                 // per-request, RLS-scoped
-        try { return { content: [{ type: 'text', text: JSON.stringify(await dispatchTool(t.name, args, ctx)) }] }; }
+        const guards = { rateLimiter, maxPayloadBytes: DEFAULT_MAX_PAYLOAD_BYTES, audit: supabaseAuditSink(ctx.client) };
+        try { return { content: [{ type: 'text', text: JSON.stringify(await dispatchTool(t.name, args, ctx, guards)) }] }; }
         catch (e) { const code = e instanceof McpToolError ? e.code : 'internal';
           return { isError: true, content: [{ type: 'text', text: `${code}: ${(e as Error).message}` }] }; }
       });

--- a/src/shared/lib/api/mcp/audit.ts
+++ b/src/shared/lib/api/mcp/audit.ts
@@ -1,0 +1,41 @@
+// Audit log for MCP tool calls (CVS-104): who / what / when / outcome. The sink
+// is pluggable so dispatch stays transport-agnostic and unit-testable. The
+// Supabase sink writes to public.mcp_audit_log (RLS-scoped, append-only) via the
+// caller's own client, so an entry is always attributed to the acting user.
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import type { McpScope } from './authContext';
+
+export interface McpAuditEntry {
+  userId: string;
+  tool: string;
+  scope: McpScope;
+  outcome: 'ok' | 'error';
+  errorCode?: string | null;
+  durationMs?: number;
+}
+
+export interface AuditSink {
+  record(entry: McpAuditEntry): Promise<void>;
+}
+
+export const noopAuditSink: AuditSink = {
+  record: async () => {},
+};
+
+export function supabaseAuditSink(
+  client: SupabaseClient<Database>
+): AuditSink {
+  return {
+    record: async (e) => {
+      await client.from('mcp_audit_log').insert({
+        user_id: e.userId,
+        tool_name: e.tool,
+        scope: e.scope,
+        outcome: e.outcome,
+        error_code: e.errorCode ?? null,
+        duration_ms: e.durationMs ?? null,
+      });
+    },
+  };
+}

--- a/src/shared/lib/api/mcp/errors.ts
+++ b/src/shared/lib/api/mcp/errors.ts
@@ -5,6 +5,8 @@ export type McpErrorCode =
   | 'unauthenticated'
   | 'forbidden'
   | 'not_found'
+  | 'rate_limited'
+  | 'payload_too_large'
   | 'internal';
 
 export class McpToolError extends Error {

--- a/src/shared/lib/api/mcp/guards.test.ts
+++ b/src/shared/lib/api/mcp/guards.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { RateLimiter, enforcePayloadSize, enforceRateLimit } from './guards';
+import { McpToolError } from './errors';
+
+describe('RateLimiter', () => {
+  it('allows up to capacity, then denies', () => {
+    const rl = new RateLimiter(2, 1);
+    expect(rl.tryRemove('u1', 0)).toBe(true);
+    expect(rl.tryRemove('u1', 0)).toBe(true);
+    expect(rl.tryRemove('u1', 0)).toBe(false);
+  });
+  it('refills over time', () => {
+    const rl = new RateLimiter(1, 1); // 1 token/sec
+    expect(rl.tryRemove('u1', 0)).toBe(true);
+    expect(rl.tryRemove('u1', 0)).toBe(false);
+    expect(rl.tryRemove('u1', 1000)).toBe(true); // +1s → +1 token
+  });
+  it('keys are independent', () => {
+    const rl = new RateLimiter(1, 0);
+    expect(rl.tryRemove('a', 0)).toBe(true);
+    expect(rl.tryRemove('b', 0)).toBe(true);
+    expect(rl.tryRemove('a', 0)).toBe(false);
+  });
+});
+
+describe('enforcePayloadSize', () => {
+  it('passes small payloads', () => {
+    expect(() => enforcePayloadSize({ a: 1 }, 1000)).not.toThrow();
+  });
+  it('throws payload_too_large over the cap', () => {
+    const err = (() => {
+      try {
+        enforcePayloadSize({ big: 'x'.repeat(100) }, 10);
+      } catch (e) {
+        return e as McpToolError;
+      }
+    })();
+    expect(err).toBeInstanceOf(McpToolError);
+    expect(err?.code).toBe('payload_too_large');
+  });
+});
+
+describe('enforceRateLimit', () => {
+  it('throws rate_limited when the bucket is empty', () => {
+    const rl = new RateLimiter(1, 0);
+    enforceRateLimit(rl, 'u1', 0);
+    expect(() => enforceRateLimit(rl, 'u1', 0)).toThrow(McpToolError);
+    try {
+      enforceRateLimit(rl, 'u1', 0);
+    } catch (e) {
+      expect((e as McpToolError).code).toBe('rate_limited');
+    }
+  });
+});

--- a/src/shared/lib/api/mcp/guards.ts
+++ b/src/shared/lib/api/mcp/guards.ts
@@ -1,0 +1,63 @@
+// Abuse controls for the MCP server (CVS-104): a per-key token-bucket rate
+// limiter + a payload-size cap. Both are transport-agnostic and injected into
+// dispatchTool. The limiter is in-memory (per server instance) — fine for a
+// single Vercel function / Node process; a multi-instance deploy should back it
+// with Postgres/Redis (see docs/features/mcp-server.md).
+import { McpToolError } from './errors';
+
+/** Token bucket: `capacity` burst, refilled at `refillPerSec` tokens/second. */
+export class RateLimiter {
+  private readonly capacity: number;
+  private readonly refillPerSec: number;
+  private readonly buckets = new Map<string, { tokens: number; last: number }>();
+
+  constructor(capacity = 60, refillPerSec = 1) {
+    this.capacity = capacity;
+    this.refillPerSec = refillPerSec;
+  }
+
+  /** Returns true if a token was available (and consumed) for `key`. */
+  tryRemove(key: string, now: number = Date.now()): boolean {
+    const b = this.buckets.get(key) ?? { tokens: this.capacity, last: now };
+    const elapsedSec = Math.max(0, (now - b.last) / 1000);
+    const tokens = Math.min(this.capacity, b.tokens + elapsedSec * this.refillPerSec);
+    if (tokens < 1) {
+      this.buckets.set(key, { tokens, last: now });
+      return false;
+    }
+    this.buckets.set(key, { tokens: tokens - 1, last: now });
+    return true;
+  }
+}
+
+// Coarse outer bound on a single tool-call payload. Sits above the per-tool Zod
+// caps (e.g. the 1MB CSV limit) so valid calls pass but pathological ones don't.
+export const DEFAULT_MAX_PAYLOAD_BYTES = 2_000_000;
+
+export function enforcePayloadSize(
+  args: unknown,
+  maxBytes: number = DEFAULT_MAX_PAYLOAD_BYTES
+): void {
+  let size = 0;
+  try {
+    size = JSON.stringify(args ?? {}).length;
+  } catch {
+    throw new McpToolError('invalid_input', 'Tool arguments are not serializable');
+  }
+  if (size > maxBytes) {
+    throw new McpToolError(
+      'payload_too_large',
+      `Payload ${size} bytes exceeds the ${maxBytes}-byte limit`
+    );
+  }
+}
+
+export function enforceRateLimit(
+  limiter: RateLimiter,
+  key: string,
+  now: number = Date.now()
+): void {
+  if (!limiter.tryRemove(key, now)) {
+    throw new McpToolError('rate_limited', 'Rate limit exceeded — slow down and retry');
+  }
+}

--- a/src/shared/lib/api/mcp/index.ts
+++ b/src/shared/lib/api/mcp/index.ts
@@ -1,8 +1,26 @@
 // MCP scaffold (CVS-100): transport-agnostic tool registry + dispatch + auth seam
 // over the RLS-scoped programmatic API (CVS-98). The Streamable-HTTP transport +
 // deploy is documented in docs/features/mcp-server.md; auth resolver is CVS-99.
-export { TOOLS, listTools, dispatchTool, type McpTool } from './registry';
+export {
+  TOOLS,
+  listTools,
+  dispatchTool,
+  type McpTool,
+  type DispatchGuards,
+} from './registry';
 export { McpToolError, type McpErrorCode } from './errors';
+export {
+  RateLimiter,
+  enforcePayloadSize,
+  enforceRateLimit,
+  DEFAULT_MAX_PAYLOAD_BYTES,
+} from './guards';
+export {
+  noopAuditSink,
+  supabaseAuditSink,
+  type AuditSink,
+  type McpAuditEntry,
+} from './audit';
 export {
   unimplementedAuthResolver,
   type McpAuthContext,

--- a/src/shared/lib/api/mcp/registry.test.ts
+++ b/src/shared/lib/api/mcp/registry.test.ts
@@ -36,6 +36,8 @@ vi.mock('../metrimapApi', () => ({ createMetrimapApi: vi.fn(() => fakeApi) }));
 
 import { TOOLS, listTools, dispatchTool } from './registry';
 import { McpToolError } from './errors';
+import { RateLimiter } from './guards';
+import type { AuditSink } from './audit';
 import type { McpAuthContext } from './authContext';
 
 const ctx = (scopes?: ('read' | 'write')[]): McpAuthContext => ({
@@ -138,5 +140,37 @@ describe('dispatchTool', () => {
     expect(err).toBeInstanceOf(McpToolError);
     expect(err.code).toBe('internal');
     expect(err.message).toMatch(/db exploded/);
+  });
+});
+
+describe('dispatchTool guards (CVS-104)', () => {
+  it('rate-limits per user', async () => {
+    const rateLimiter = new RateLimiter(1, 0); // one call, no refill
+    await dispatchTool('list_canvases', {}, ctx(), { rateLimiter });
+    await expect(dispatchTool('list_canvases', {}, ctx(), { rateLimiter })).rejects.toMatchObject({
+      code: 'rate_limited',
+    });
+  });
+
+  it('rejects oversized payloads', async () => {
+    await expect(
+      dispatchTool('create_canvas', { name: 'a-fairly-long-name' }, ctx(), { maxPayloadBytes: 5 })
+    ).rejects.toMatchObject({ code: 'payload_too_large' });
+  });
+
+  it('records an ok audit entry on success', async () => {
+    const audit: AuditSink = { record: vi.fn(async () => {}) };
+    await dispatchTool('create_canvas', { name: 'Tree' }, ctx(), { audit });
+    expect(audit.record).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'u1', tool: 'create_canvas', scope: 'write', outcome: 'ok', errorCode: null })
+    );
+  });
+
+  it('records an error audit entry on invalid input', async () => {
+    const audit: AuditSink = { record: vi.fn(async () => {}) };
+    await dispatchTool('create_canvas', { name: '' }, ctx(), { audit }).catch(() => {});
+    expect(audit.record).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: 'create_canvas', outcome: 'error', errorCode: 'invalid_input' })
+    );
   });
 });

--- a/src/shared/lib/api/mcp/registry.ts
+++ b/src/shared/lib/api/mcp/registry.ts
@@ -15,6 +15,8 @@ import {
 } from '../schemas';
 import type { McpAuthContext, McpScope } from './authContext';
 import { McpToolError } from './errors';
+import type { AuditSink } from './audit';
+import { enforcePayloadSize, enforceRateLimit, type RateLimiter } from './guards';
 
 export interface McpTool {
   name: string;
@@ -208,16 +210,34 @@ export function listTools() {
   }));
 }
 
+/** Abuse controls + audit, injected by the transport (CVS-104). All optional so
+ *  dispatch stays pure/testable; the deployed server always supplies them. */
+export interface DispatchGuards {
+  rateLimiter?: RateLimiter;
+  maxPayloadBytes?: number;
+  audit?: AuditSink;
+}
+
 /**
- * Validate + run one tool call under the caller's auth context. Throws
- * McpToolError (structured) for unknown tool / bad scope / invalid input /
- * downstream failure — the transport maps these to MCP error responses.
+ * Validate + run one tool call under the caller's auth context, with optional
+ * abuse controls + audit. Throws McpToolError (structured) for payload-too-large
+ * / rate-limited / unknown tool / bad scope / invalid input / downstream failure
+ * — the transport maps these to MCP error responses. Failures are clean (a
+ * rejected call writes nothing), so a tree is never partially corrupted.
  */
 export async function dispatchTool(
   name: string,
   rawArgs: unknown,
-  ctx: McpAuthContext
+  ctx: McpAuthContext,
+  guards: DispatchGuards = {}
 ): Promise<unknown> {
+  const start = Date.now();
+
+  // Transport-level guards (before we touch a tool): cap payload, then rate-limit
+  // per acting user.
+  if (guards.maxPayloadBytes !== undefined) enforcePayloadSize(rawArgs, guards.maxPayloadBytes);
+  if (guards.rateLimiter) enforceRateLimit(guards.rateLimiter, ctx.userId);
+
   const tool = BY_NAME.get(name);
   if (!tool) throw new McpToolError('not_found', `Unknown tool: ${name}`);
 
@@ -225,10 +245,27 @@ export async function dispatchTool(
     throw new McpToolError('forbidden', `Tool "${name}" requires the write scope`);
   }
 
+  const audit = (outcome: 'ok' | 'error', errorCode: string | null) => {
+    if (!guards.audit) return;
+    void guards.audit
+      .record({
+        userId: ctx.userId,
+        tool: name,
+        scope: tool.scope,
+        outcome,
+        errorCode,
+        durationMs: Date.now() - start,
+      })
+      .catch(() => {
+        /* audit is best-effort — never fail a call because logging failed */
+      });
+  };
+
   let args: unknown;
   try {
     args = tool.inputSchema.parse(rawArgs ?? {});
   } catch (e) {
+    audit('error', 'invalid_input');
     throw new McpToolError(
       'invalid_input',
       `Invalid input for "${name}"`,
@@ -237,9 +274,15 @@ export async function dispatchTool(
   }
 
   try {
-    return await tool.handler(args, ctx);
+    const result = await tool.handler(args, ctx);
+    audit('ok', null);
+    return result;
   } catch (e) {
-    if (e instanceof McpToolError) throw e;
+    if (e instanceof McpToolError) {
+      audit('error', e.code);
+      throw e;
+    }
+    audit('error', 'internal');
     throw new McpToolError('internal', e instanceof Error ? e.message : String(e));
   }
 }

--- a/src/shared/lib/supabase/types.ts
+++ b/src/shared/lib/supabase/types.ts
@@ -1033,6 +1033,39 @@ export type Database = {
           }
         ]
       }
+      mcp_audit_log: {
+        Row: {
+          created_at: string
+          duration_ms: number | null
+          error_code: string | null
+          id: string
+          outcome: string
+          scope: string | null
+          tool_name: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          duration_ms?: number | null
+          error_code?: string | null
+          id?: string
+          outcome: string
+          scope?: string | null
+          tool_name: string
+          user_id?: string
+        }
+        Update: {
+          created_at?: string
+          duration_ms?: number | null
+          error_code?: string | null
+          id?: string
+          outcome?: string
+          scope?: string | null
+          tool_name?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       metric_card_tags: {
         Row: {
           id: string

--- a/supabase/migrations/20260704150000_mcp_audit_log.sql
+++ b/supabase/migrations/20260704150000_mcp_audit_log.sql
@@ -1,0 +1,32 @@
+-- =====================================================================
+-- MCP AUDIT LOG (CVS-104). Append-only record of every MCP tool call —
+-- who (user_id) / what (tool_name, scope) / when (created_at) / outcome. Written
+-- by the MCP server via the acting user's RLS-scoped client, so entries are
+-- always attributed and a user only ever sees their own. No UPDATE/DELETE policy
+-- (append-only); service_role can prune out-of-band.
+-- =====================================================================
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.mcp_audit_log (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     text NOT NULL DEFAULT requesting_user_id(),
+  tool_name   text NOT NULL,
+  scope       text,
+  outcome     text NOT NULL CHECK (outcome IN ('ok', 'error')),
+  error_code  text,
+  duration_ms integer,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_user_time
+  ON public.mcp_audit_log (user_id, created_at DESC);
+
+ALTER TABLE public.mcp_audit_log ENABLE ROW LEVEL SECURITY;
+
+-- Users read + append only their own entries; no update/delete (append-only).
+CREATE POLICY mcp_audit_log_select ON public.mcp_audit_log FOR SELECT
+  USING (user_id = requesting_user_id());
+CREATE POLICY mcp_audit_log_insert ON public.mcp_audit_log FOR INSERT
+  WITH CHECK (user_id = requesting_user_id());
+
+COMMIT;


### PR DESCRIPTION
Abuse controls + audit for the MCP server, injected into `dispatchTool(name, args, ctx, guards)` so they stay transport-agnostic and unit-tested.

## What lands
- **`guards.ts`** — `RateLimiter` (per-user token bucket) + `enforcePayloadSize` (default 2 MB, above the 1 MB CSV Zod cap). New error codes `rate_limited` / `payload_too_large`.
- **`audit.ts`** — pluggable `AuditSink` + `supabaseAuditSink` → `public.mcp_audit_log` (**migration** `20260704150000`: RLS-scoped, append-only). Best-effort — logging never fails a call.
- **`dispatchTool`** — pipeline: payload cap → rate limit → scope → validate → run, auditing `ok`/`error` outcomes with duration. **Safe failure**: a rejected call runs no handler, so a tree is never partially corrupted.
- Reference transport adapter wires the guards (`docs/features/mcp-server.md`).

## Acceptance criteria
- [x] All tools RLS-scoped; no cross-tenant access (via CVS-98 + auth seam).
- [x] Scoped credentials (read/write) + rate limits + size caps enforced.
- [x] Audit log of MCP tool calls (`mcp_audit_log`).
- [ ] Load/security review before public exposure — **owner, once deployed** (needs CVS-99 + hosting).

Guards are optional params, so existing callers are unchanged (176 tests pass).

## Review notes
- ⚠️ **Not self-merged** — adds an **RLS table** (`mcp_audit_log`). Please review + `npx supabase db push`. `types.ts` hand-patched at the `mcp_audit_log` slot (distinct from PR #56's region → no conflict).

Verify: type-check + eslint + `vitest run` (**176 passing**) green.

Ref: CVS-104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)