### PR TITLE
feat(evidence): notebook blocks /relationship + /metric (CVS-34 slice 4.2)

### DIFF
--- a/src/features/evidence/blocks/MetricRefBlock.ts
+++ b/src/features/evidence/blocks/MetricRefBlock.ts
@@ -1,0 +1,168 @@
+// Custom EditorJS block: /metric — embed a metric card's current value (CVS-34
+// slice 4.2). Stores cardId + a snapshot of the latest value/trend; resolves the
+// live latest value from the canvas store (card.data: MetricValue[]) when present.
+import { useCanvasStore } from '@/lib/stores';
+
+interface MetricRefData {
+  cardId: string;
+  title?: string;
+  value?: number;
+  trend?: string;
+  period?: string;
+}
+
+interface BlockToolArgs {
+  data: Partial<MetricRefData>;
+  readOnly?: boolean;
+}
+
+function nodes(): any[] {
+  return useCanvasStore.getState().canvas?.nodes ?? [];
+}
+function latest(card: any): { value?: number; trend?: string; period?: string } {
+  const arr = (card?.data ?? []) as any[];
+  return arr.length ? arr[arr.length - 1] : {};
+}
+const TREND: Record<string, string> = { up: '▲', down: '▼', neutral: '—' };
+
+export default class MetricRefBlock {
+  static get toolbox() {
+    return {
+      title: 'Metric',
+      icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 17l6-6 4 4 7-7"/></svg>',
+    };
+  }
+
+  static get isReadOnlySupported() {
+    return true;
+  }
+
+  static get sanitize() {
+    return {
+      cardId: false,
+      title: false,
+      value: false,
+      trend: false,
+      period: false,
+    };
+  }
+
+  private data: MetricRefData;
+  private readOnly: boolean;
+  private wrapper: HTMLElement | null = null;
+
+  constructor({ data, readOnly }: BlockToolArgs) {
+    this.data = { cardId: data?.cardId ?? '', ...data };
+    this.readOnly = Boolean(readOnly);
+  }
+
+  private rebuild() {
+    if (!this.wrapper) return;
+    this.wrapper.innerHTML = '';
+    this.wrapper.appendChild(
+      !this.readOnly && !this.data.cardId
+        ? this.renderPicker()
+        : this.renderChip()
+    );
+  }
+
+  private renderPicker(): HTMLElement {
+    const list = nodes();
+    const box = document.createElement('div');
+    box.style.cssText =
+      'padding:8px;border:1px dashed #cbd5e1;border-radius:8px;background:#f8fafc;';
+    if (list.length === 0) {
+      box.textContent = 'No metric cards on this canvas to reference.';
+      box.style.cssText += 'color:#94a3b8;font-size:13px;';
+      return box;
+    }
+    const select = document.createElement('select');
+    select.style.cssText =
+      'width:100%;padding:6px 8px;border:1px solid #e2e8f0;border-radius:6px;font-size:14px;background:#fff;';
+    const ph = document.createElement('option');
+    ph.value = '';
+    ph.textContent = 'Select a metric…';
+    select.appendChild(ph);
+    list.forEach((c: any) => {
+      const opt = document.createElement('option');
+      opt.value = c.id;
+      opt.textContent = c.title || 'Untitled';
+      select.appendChild(opt);
+    });
+    select.onchange = () => {
+      const c = list.find((x: any) => x.id === select.value);
+      if (c) {
+        const l = latest(c);
+        this.data = {
+          cardId: c.id,
+          title: c.title,
+          value: l.value,
+          trend: l.trend,
+          period: l.period,
+        };
+        this.rebuild();
+      }
+    };
+    box.appendChild(select);
+    return box;
+  }
+
+  private renderChip(): HTMLElement {
+    const live = nodes().find((c: any) => c.id === this.data.cardId) as any;
+    const l = live ? latest(live) : {};
+    const title = live?.title || this.data.title || 'Unknown metric';
+    const value = l.value ?? this.data.value;
+    const trend = l.trend || this.data.trend;
+
+    const chip = document.createElement('div');
+    chip.style.cssText =
+      'display:inline-flex;align-items:baseline;gap:8px;padding:6px 12px;border:1px solid #e2e8f0;border-radius:8px;background:#fff;font-size:14px;color:#0f172a;';
+
+    const name = document.createElement('span');
+    name.textContent = title;
+    name.style.color = '#64748b';
+    chip.appendChild(name);
+
+    const val = document.createElement('span');
+    val.style.cssText = 'font-weight:700;font-size:16px;';
+    val.textContent =
+      value === undefined || value === null
+        ? '—'
+        : value.toLocaleString();
+    chip.appendChild(val);
+
+    if (trend && TREND[trend]) {
+      const tr = document.createElement('span');
+      tr.textContent = TREND[trend];
+      tr.style.color =
+        trend === 'up' ? '#16a34a' : trend === 'down' ? '#dc2626' : '#94a3b8';
+      chip.appendChild(tr);
+    }
+    if (!this.readOnly) {
+      const change = document.createElement('button');
+      change.type = 'button';
+      change.textContent = 'change';
+      change.style.cssText =
+        'margin-left:4px;font-size:11px;color:#94a3b8;background:none;border:none;cursor:pointer;';
+      change.onclick = (ev) => {
+        ev.preventDefault();
+        this.data = { cardId: '' };
+        this.rebuild();
+      };
+      chip.appendChild(change);
+    }
+    return chip;
+  }
+
+  render(): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.style.margin = '6px 0';
+    this.wrapper = wrapper;
+    this.rebuild();
+    return wrapper;
+  }
+
+  save(): MetricRefData {
+    return this.data;
+  }
+}

