### PR TITLE
feat(evidence): custom notebook blocks /note + /node (CVS-34 slice 4.1)

### DIFF
--- a/src/features/evidence/blocks/NodeRefBlock.ts
+++ b/src/features/evidence/blocks/NodeRefBlock.ts
@@ -1,0 +1,164 @@
+// Custom EditorJS block: /node — embed a reference to a metric card/node (CVS-34
+// slice 4.1). Stores the card id + a snapshot (title/category) so it still renders
+// if the card is later deleted; resolves live from the canvas store when present.
+// Plain DOM; reads the store via getState() (works outside React).
+import { useCanvasStore } from '@/lib/stores';
+
+interface NodeRefData {
+  cardId: string;
+  title?: string;
+  category?: string;
+}
+
+interface BlockToolArgs {
+  data: Partial<NodeRefData>;
+  readOnly?: boolean;
+}
+
+function cards() {
+  return useCanvasStore.getState().canvas?.nodes ?? [];
+}
+
+export default class NodeRefBlock {
+  static get toolbox() {
+    return {
+      title: 'Node',
+      icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="8" width="18" height="8" rx="2"/><path d="M7 12h.01M11 12h6"/></svg>',
+    };
+  }
+
+  static get isReadOnlySupported() {
+    return true;
+  }
+
+  static get sanitize() {
+    return { cardId: false, title: false, category: false };
+  }
+
+  private data: NodeRefData;
+  private readOnly: boolean;
+  private wrapper: HTMLElement | null = null;
+
+  constructor({ data, readOnly }: BlockToolArgs) {
+    this.data = {
+      cardId: data?.cardId ?? '',
+      title: data?.title,
+      category: data?.category,
+    };
+    this.readOnly = Boolean(readOnly);
+  }
+
+  private rebuild() {
+    if (!this.wrapper) return;
+    this.wrapper.innerHTML = '';
+    if (!this.readOnly && !this.data.cardId) {
+      this.wrapper.appendChild(this.renderPicker());
+    } else {
+      this.wrapper.appendChild(this.renderChip());
+    }
+  }
+
+  private renderPicker(): HTMLElement {
+    const list = cards();
+    const box = document.createElement('div');
+    box.style.cssText =
+      'padding:8px;border:1px dashed #cbd5e1;border-radius:8px;background:#f8fafc;';
+    if (list.length === 0) {
+      box.textContent = 'No nodes on this canvas to reference.';
+      box.style.color = '#94a3b8';
+      box.style.fontSize = '13px';
+      return box;
+    }
+    const label = document.createElement('div');
+    label.textContent = 'Reference a node';
+    label.style.cssText =
+      'font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#94a3b8;margin-bottom:4px;';
+    box.appendChild(label);
+
+    const select = document.createElement('select');
+    select.style.cssText =
+      'width:100%;padding:6px 8px;border:1px solid #e2e8f0;border-radius:6px;font-size:14px;background:#fff;';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Select a node…';
+    select.appendChild(placeholder);
+    list.forEach((c: any) => {
+      const opt = document.createElement('option');
+      opt.value = c.id;
+      opt.textContent = c.title || 'Untitled';
+      select.appendChild(opt);
+    });
+    select.onchange = () => {
+      const card = list.find((c: any) => c.id === select.value);
+      if (card) {
+        this.data = {
+          cardId: card.id,
+          title: (card as any).title,
+          category: (card as any).category,
+        };
+        this.rebuild();
+      }
+    };
+    box.appendChild(select);
+    return box;
+  }
+
+  private renderChip(): HTMLElement {
+    const live = cards().find((c: any) => c.id === this.data.cardId) as any;
+    const title = live?.title || this.data.title || 'Unknown node';
+    const category = live?.category || this.data.category || 'Node';
+    const projectId = useCanvasStore.getState().canvas?.id;
+
+    const chip = document.createElement(this.readOnly ? 'a' : 'div');
+    chip.className = 'cm-node-ref';
+    chip.style.cssText =
+      'display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid #e2e8f0;border-radius:8px;background:#fff;font-size:14px;color:#0f172a;text-decoration:none;max-width:100%;';
+    if (this.readOnly && projectId) {
+      (chip as HTMLAnchorElement).href = `/canvas/${projectId}?focus=card:${this.data.cardId}`;
+    }
+
+    const dot = document.createElement('span');
+    dot.style.cssText =
+      'width:8px;height:8px;border-radius:9999px;background:#6366f1;flex:0 0 auto;';
+    chip.appendChild(dot);
+
+    const text = document.createElement('span');
+    text.style.cssText = 'font-weight:600;';
+    text.textContent = title;
+    chip.appendChild(text);
+
+    const cat = document.createElement('span');
+    cat.textContent = category;
+    cat.style.cssText =
+      'font-size:11px;color:#64748b;background:#f1f5f9;padding:1px 6px;border-radius:9999px;';
+    chip.appendChild(cat);
+
+    if (!this.readOnly) {
+      const change = document.createElement('button');
+      change.type = 'button';
+      change.textContent = 'change';
+      change.style.cssText =
+        'margin-left:4px;font-size:11px;color:#94a3b8;background:none;border:none;cursor:pointer;';
+      change.onclick = (e) => {
+        e.preventDefault();
+        this.data = { cardId: '' };
+        this.rebuild();
+      };
+      chip.appendChild(change);
+    }
+    return chip;
+  }
+
+  render(): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'cm-node-ref-block';
+    wrapper.style.cssText = 'margin:6px 0;';
+    this.wrapper = wrapper;
+    this.rebuild();
+    return wrapper;
+  }
+
+  save(): NodeRefData {
+    return this.data;
+  }
+}

