### PR TITLE
CVS-64: clear ESLint errors + gate full-repo lint

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,8 @@
 # Quality gate on every commit (there is no CI yet):
-#   1. lint-staged — ESLint on the files this commit touches (errors block;
-#      the repo's pre-existing lint debt in untouched files does not — see CVS-64).
-#   2. type-check   — whole-repo tsc (fast, currently clean).
-#   3. tests        — the full Vitest suite (jsdom, no browser).
-npx lint-staged &&
+#   1. lint       — full-repo ESLint, 0 errors enforced (CVS-64 cleared the debt,
+#      so any new error anywhere blocks the commit). Warnings don't block.
+#   2. type-check — whole-repo tsc.
+#   3. tests      — the full Vitest suite (jsdom, no browser).
+npm run lint &&
 npm run type-check &&
 npx vitest run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ npx supabase <cmd>   # Always use npx for the Supabase CLI
 
 A single Husky **`pre-commit`** hook gates quality on every commit (there is no CI yet — this is the safety net). Don't bypass it without reason. It runs, in order:
 
-1. `lint-staged` — ESLint on just the files the commit touches. Because it's staged-scoped, the repo's pre-existing lint debt in untouched files won't block you (tracked in **CVS-64**) — but new/edited files must be lint-clean.
-2. `npm run type-check` — whole-repo `tsc` (fast, currently clean).
+1. `npm run lint` — full-repo ESLint, **0 errors enforced** (CVS-64 cleared the pre-existing error debt, so any new error anywhere blocks the commit; warnings don't block).
+2. `npm run type-check` — whole-repo `tsc`.
 3. `vitest run` — the full Vitest suite (jsdom, no browser — Storybook/Chromium was removed, so tests are fast).
 
 ## Branching

--- a/src/features/canvas/components/CanvasDebugPanels.tsx
+++ b/src/features/canvas/components/CanvasDebugPanels.tsx
@@ -26,11 +26,11 @@ export default function CanvasDebugPanels({
   canvas,
   isDevelopment,
 }: CanvasDebugPanelsProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
   if (!isDevelopment && !import.meta.env.DEV) {
     return null;
   }
-
-  const [isOpen, setIsOpen] = useState(true);
 
   return (
     <>

--- a/src/features/canvas/components/edges/RelationshipWorkflows.tsx
+++ b/src/features/canvas/components/edges/RelationshipWorkflows.tsx
@@ -426,20 +426,7 @@ export default function RelationshipWorkflows({
   const config = getWorkflowConfig(type);
   const [workflowData, setWorkflowData] = useState<any>({});
 
-  if (!config) return null;
-
-  const Icon = config.icon;
-
-  const handleTemplateChange = (field: string, value: string) => {
-    setWorkflowData((prev: any) => ({ ...prev, [field]: value }));
-  };
-
-  const handleUpgradeToCausal = () => {
-    if (onTypeUpgrade) {
-      onTypeUpgrade("Causal");
-    }
-  };
-
+  // Hooks must run before the early return below (Rules of Hooks).
   const validateAndSuggestConfidence = useCallback(() => {
     // Auto-suggest confidence based on workflow completion
     let suggestedConfidence: ConfidenceLevel = "Low";
@@ -452,7 +439,7 @@ export default function RelationshipWorkflows({
           suggestedConfidence = "Medium";
         }
         break;
-      case "Probabilistic":
+      case "Probabilistic": {
         const r = parseFloat(workflowData.correlationCoefficient);
         const n = parseInt(workflowData.sampleSize);
         const p = parseFloat(workflowData.pValue);
@@ -463,6 +450,7 @@ export default function RelationshipWorkflows({
           suggestedConfidence = "Medium";
         }
         break;
+      }
       case "Causal":
         if (
           workflowData.experimentType === "RCT" &&
@@ -485,6 +473,20 @@ export default function RelationshipWorkflows({
 
     onConfidenceChange(suggestedConfidence);
   }, [type, workflowData, onConfidenceChange]);
+
+  if (!config) return null;
+
+  const Icon = config.icon;
+
+  const handleTemplateChange = (field: string, value: string) => {
+    setWorkflowData((prev: any) => ({ ...prev, [field]: value }));
+  };
+
+  const handleUpgradeToCausal = () => {
+    if (onTypeUpgrade) {
+      onTypeUpgrade("Causal");
+    }
+  };
 
   const generateTemplateEvidence = () => {
     const evidence: EvidenceItem = {

--- a/src/features/canvas/components/layout/CanvasDebugPanels.tsx
+++ b/src/features/canvas/components/layout/CanvasDebugPanels.tsx
@@ -22,12 +22,12 @@ export default function CanvasDebugPanels({
   canvas,
   isDevelopment,
 }: CanvasDebugPanelsProps) {
+  // Local toggle for collapsing the Debug State panel (dev only)
+  const [isOpen, setIsOpen] = useState(true);
+
   if (!isDevelopment && !import.meta.env.DEV) {
     return null;
   }
-
-  // Local toggle for collapsing the Debug State panel (dev only)
-  const [isOpen, setIsOpen] = useState(true);
 
   return (
     <>

--- a/src/features/canvas/components/nodes/metric-node/DimensionSliceModal.tsx
+++ b/src/features/canvas/components/nodes/metric-node/DimensionSliceModal.tsx
@@ -33,7 +33,7 @@ export default function DimensionSliceModal({
   const candidateDimensions = Array.from(
     new Set(
       (parentCard.dimensions ?? [])
-        .map((d: any) => (typeof d === 'string' ? d : d?.name).trim())
+        .map((d: any) => (typeof d === 'string' ? d : (d?.name ?? '')).trim())
         .filter(Boolean)
     )
   ) as string[];

--- a/src/features/evidence/components/EvidenceEditor.tsx
+++ b/src/features/evidence/components/EvidenceEditor.tsx
@@ -137,7 +137,9 @@ export default function EvidenceEditor({
       try {
         const content = await editorRef.current!.save();
         autoSave(content, formData);
-      } catch {}
+      } catch {
+        /* EditorJS save can race during unmount — safe to ignore */
+      }
     }, 100);
   }, [autoSave, formData]);
 
@@ -200,7 +202,9 @@ export default function EvidenceEditor({
       if (editorRef.current) {
         try {
           editorRef.current.destroy();
-        } catch {}
+        } catch {
+          /* EditorJS save/teardown can race during unmount — safe to ignore */
+        }
         editorRef.current = null;
       }
     };

--- a/src/lib/workers/compute.worker.ts
+++ b/src/lib/workers/compute.worker.ts
@@ -386,10 +386,11 @@ const computationWorker: ComputationWorker = {
       case 'sum':
         return data.reduce((sum, item) => sum + (typeof item === 'number' ? item : 0), 0);
       
-      case 'average':
+      case 'average': {
         const numbers = data.filter(item => typeof item === 'number');
         return numbers.length > 0 ? numbers.reduce((sum, num) => sum + num, 0) / numbers.length : 0;
-      
+      }
+
       case 'group':
         return data.reduce((groups, item) => {
           const key = item.category || 'uncategorized';

--- a/src/lib/workers/worker-manager.ts
+++ b/src/lib/workers/worker-manager.ts
@@ -361,10 +361,11 @@ class WorkerManager {
         case 'sum':
           return data.reduce((sum, item) => sum + (typeof item === 'number' ? item : 0), 0);
         
-        case 'average':
+        case 'average': {
           const numbers = data.filter(item => typeof item === 'number');
           return numbers.length > 0 ? numbers.reduce((sum, num) => sum + num, 0) / numbers.length : 0;
-        
+        }
+
         case 'group':
           return data.reduce((groups, item) => {
             const key = item.category || 'uncategorized';

--- a/src/shared/hooks/useAssetsFiltering.ts
+++ b/src/shared/hooks/useAssetsFiltering.ts
@@ -92,7 +92,7 @@ export function useAssetsFiltering({
     return filtered.sort((a: Relationship, b: Relationship) => {
       const multiplier = sortOrder === 'asc' ? 1 : -1;
       switch (sortField) {
-        case 'name':
+        case 'name': {
           const sourceNodeA = metrics.find(
             (m: MetricCard) => m.id === a.sourceId
           );
@@ -108,6 +108,7 @@ export function useAssetsFiltering({
           const nameA = `${sourceNodeA?.title || 'Unknown'} → ${targetNodeA?.title || 'Unknown'}`;
           const nameB = `${sourceNodeB?.title || 'Unknown'} → ${targetNodeB?.title || 'Unknown'}`;
           return nameA.localeCompare(nameB) * multiplier;
+        }
         case 'type':
           return a.type.localeCompare(b.type) * multiplier;
         case 'confidence':

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 const config: Config = {
   darkMode: "class",
@@ -79,7 +80,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 };
 
 export default config;


### PR DESCRIPTION
Closes CVS-64.

Cleared the remaining **18 ESLint errors** so `npm run lint` exits 0, and upgraded the pre-commit hook to enforce it **repo-wide** (the staged-only workaround is retired).

## Fixes
- **3 `react-hooks/rules-of-hooks`** — relocated hooks above early returns (RelationshipWorkflows `useCallback`; both CanvasDebugPanels `useState`). Behavior-neutral (call order only).
- **11 `no-case-declarations`** — braced case blocks (useAssetsFiltering, RelationshipWorkflows, compute.worker, worker-manager).
- **2 `no-empty`** — documented the intentional EditorJS teardown/save catches.
- **1 `no-unsafe-optional-chaining`** — guard `d?.name` before `.trim()`.
- **1 `no-require-imports`** — `tailwind.config` → `import tailwindcss-animate`.

## Hook change (⚠️ affects everyone)
`.husky/pre-commit` now runs **`npm run lint`** (full-repo, 0-error gate) instead of `lint-staged`; AGENTS.md updated. **Any new error anywhere now blocks a commit** (warnings don't). Verified 0 errors on latest `main`.

Verify: `npm run lint` exits 0 · type-check clean · 166 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)