### PR TITLE
feat(cvs-169): Strategy Impact panel on Action/Hypothesis detail

### DIFF
--- a/src/features/strategy/components/StrategyImpactSheet.test.tsx
+++ b/src/features/strategy/components/StrategyImpactSheet.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { MetricCard } from '@/shared/types';
+
+// No Clerk client in the test → the load effect early-returns and no network runs.
+vi.mock('@/shared/hooks/useClerkSupabase', () => ({ useClerkSupabase: () => null }));
+vi.mock('@/shared/lib/supabase/services/strategyImpact', () => ({
+  getContractForNode: vi.fn(),
+  getMetricLinks: vi.fn(),
+  upsertContract: vi.fn(),
+  setMetricLinks: vi.fn(),
+  deleteContract: vi.fn(),
+}));
+vi.mock('@/shared/lib/supabase/services/trackedMetrics', () => ({
+  listTrackedMetrics: vi.fn(async () => []),
+}));
+
+import { StrategyImpactSheet } from './StrategyImpactSheet';
+
+const card = (id: string, over: Partial<MetricCard> = {}): MetricCard => ({
+  id,
+  title: id,
+  description: '',
+  category: 'Work/Action',
+  tags: [],
+  causalFactors: [],
+  dimensions: [],
+  position: { x: 0, y: 0 },
+  assignees: [],
+  createdAt: '',
+  updatedAt: '',
+  ...over,
+});
+
+const baseProps = {
+  cardId: 'action_1',
+  cardTitle: 'Reduce checkout friction',
+  projectId: 'canvas_1',
+  cards: [card('action_1'), card('m_cvr', { title: 'Checkout CVR', category: 'Data/Metric' })],
+  relationships: [],
+  open: true,
+  onOpenChange: () => {},
+};
+
+describe('StrategyImpactSheet', () => {
+  it('shows the empty state and the contract fields when no target is set', () => {
+    render(<StrategyImpactSheet {...baseProps} canEdit />);
+    expect(screen.getByText('Add a target metric to measure impact.')).toBeInTheDocument();
+    expect(screen.getByText('Target metric')).toBeInTheDocument();
+    expect(screen.getByText('Direction')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save impact/i })).toBeInTheDocument();
+  });
+
+  it('edits a plain field (result note)', () => {
+    render(<StrategyImpactSheet {...baseProps} canEdit />);
+    const note = screen.getByPlaceholderText(/what happened/i) as HTMLTextAreaElement;
+    fireEvent.change(note, { target: { value: 'Won: +6% conversion' } });
+    expect(note.value).toBe('Won: +6% conversion');
+  });
+
+  it('hides the save/remove controls when the user cannot edit', () => {
+    render(<StrategyImpactSheet {...baseProps} canEdit={false} />);
+    expect(screen.queryByRole('button', { name: /save impact/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/features/strategy/components/StrategyImpactSheet.tsx
+++ b/src/features/strategy/components/StrategyImpactSheet.tsx
@@ -1,0 +1,623 @@
+// Strategy Impact panel (CVS-169). Right-side sheet on an Action/Hypothesis
+// detail: edit the impact contract (target/leading/guardrail metrics, expected
+// direction + delta, baseline + measurement window, confidence, status, result)
+// and preview the Action → Target → KPI trace via the CVS-168 resolver.
+
+import { useEffect, useMemo, useState } from 'react';
+import { Loader2, Plus, Target, TrendingUp, X } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/shared/components/ui/sheet';
+import { Button } from '@/shared/components/ui/button';
+import { Input } from '@/shared/components/ui/input';
+import { Label } from '@/shared/components/ui/label';
+import { Textarea } from '@/shared/components/ui/textarea';
+import { Badge } from '@/shared/components/ui/badge';
+import { Separator } from '@/shared/components/ui/separator';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/shared/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/components/ui/select';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import { listTrackedMetrics } from '@/shared/lib/supabase/services/trackedMetrics';
+import {
+  deleteContract,
+  getContractForNode,
+  getMetricLinks,
+  setMetricLinks,
+  upsertContract,
+} from '@/shared/lib/supabase/services/strategyImpact';
+import type { MetricCard, Relationship } from '@/shared/types';
+import type {
+  Confidence,
+  ExpectedDirection,
+  ImpactStatus,
+  MetricLink,
+  MetricLinkInput,
+  MetricLinkRole,
+} from '@/features/strategy/impact/types';
+import {
+  CONFIDENCE_LEVELS,
+  EXPECTED_DIRECTIONS,
+  IMPACT_STATUSES,
+} from '@/features/strategy/impact/types';
+import { resolveImpactTrace } from '@/features/strategy/impact/impactTrace';
+
+/** A selectable metric — a catalogued tracked metric or a canvas metric card. */
+interface MetricOption {
+  source: 'tracked' | 'card';
+  id: string;
+  label: string;
+  unit?: string | null;
+}
+
+const METRIC_CARD_CATEGORIES = new Set(['Data/Metric', 'Core/Value']);
+
+interface StrategyImpactSheetProps {
+  cardId: string | null;
+  cardTitle?: string;
+  projectId?: string;
+  cards: MetricCard[];
+  relationships: Relationship[];
+  canEdit: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function optionKey(o: Pick<MetricOption, 'source' | 'id'>): string {
+  return `${o.source}:${o.id}`;
+}
+
+function optionToLinkInput(o: MetricOption, role: MetricLinkRole): MetricLinkInput {
+  return {
+    role,
+    refSource: o.source,
+    trackedMetricId: o.source === 'tracked' ? o.id : null,
+    cardId: o.source === 'card' ? o.id : null,
+  };
+}
+
+export function StrategyImpactSheet({
+  cardId,
+  cardTitle,
+  projectId,
+  cards,
+  relationships,
+  canEdit,
+  open,
+  onOpenChange,
+}: StrategyImpactSheetProps) {
+  const client = useClerkSupabase();
+
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [contractId, setContractId] = useState<string | null>(null);
+
+  const [target, setTarget] = useState<MetricOption | null>(null);
+  const [leading, setLeading] = useState<MetricOption[]>([]);
+  const [guardrails, setGuardrails] = useState<MetricOption[]>([]);
+
+  const [direction, setDirection] = useState<ExpectedDirection | ''>('');
+  const [deltaValue, setDeltaValue] = useState('');
+  const [deltaUnit, setDeltaUnit] = useState<'percent' | 'absolute'>('percent');
+  const [baselineStart, setBaselineStart] = useState('');
+  const [baselineEnd, setBaselineEnd] = useState('');
+  const [measureStart, setMeasureStart] = useState('');
+  const [measureEnd, setMeasureEnd] = useState('');
+  const [confidence, setConfidence] = useState<Confidence | ''>('');
+  const [status, setStatus] = useState<ImpactStatus>('draft');
+  const [resultNote, setResultNote] = useState('');
+
+  const [trackedOptions, setTrackedOptions] = useState<MetricOption[]>([]);
+
+  // Canvas metric cards are always available from props; catalog metrics load lazily.
+  const cardOptions: MetricOption[] = useMemo(
+    () =>
+      cards
+        .filter((c) => METRIC_CARD_CATEGORIES.has(c.category))
+        .map((c) => ({ source: 'card', id: c.id, label: c.title || 'Untitled' })),
+    [cards]
+  );
+  const allOptions = useMemo(
+    () => [...trackedOptions, ...cardOptions],
+    [trackedOptions, cardOptions]
+  );
+
+  const resetForm = () => {
+    setContractId(null);
+    setTarget(null);
+    setLeading([]);
+    setGuardrails([]);
+    setDirection('');
+    setDeltaValue('');
+    setDeltaUnit('percent');
+    setBaselineStart('');
+    setBaselineEnd('');
+    setMeasureStart('');
+    setMeasureEnd('');
+    setConfidence('');
+    setStatus('draft');
+    setResultNote('');
+  };
+
+  // Resolve a stored link to a display option (prefer a known option; else show its id).
+  const linkToOption = (link: MetricLink, options: MetricOption[]): MetricOption => {
+    const source = link.refSource;
+    const id = link.refSource === 'tracked' ? link.trackedMetricId! : link.cardId!;
+    return (
+      options.find((o) => o.source === source && o.id === id) ?? {
+        source,
+        id,
+        label: id,
+      }
+    );
+  };
+
+  // Load catalog + existing contract whenever a different card's sheet opens.
+  useEffect(() => {
+    if (!open || !cardId || !client) return;
+    let cancelled = false;
+    setLoading(true);
+    resetForm();
+    (async () => {
+      try {
+        const tracked = await listTrackedMetrics(client);
+        const trackedOpts: MetricOption[] = tracked.map((m) => ({
+          source: 'tracked',
+          id: m.id,
+          label: m.name,
+          unit: m.unit,
+        }));
+        const options = [...trackedOpts, ...cardOptions];
+        if (cancelled) return;
+        setTrackedOptions(trackedOpts);
+
+        const contract = await getContractForNode(cardId, client);
+        if (cancelled) return;
+        if (contract) {
+          setContractId(contract.id);
+          setDirection(contract.expectedDirection ?? '');
+          setDeltaValue(
+            contract.expectedDeltaValue != null ? String(contract.expectedDeltaValue) : ''
+          );
+          setDeltaUnit(contract.expectedDeltaUnit === 'absolute' ? 'absolute' : 'percent');
+          setBaselineStart(contract.baselineStart ?? '');
+          setBaselineEnd(contract.baselineEnd ?? '');
+          setMeasureStart(contract.measureStart ?? '');
+          setMeasureEnd(contract.measureEnd ?? '');
+          setConfidence(contract.confidence ?? '');
+          setStatus(contract.impactStatus);
+          setResultNote(contract.resultNote ?? '');
+
+          const links = await getMetricLinks(contract.id, client);
+          if (cancelled) return;
+          setTarget(
+            links.filter((l) => l.role === 'target').map((l) => linkToOption(l, options))[0] ?? null
+          );
+          setLeading(
+            links.filter((l) => l.role === 'leading').map((l) => linkToOption(l, options))
+          );
+          setGuardrails(
+            links.filter((l) => l.role === 'guardrail').map((l) => linkToOption(l, options))
+          );
+        }
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : 'Failed to load impact contract');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, cardId, client]);
+
+  // Live trace preview from the current (possibly unsaved) selections.
+  const trace = useMemo(() => {
+    if (!cardId) return null;
+    const links: MetricLink[] = [];
+    const push = (o: MetricOption, role: MetricLinkRole, i: number) =>
+      links.push({
+        id: `preview-${role}-${i}`,
+        contractId: 'preview',
+        role,
+        refSource: o.source,
+        trackedMetricId: o.source === 'tracked' ? o.id : null,
+        cardId: o.source === 'card' ? o.id : null,
+      });
+    if (target) push(target, 'target', 0);
+    leading.forEach((o, i) => push(o, 'leading', i));
+    guardrails.forEach((o, i) => push(o, 'guardrail', i));
+    return resolveImpactTrace({
+      strategyNodeId: cardId,
+      links,
+      cards,
+      relationships,
+      widgets: [],
+    });
+  }, [cardId, target, leading, guardrails, cards, relationships]);
+
+  const handleSave = async () => {
+    if (!cardId || !client) return;
+    setSaving(true);
+    try {
+      const contract = await upsertContract(
+        {
+          strategyNodeId: cardId,
+          projectId: projectId ?? null,
+          expectedDirection: direction || null,
+          expectedDeltaValue: deltaValue.trim() === '' ? null : Number(deltaValue),
+          expectedDeltaUnit: direction === 'stabilize' ? null : deltaUnit,
+          baselineStart: baselineStart.trim() || null,
+          baselineEnd: baselineEnd.trim() || null,
+          measureStart: measureStart.trim() || null,
+          measureEnd: measureEnd.trim() || null,
+          confidence: confidence || null,
+          impactStatus: status,
+          resultNote: resultNote.trim() || null,
+        },
+        client
+      );
+      const links: MetricLinkInput[] = [
+        ...(target ? [optionToLinkInput(target, 'target')] : []),
+        ...leading.map((o) => optionToLinkInput(o, 'leading')),
+        ...guardrails.map((o) => optionToLinkInput(o, 'guardrail')),
+      ];
+      await setMetricLinks(contract.id, links, client);
+      setContractId(contract.id);
+      toast.success('Impact contract saved');
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to save impact contract');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (!contractId || !client) return;
+    setSaving(true);
+    try {
+      await deleteContract(contractId, client);
+      resetForm();
+      toast.success('Impact contract removed');
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to remove impact contract');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const kpiPathLabels = trace?.kpiPath.map((c) => c.title || 'Untitled') ?? [];
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="flex w-[460px] flex-col overflow-y-auto sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2 truncate">
+            <Target className="h-4 w-4 shrink-0" />
+            {cardTitle || 'Impact'}
+          </SheetTitle>
+          <SheetDescription>
+            What should this move, by how much, and where will you see it?
+          </SheetDescription>
+        </SheetHeader>
+
+        {loading ? (
+          <div className="flex flex-1 items-center justify-center">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="mt-4 space-y-5 px-1 pb-6">
+            {/* Trace preview */}
+            <div className="rounded-md border bg-muted/40 p-3">
+              <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                <TrendingUp className="h-3.5 w-3.5" />
+                Impact path
+              </div>
+              {!target ? (
+                <p className="text-sm text-muted-foreground">
+                  Add a target metric to measure impact.
+                </p>
+              ) : (
+                <p className="text-sm">
+                  <span className="font-medium">{cardTitle || 'This item'}</span>
+                  {' → '}
+                  {kpiPathLabels.length > 0 ? (
+                    kpiPathLabels.join(' → ')
+                  ) : (
+                    <span className="text-muted-foreground">
+                      {target.label}
+                      {trace?.missing.targetNotOnCanvas
+                        ? ' (not on this canvas)'
+                        : ' (no KPI path yet)'}
+                    </span>
+                  )}
+                </p>
+              )}
+            </div>
+
+            {/* Metric roles */}
+            <MetricRoleField
+              label="Target metric"
+              hint="The metric this bet should move."
+              options={allOptions}
+              value={target ? [target] : []}
+              single
+              disabled={!canEdit}
+              onChange={(vals) => setTarget(vals[0] ?? null)}
+            />
+            <MetricRoleField
+              label="Leading metrics"
+              hint="Early signals that it's working."
+              options={allOptions}
+              value={leading}
+              disabled={!canEdit}
+              onChange={setLeading}
+            />
+            <MetricRoleField
+              label="Guardrail metrics"
+              hint="Must not get worse."
+              options={allOptions}
+              value={guardrails}
+              disabled={!canEdit}
+              onChange={setGuardrails}
+            />
+
+            <Separator />
+
+            {/* Expected impact */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Direction</Label>
+                <Select
+                  value={direction || undefined}
+                  onValueChange={(v) => setDirection(v as ExpectedDirection)}
+                  disabled={!canEdit}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {EXPECTED_DIRECTIONS.map((d) => (
+                      <SelectItem key={d} value={d} className="capitalize">
+                        {d}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Expected delta</Label>
+                <div className="flex gap-1.5">
+                  <Input
+                    type="number"
+                    inputMode="decimal"
+                    placeholder="e.g. 5"
+                    value={deltaValue}
+                    disabled={!canEdit || direction === 'stabilize'}
+                    onChange={(e) => setDeltaValue(e.target.value)}
+                  />
+                  <Select
+                    value={deltaUnit}
+                    onValueChange={(v) => setDeltaUnit(v as 'percent' | 'absolute')}
+                    disabled={!canEdit || direction === 'stabilize'}
+                  >
+                    <SelectTrigger className="w-24">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="percent">%</SelectItem>
+                      <SelectItem value="absolute">abs</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </div>
+
+            {/* Baseline + measurement windows */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Baseline period</Label>
+                <div className="flex items-center gap-1.5">
+                  <Input placeholder="YYYY-MM" value={baselineStart} disabled={!canEdit} onChange={(e) => setBaselineStart(e.target.value)} />
+                  <span className="text-muted-foreground">–</span>
+                  <Input placeholder="YYYY-MM" value={baselineEnd} disabled={!canEdit} onChange={(e) => setBaselineEnd(e.target.value)} />
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Measurement window</Label>
+                <div className="flex items-center gap-1.5">
+                  <Input placeholder="YYYY-MM" value={measureStart} disabled={!canEdit} onChange={(e) => setMeasureStart(e.target.value)} />
+                  <span className="text-muted-foreground">–</span>
+                  <Input placeholder="YYYY-MM" value={measureEnd} disabled={!canEdit} onChange={(e) => setMeasureEnd(e.target.value)} />
+                </div>
+              </div>
+            </div>
+
+            {/* Confidence + status */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Confidence</Label>
+                <Select
+                  value={confidence || undefined}
+                  onValueChange={(v) => setConfidence(v as Confidence)}
+                  disabled={!canEdit}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CONFIDENCE_LEVELS.map((c) => (
+                      <SelectItem key={c} value={c} className="capitalize">
+                        {c}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Status</Label>
+                <Select
+                  value={status}
+                  onValueChange={(v) => setStatus(v as ImpactStatus)}
+                  disabled={!canEdit}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {IMPACT_STATUSES.map((s) => (
+                      <SelectItem key={s} value={s} className="capitalize">
+                        {s}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Result note</Label>
+              <Textarea
+                placeholder="What happened? Summarize the outcome when measured."
+                value={resultNote}
+                disabled={!canEdit}
+                onChange={(e) => setResultNote(e.target.value)}
+                rows={3}
+              />
+            </div>
+
+            {canEdit && (
+              <div className="flex items-center justify-between pt-1">
+                {contractId ? (
+                  <Button variant="ghost" size="sm" className="text-destructive" onClick={handleRemove} disabled={saving}>
+                    Remove
+                  </Button>
+                ) : (
+                  <span />
+                )}
+                <Button onClick={handleSave} disabled={saving}>
+                  {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Save impact
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// --- inline metric-ref picker -----------------------------------------------
+interface MetricRoleFieldProps {
+  label: string;
+  hint: string;
+  options: MetricOption[];
+  value: MetricOption[];
+  single?: boolean;
+  disabled?: boolean;
+  onChange: (next: MetricOption[]) => void;
+}
+
+function MetricRoleField({
+  label,
+  hint,
+  options,
+  value,
+  single,
+  disabled,
+  onChange,
+}: MetricRoleFieldProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const selectedKeys = new Set(value.map(optionKey));
+  const filtered = options.filter(
+    (o) =>
+      !selectedKeys.has(optionKey(o)) &&
+      (query ? o.label.toLowerCase().includes(query.toLowerCase()) : true)
+  );
+
+  const add = (o: MetricOption) => {
+    onChange(single ? [o] : [...value, o]);
+    setQuery('');
+    if (single) setPickerOpen(false);
+  };
+  const remove = (o: MetricOption) =>
+    onChange(value.filter((v) => optionKey(v) !== optionKey(o)));
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between">
+        <Label>{label}</Label>
+        <span className="text-xs text-muted-foreground">{hint}</span>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {value.map((o) => (
+          <Badge key={optionKey(o)} variant="secondary" className="gap-1">
+            {o.source === 'tracked' ? '◆' : '○'} {o.label}
+            {!disabled && (
+              <button onClick={() => remove(o)} className="ml-0.5 rounded-full hover:bg-muted-foreground/20" aria-label={`Remove ${o.label}`}>
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </Badge>
+        ))}
+        {!disabled && (!single || value.length === 0) && (
+          <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm" className="h-6 gap-1 px-2 text-xs">
+                <Plus className="h-3 w-3" />
+                Add
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-72 p-2">
+              <Input
+                placeholder="Search metrics…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                autoFocus
+                className="mb-2"
+              />
+              <div className="max-h-56 space-y-1 overflow-auto">
+                {filtered.length === 0 ? (
+                  <p className="py-4 text-center text-xs text-muted-foreground">
+                    {options.length === 0 ? 'No metrics available.' : 'No matches.'}
+                  </p>
+                ) : (
+                  filtered.map((o) => (
+                    <button
+                      key={optionKey(o)}
+                      onClick={() => add(o)}
+                      className="flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted"
+                    >
+                      <span className="truncate">{o.label}</span>
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {o.source === 'tracked' ? 'catalog' : 'canvas'}
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/strategy/components/StrategyTable.tsx
+++ b/src/features/strategy/components/StrategyTable.tsx
@@ -41,6 +41,7 @@ import {
   MessageSquare,
   MoreVertical,
   Plus,
+  Target,
   Trash2,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -61,6 +62,7 @@ export interface StrategyTableHandlers {
   onDueDateChange: (cardId: string, iso: string | undefined) => void;
   onOpenCard: (cardId: string) => void;
   onOpenComments: (cardId: string) => void;
+  onOpenImpact: (cardId: string) => void;
   onCreateItem: (category: MetricCard['category'], status: WorkflowStatus) => void;
   onDeleteCard: (cardId: string) => void;
 }
@@ -103,6 +105,7 @@ export function StrategyTable({
   onDueDateChange,
   onOpenCard,
   onOpenComments,
+  onOpenImpact,
   onCreateItem,
   onDeleteCard,
 }: StrategyTableProps) {
@@ -321,6 +324,12 @@ export function StrategyTable({
                                   onSelect={() => onOpenComments(card.id)}
                                 >
                                   Discussion
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onSelect={() => onOpenImpact(card.id)}
+                                >
+                                  <Target className="mr-2 h-4 w-4" />
+                                  Impact
                                 </DropdownMenuItem>
                                 {canEdit && (
                                   <>

--- a/src/features/strategy/pages/StrategyPage.tsx
+++ b/src/features/strategy/pages/StrategyPage.tsx
@@ -29,6 +29,7 @@ import { resolveGroupMembers } from '@/features/dashboard/utils/groupDashboard';
 import { StrategyBoard } from '@/features/strategy/components/StrategyBoard';
 import { StrategyTable } from '@/features/strategy/components/StrategyTable';
 import { CardCommentSheet } from '@/features/strategy/components/CardCommentSheet';
+import { StrategyImpactSheet } from '@/features/strategy/components/StrategyImpactSheet';
 import { ValueJourneyStrip } from '@/features/strategy/components/ValueJourneyStrip';
 import { TaskPanel } from '@/features/canvas/components/panels/task-panel/TaskPanel';
 import {
@@ -79,6 +80,7 @@ export default function StrategyPage() {
 
   const [settingsCardId, setSettingsCardId] = useState<string | null>(null);
   const [commentCardId, setCommentCardId] = useState<string | null>(null);
+  const [impactCardId, setImpactCardId] = useState<string | null>(null);
 
   // Prefer the live in-canvas store when it matches this canvas (fresher,
   // holds unsaved edits); otherwise fall back to what we loaded from the DB.
@@ -450,6 +452,7 @@ export default function StrategyPage() {
           onDueDateChange={handleDueDateChange}
           onOpenCard={setSettingsCardId}
           onOpenComments={setCommentCardId}
+          onOpenImpact={setImpactCardId}
           onCreateItem={handleCreateItem}
           onDeleteCard={handleDeleteCard}
         />
@@ -474,6 +477,16 @@ export default function StrategyPage() {
         open={Boolean(commentCardId)}
         onOpenChange={(open) => !open && setCommentCardId(null)}
         onClosed={refreshCommentCounts}
+      />
+      <StrategyImpactSheet
+        cardId={impactCardId}
+        cardTitle={cards.find((c) => c.id === impactCardId)?.title}
+        projectId={canvasId}
+        cards={cards}
+        relationships={edges}
+        canEdit={canEdit}
+        open={Boolean(impactCardId)}
+        onOpenChange={(open) => !open && setImpactCardId(null)}
       />
     </div>
   );


### PR DESCRIPTION
Closes **CVS-169** (Strategy impact — Milestone 2: Strategy UX). **Stacked on [#60](https://github.com/nadeemramli/metrimap/pull/60) → [#59](https://github.com/nadeemramli/metrimap/pull/59)** — review/merge those first; base auto-retargets.

## What
A right-side **Impact panel** for an Action/Hypothesis, opened from the Strategy table row menu (**⋮ → Impact**).

- **`StrategyImpactSheet.tsx`** — edit the impact contract:
  - target / leading / guardrail metric pickers (choose **catalog tracked metrics** or **canvas metric cards**; guardrails + leading support multiples),
  - expected direction + delta (value & %/abs), baseline period, measurement window, confidence, impact status, result note;
  - live **`Action → Target → KPI`** preview via the CVS-168 resolver; empty state “Add a target metric to measure impact.”; **read-only when the user can’t edit**.
- Persists via the CVS-167 service (`upsertContract` + `setMetricLinks`, idempotent per node); load-on-open.
- `StrategyTable` gains an **Impact** row action (`onOpenImpact`); `StrategyPage` renders the sheet with the canvas cards + relationships.

Self-contained in `src/features/strategy/*` — the shared `TaskPanel`/canvas code is untouched.

## Verification
- `type-check` ✅ · `lint` ✅ · **full `vitest` 184/184** ✅ (adds 3 component tests: empty state, field editing, edit-permission gating).
- Migration for the underlying tables **is applied** to `metrimap-v2`, so this persists end-to-end once merged.

Backward compatible: work cards without a contract render exactly as before. Dashboard badges + full trace view are CVS-172/173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)