--- a/src/features/evidence/blocks/NoteBlock.ts
+++ b/src/features/evidence/blocks/NoteBlock.ts
@@ -1,0 +1,120 @@
+// Custom EditorJS block: /note — a Metrimap callout for the analytical notebook
+// (CVS-34 slice 4.1). Marks a note / decision / insight in the narrative. Plain
+// DOM (no React) so it's robust inside EditorJS's DOM-based rendering and works
+// identically in the editor and the read-only preview/renderer.
+
+type NoteVariant = 'note' | 'decision' | 'insight';
+
+interface NoteData {
+  text: string;
+  variant: NoteVariant;
+}
+
+const VARIANTS: Record<
+  NoteVariant,
+  { label: string; border: string; bg: string; fg: string }
+> = {
+  note: { label: 'Note', border: '#c7d2fe', bg: '#eef2ff', fg: '#4338ca' },
+  decision: { label: 'Decision', border: '#bbf7d0', bg: '#f0fdf4', fg: '#15803d' },
+  insight: { label: 'Insight', border: '#fde68a', bg: '#fffbeb', fg: '#b45309' },
+};
+
+interface BlockToolArgs {
+  data: Partial<NoteData>;
+  readOnly?: boolean;
+}
+
+export default class NoteBlock {
+  static get toolbox() {
+    return {
+      title: 'Note',
+      icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16v12H8l-4 4z"/></svg>',
+    };
+  }
+
+  static get isReadOnlySupported() {
+    return true;
+  }
+
+  static get sanitize() {
+    return { text: { br: true, b: true, i: true, u: true, a: true }, variant: false };
+  }
+
+  private data: NoteData;
+  private readOnly: boolean;
+  private wrapper: HTMLElement | null = null;
+
+  constructor({ data, readOnly }: BlockToolArgs) {
+    this.data = {
+      text: data?.text ?? '',
+      variant: (data?.variant as NoteVariant) ?? 'note',
+    };
+    this.readOnly = Boolean(readOnly);
+  }
+
+  private applyStyles() {
+    const v = VARIANTS[this.data.variant];
+    const w = this.wrapper!;
+    w.style.borderLeft = `3px solid ${v.border}`;
+    w.style.background = v.bg;
+    const label = w.querySelector<HTMLElement>('.cm-note-label');
+    if (label) {
+      label.textContent = v.label;
+      label.style.color = v.fg;
+    }
+  }
+
+  render(): HTMLElement {
+    const wrapper = document.createElement('div');
+    this.wrapper = wrapper;
+    wrapper.className = 'cm-note-block';
+    wrapper.style.cssText =
+      'border-radius:8px;padding:10px 14px;margin:6px 0;font-size:14px;';
+
+    const header = document.createElement('div');
+    header.style.cssText =
+      'display:flex;align-items:center;gap:8px;margin-bottom:4px;';
+
+    const label = document.createElement('span');
+    label.className = 'cm-note-label';
+    label.style.cssText =
+      'font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.05em;';
+    header.appendChild(label);
+
+    if (!this.readOnly) {
+      (Object.keys(VARIANTS) as NoteVariant[]).forEach((key) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = VARIANTS[key].label;
+        btn.style.cssText =
+          'font-size:10px;padding:1px 6px;border-radius:6px;border:1px solid #e5e7eb;background:#fff;cursor:pointer;color:#6b7280;';
+        btn.onclick = (e) => {
+          e.preventDefault();
+          this.data.variant = key;
+          this.applyStyles();
+        };
+        header.appendChild(btn);
+      });
+    }
+    wrapper.appendChild(header);
+
+    const text = document.createElement('div');
+    text.className = 'cm-note-text';
+    text.contentEditable = this.readOnly ? 'false' : 'true';
+    text.innerHTML = this.data.text;
+    text.dataset.placeholder = 'Write a note, decision or insight…';
+    text.style.cssText = 'outline:none;color:#374151;line-height:1.55;';
+    wrapper.appendChild(text);
+
+    this.applyStyles();
+    return wrapper;
+  }
+
+  save(block: HTMLElement): NoteData {
+    const text = block.querySelector<HTMLElement>('.cm-note-text');
+    return {
+      text: text ? text.innerHTML : this.data.text,
+      variant: this.data.variant,
+    };
+  }
+}