--- a/src/features/evidence/blocks/RelationshipRefBlock.ts
+++ b/src/features/evidence/blocks/RelationshipRefBlock.ts
@@ -1,0 +1,169 @@
+// Custom EditorJS block: /relationship — embed a reference to a relationship/edge
+// (CVS-34 slice 4.2). Stores the relationship id + a snapshot (endpoints/type/
+// confidence) so it survives deletion; resolves live from the canvas store.
+import { useCanvasStore } from '@/lib/stores';
+
+interface RelationshipRefData {
+  relationshipId: string;
+  source?: string;
+  target?: string;
+  type?: string;
+  confidence?: string;
+}
+
+interface BlockToolArgs {
+  data: Partial<RelationshipRefData>;
+  readOnly?: boolean;
+}
+
+function edges(): any[] {
+  return useCanvasStore.getState().canvas?.edges ?? [];
+}
+function nodeTitle(id: string): string {
+  const n = (useCanvasStore.getState().canvas?.nodes ?? []).find(
+    (c: any) => c.id === id
+  ) as any;
+  return n?.title || 'Unknown';
+}
+
+export default class RelationshipRefBlock {
+  static get toolbox() {
+    return {
+      title: 'Relationship',
+      icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="12" r="2.5"/><circle cx="19" cy="12" r="2.5"/><path d="M7.5 12h9"/></svg>',
+    };
+  }
+
+  static get isReadOnlySupported() {
+    return true;
+  }
+
+  static get sanitize() {
+    return {
+      relationshipId: false,
+      source: false,
+      target: false,
+      type: false,
+      confidence: false,
+    };
+  }
+
+  private data: RelationshipRefData;
+  private readOnly: boolean;
+  private wrapper: HTMLElement | null = null;
+
+  constructor({ data, readOnly }: BlockToolArgs) {
+    this.data = { relationshipId: data?.relationshipId ?? '', ...data };
+    this.readOnly = Boolean(readOnly);
+  }
+
+  private rebuild() {
+    if (!this.wrapper) return;
+    this.wrapper.innerHTML = '';
+    this.wrapper.appendChild(
+      !this.readOnly && !this.data.relationshipId
+        ? this.renderPicker()
+        : this.renderChip()
+    );
+  }
+
+  private renderPicker(): HTMLElement {
+    const list = edges();
+    const box = document.createElement('div');
+    box.style.cssText =
+      'padding:8px;border:1px dashed #cbd5e1;border-radius:8px;background:#f8fafc;';
+    if (list.length === 0) {
+      box.textContent = 'No relationships on this canvas to reference.';
+      box.style.cssText += 'color:#94a3b8;font-size:13px;';
+      return box;
+    }
+    const select = document.createElement('select');
+    select.style.cssText =
+      'width:100%;padding:6px 8px;border:1px solid #e2e8f0;border-radius:6px;font-size:14px;background:#fff;';
+    const ph = document.createElement('option');
+    ph.value = '';
+    ph.textContent = 'Select a relationship…';
+    select.appendChild(ph);
+    list.forEach((e: any) => {
+      const opt = document.createElement('option');
+      opt.value = e.id;
+      opt.textContent = `${nodeTitle(e.sourceId)} → ${nodeTitle(e.targetId)}`;
+      select.appendChild(opt);
+    });
+    select.onchange = () => {
+      const e = list.find((x: any) => x.id === select.value);
+      if (e) {
+        this.data = {
+          relationshipId: e.id,
+          source: nodeTitle(e.sourceId),
+          target: nodeTitle(e.targetId),
+          type: e.type,
+          confidence: e.confidence,
+        };
+        this.rebuild();
+      }
+    };
+    box.appendChild(select);
+    return box;
+  }
+
+  private renderChip(): HTMLElement {
+    const live = edges().find(
+      (e: any) => e.id === this.data.relationshipId
+    ) as any;
+    const source = live ? nodeTitle(live.sourceId) : this.data.source || '—';
+    const target = live ? nodeTitle(live.targetId) : this.data.target || '—';
+    const type = live?.type || this.data.type || '';
+    const confidence = live?.confidence || this.data.confidence || '';
+
+    const chip = document.createElement('div');
+    chip.style.cssText =
+      'display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid #e2e8f0;border-radius:8px;background:#fff;font-size:14px;color:#0f172a;';
+
+    const flow = document.createElement('span');
+    flow.style.fontWeight = '600';
+    flow.textContent = `${source} → ${target}`;
+    chip.appendChild(flow);
+
+    if (type) {
+      const t = document.createElement('span');
+      t.textContent = type;
+      t.style.cssText =
+        'font-size:11px;color:#64748b;background:#f1f5f9;padding:1px 6px;border-radius:9999px;';
+      chip.appendChild(t);
+    }
+    if (confidence) {
+      const c = document.createElement('span');
+      c.textContent = confidence;
+      c.style.cssText =
+        'font-size:11px;color:#0369a1;background:#e0f2fe;padding:1px 6px;border-radius:9999px;';
+      chip.appendChild(c);
+    }
+    if (!this.readOnly) {
+      const change = document.createElement('button');
+      change.type = 'button';
+      change.textContent = 'change';
+      change.style.cssText =
+        'margin-left:4px;font-size:11px;color:#94a3b8;background:none;border:none;cursor:pointer;';
+      change.onclick = (ev) => {
+        ev.preventDefault();
+        this.data = { relationshipId: '' };
+        this.rebuild();
+      };
+      chip.appendChild(change);
+    }
+    return chip;
+  }
+
+  render(): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.style.margin = '6px 0';
+    this.wrapper = wrapper;
+    this.rebuild();
+    return wrapper;
+  }
+
+  save(): RelationshipRefData {
+    return this.data;
+  }
+}