--- a/src/lib/editorjs-config.ts
+++ b/src/lib/editorjs-config.ts
@@ -27,6 +27,9 @@ import Paragraph from "@editorjs/paragraph";
 import EJLaTeX from "editorjs-latex";
 import TOC from "@phigoro/editorjs-toc";
 import NestedChecklist from "@calumk/editorjs-nested-checklist";
+// Metrimap custom analytical-notebook blocks (CVS-34 slice 4)
+import NoteBlock from "@/features/evidence/blocks/NoteBlock";
+import NodeRefBlock from "@/features/evidence/blocks/NodeRefBlock";
 // Note: DragDrop and Undo are problematic, we'll implement them later
 
 export interface EditorJSConfigOptions {
@@ -66,7 +69,10 @@ export const VALID_BLOCK_TYPES = [
   "hyperlink",
   "changeCase",
   "latex",
-  "toc"
+  "toc",
+  // Metrimap analytical-notebook blocks (CVS-34 slice 4)
+  "note",
+  "metricNode"
 ] as const;
 
 export type ValidBlockType = typeof VALID_BLOCK_TYPES[number];
@@ -269,6 +275,13 @@ export const createEditorJSTools = () => {
         showLocaleOption: true,
         locale: 'en'
       },
+    },
+    // Metrimap analytical-notebook blocks (CVS-34 slice 4)
+    note: {
+      class: NoteBlock as any,
+    },
+    metricNode: {
+      class: NodeRefBlock as any,
     },
   };
 };


### PR DESCRIPTION
**Slice 4.1 of CVS-34 / [CVS-197]** — first analytical-notebook blocks + the custom-block scaffold.

## What
- New `src/features/evidence/blocks/` — plain-DOM EditorJS `BlockTool` classes (robust inside EditorJS; work identically in editor + read-only renderer).
- **`/note`** — Note / Decision / Insight callout (contenteditable + variant switcher).
- **`/node`** — reference a metric card: picker built from the canvas store (`useCanvasStore.getState()`) → chip (title + category, "focus on canvas" link when read-only). Persists `cardId` + a `{title, category}` snapshot so it survives card deletion; resolves live when the card exists.
- Registered in `editorjs-config.ts` → `createEditorJSTools()` **and** `VALID_BLOCK_TYPES` (otherwise `validateAndMigrateEditorData` strips them). Both editor + read-only instances share the tool registry, so these render on the on-canvas Evidence card + full view automatically — building on slices 1–3 (content persists to the DB).

## Verification
type-check ✓, lint ✓ (0 errors), **full `npm run build` ✓**. Runtime behaviour (insert / persist / read-only render) covered by the manual-test sub-issue since custom EditorJS blocks can't be unit-tested here.

## Next (per the build plan)
4.2 `/relationship` + `/metric` → 4.3 `/chart` → 4.4 `/snapshot` → 4.5 `/source` `/evidence` `/hypothesis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)