--- a/src/lib/editorjs-config.ts
+++ b/src/lib/editorjs-config.ts
@@ -30,6 +30,8 @@ import NestedChecklist from "@calumk/editorjs-nested-checklist";
 // Metrimap custom analytical-notebook blocks (CVS-34 slice 4)
 import NoteBlock from "@/features/evidence/blocks/NoteBlock";
 import NodeRefBlock from "@/features/evidence/blocks/NodeRefBlock";
+import RelationshipRefBlock from "@/features/evidence/blocks/RelationshipRefBlock";
+import MetricRefBlock from "@/features/evidence/blocks/MetricRefBlock";
 // Note: DragDrop and Undo are problematic, we'll implement them later
 
 export interface EditorJSConfigOptions {
@@ -72,7 +74,9 @@ export const VALID_BLOCK_TYPES = [
   "toc",
   // Metrimap analytical-notebook blocks (CVS-34 slice 4)
   "note",
-  "metricNode"
+  "metricNode",
+  "relationshipRef",
+  "metricValue"
 ] as const;
 
 export type ValidBlockType = typeof VALID_BLOCK_TYPES[number];
@@ -282,6 +286,12 @@ export const createEditorJSTools = () => {
     },
     metricNode: {
       class: NodeRefBlock as any,
+    },
+    relationshipRef: {
+      class: RelationshipRefBlock as any,
+    },
+    metricValue: {
+      class: MetricRefBlock as any,
     },
   };
 };


### PR DESCRIPTION
**Slice 4.2 of CVS-197** — two more analytical blocks, same pattern as `/node` (4.1).

- **`/relationship`** — pick a relationship/edge → renders `source → target` + type + confidence badge. Resolves endpoint titles + type/confidence live from the canvas store; snapshot fallback if deleted.
- **`/metric`** — pick a metric card → renders its **latest value** (`card.data: MetricValue[]`) + trend arrow (▲/▼/—). Live-resolves; snapshot fallback.

Registered in `createEditorJSTools()` + `VALID_BLOCK_TYPES`.

## Verification
type-check ✓, lint ✓ (0 errors), **full build ✓**. Runtime behaviour in the manual-test sub-issue.

## Next
4.3 `/chart` (embed a dashboard widget / chart), 4.4 `/snapshot` (screenshot capture) — these add a dep + chart rendering, so worth verifying 4.1–4.2 in-app first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)