### PR TITLE
feat(evidence): notebook blocks /hypothesis + /source + /evidence (CVS-34 slice 4.5)

### DIFF
--- a/src/features/evidence/blocks/EvidenceLinkBlock.ts
+++ b/src/features/evidence/blocks/EvidenceLinkBlock.ts
@@ -1,0 +1,135 @@
+// Custom EditorJS block: /evidence — link to another evidence item (CVS-34 slice
+// 4.5). Stores the evidence id + a title snapshot; resolves live from the evidence
+// store. Plain DOM.
+import { useEvidenceStore, useCanvasStore } from '@/lib/stores';
+
+interface EvidenceLinkData {
+  evidenceId: string;
+  title?: string;
+}
+
+interface BlockToolArgs {
+  data: Partial<EvidenceLinkData>;
+  readOnly?: boolean;
+}
+
+function items(): any[] {
+  return useEvidenceStore.getState().evidence ?? [];
+}
+
+export default class EvidenceLinkBlock {
+  static get toolbox() {
+    return {
+      title: 'Evidence',
+      icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h11l5 5v11H4z"/><path d="M15 4v5h5"/></svg>',
+    };
+  }
+  static get isReadOnlySupported() {
+    return true;
+  }
+  static get sanitize() {
+    return { evidenceId: false, title: false };
+  }
+
+  private data: EvidenceLinkData;
+  private readOnly: boolean;
+  private wrapper: HTMLElement | null = null;
+
+  constructor({ data, readOnly }: BlockToolArgs) {
+    this.data = { evidenceId: data?.evidenceId ?? '', title: data?.title };
+    this.readOnly = Boolean(readOnly);
+  }
+
+  private rebuild() {
+    if (!this.wrapper) return;
+    this.wrapper.innerHTML = '';
+    this.wrapper.appendChild(
+      !this.readOnly && !this.data.evidenceId
+        ? this.renderPicker()
+        : this.renderChip()
+    );
+  }
+
+  private renderPicker(): HTMLElement {
+    const list = items();
+    const box = document.createElement('div');
+    box.style.cssText =
+      'padding:8px;border:1px dashed #cbd5e1;border-radius:8px;background:#f8fafc;';
+    if (list.length === 0) {
+      box.textContent = 'No other evidence to link.';
+      box.style.cssText += 'color:#94a3b8;font-size:13px;';
+      return box;
+    }
+    const select = document.createElement('select');
+    select.style.cssText =
+      'width:100%;padding:6px 8px;border:1px solid #e2e8f0;border-radius:6px;font-size:14px;background:#fff;';
+    const ph = document.createElement('option');
+    ph.value = '';
+    ph.textContent = 'Link evidence…';
+    select.appendChild(ph);
+    list.forEach((e: any) => {
+      const o = document.createElement('option');
+      o.value = e.id;
+      o.textContent = e.title || 'Untitled evidence';
+      select.appendChild(o);
+    });
+    select.onchange = () => {
+      const e = list.find((x: any) => x.id === select.value);
+      if (e) {
+        this.data = { evidenceId: e.id, title: e.title };
+        this.rebuild();
+      }
+    };
+    box.appendChild(select);
+    return box;
+  }
+
+  private renderChip(): HTMLElement {
+    const live = items().find((e: any) => e.id === this.data.evidenceId) as any;
+    const title = live?.title || this.data.title || 'Untitled evidence';
+    const projectId = useCanvasStore.getState().canvas?.id;
+
+    const chip = document.createElement(this.readOnly ? 'a' : 'div');
+    chip.style.cssText =
+      'display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid #e2e8f0;border-radius:8px;background:#fff;font-size:14px;color:#0f172a;text-decoration:none;';
+    if (this.readOnly) {
+      (chip as HTMLAnchorElement).href = projectId
+        ? `/canvas/${projectId}/evidence/${this.data.evidenceId}`
+        : `/evidence/${this.data.evidenceId}`;
+    }
+    const icon = document.createElement('span');
+    icon.textContent = '📄';
+    chip.appendChild(icon);
+    const t = document.createElement('span');
+    t.style.fontWeight = '600';
+    t.textContent = title;
+    chip.appendChild(t);
+
+    if (!this.readOnly) {
+      const change = document.createElement('button');
+      change.type = 'button';
+      change.textContent = 'change';
+      change.style.cssText =
+        'margin-left:4px;font-size:11px;color:#94a3b8;background:none;border:none;cursor:pointer;';
+      change.onclick = (ev) => {
+        ev.preventDefault();
+        this.data = { evidenceId: '' };
+        this.rebuild();
+      };
+      chip.appendChild(change);
+    }
+    return chip;
+  }
+
+  render(): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.style.margin = '6px 0';
+    this.wrapper = wrapper;
+    this.rebuild();
+    return wrapper;
+  }
+
+  save(): EvidenceLinkData {
+    return this.data;
+  }
+}

--- a/src/features/evidence/blocks/HypothesisBlock.ts
+++ b/src/features/evidence/blocks/HypothesisBlock.ts
@@ -1,0 +1,151 @@
+// Custom EditorJS block: /hypothesis — a structured hypothesis (CVS-34 slice 4.5).
+// Statement + prediction + status. Plain DOM; no external refs.
+
+type HStatus = 'proposed' | 'validated' | 'invalidated';
+
+interface HypothesisData {
+  statement: string;
+  prediction: string;
+  status: HStatus;
+}
+
+const STATUS: Record<HStatus, { label: string; bg: string; fg: string }> = {
+  proposed: { label: 'Proposed', bg: '#eef2ff', fg: '#4338ca' },
+  validated: { label: 'Validated', bg: '#f0fdf4', fg: '#15803d' },
+  invalidated: { label: 'Invalidated', bg: '#fef2f2', fg: '#b91c1c' },
+};
+
+interface BlockToolArgs {
+  data: Partial<HypothesisData>;
+  readOnly?: boolean;
+}
+
+export default class HypothesisBlock {
+  static get toolbox() {
+    return {
+      title: 'Hypothesis',
+      icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 21h4M12 3a6 6 0 00-4 10.5c.7.7 1 1.2 1 2.5h6c0-1.3.3-1.8 1-2.5A6 6 0 0012 3z"/></svg>',
+    };
+  }
+  static get isReadOnlySupported() {
+    return true;
+  }
+  static get sanitize() {
+    return {
+      statement: { br: true, b: true, i: true },
+      prediction: { br: true, b: true, i: true },
+      status: false,
+    };
+  }
+
+  private data: HypothesisData;
+  private readOnly: boolean;
+  private wrapper: HTMLElement | null = null;
+
+  constructor({ data, readOnly }: BlockToolArgs) {
+    this.data = {
+      statement: data?.statement ?? '',
+      prediction: data?.prediction ?? '',
+      status: (data?.status as HStatus) ?? 'proposed',
+    };
+    this.readOnly = Boolean(readOnly);
+  }
+
+  private field(cls: string, label: string, html: string, placeholder: string) {
+    const box = document.createElement('div');
+    box.style.marginBottom = '8px';
+    const l = document.createElement('div');
+    l.textContent = label;
+    l.style.cssText =
+      'font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#94a3b8;margin-bottom:2px;';
+    box.appendChild(l);
+    const v = document.createElement('div');
+    v.className = cls;
+    v.contentEditable = this.readOnly ? 'false' : 'true';
+    v.innerHTML = html;
+    v.dataset.placeholder = placeholder;
+    v.style.cssText = 'outline:none;color:#374151;line-height:1.5;';
+    box.appendChild(v);
+    return box;
+  }
+
+  private updateStatusBadge() {
+    const s = STATUS[this.data.status];
+    const badge = this.wrapper?.querySelector<HTMLElement>('.cm-hyp-status');
+    if (badge) {
+      badge.textContent = s.label;
+      badge.style.background = s.bg;
+      badge.style.color = s.fg;
+    }
+  }
+
+  render(): HTMLElement {
+    const wrapper = document.createElement('div');
+    this.wrapper = wrapper;
+    wrapper.style.cssText =
+      'border:1px solid #e5e7eb;border-radius:10px;padding:12px 14px;margin:6px 0;background:#fff;';
+
+    const head = document.createElement('div');
+    head.style.cssText =
+      'display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;';
+    const title = document.createElement('span');
+    title.textContent = 'Hypothesis';
+    title.style.cssText = 'font-weight:700;color:#0f172a;';
+    head.appendChild(title);
+    const badge = document.createElement('span');
+    badge.className = 'cm-hyp-status';
+    badge.style.cssText =
+      'font-size:11px;font-weight:600;padding:2px 8px;border-radius:9999px;';
+    head.appendChild(badge);
+    wrapper.appendChild(head);
+
+    wrapper.appendChild(
+      this.field(
+        'cm-hyp-statement',
+        'We believe that',
+        this.data.statement,
+        'state the hypothesis…'
+      )
+    );
+    wrapper.appendChild(
+      this.field(
+        'cm-hyp-prediction',
+        'We will know it is true when',
+        this.data.prediction,
+        'the measurable prediction…'
+      )
+    );
+
+    if (!this.readOnly) {
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;gap:6px;margin-top:4px;';
+      (Object.keys(STATUS) as HStatus[]).forEach((k) => {
+        const b = document.createElement('button');
+        b.type = 'button';
+        b.textContent = STATUS[k].label;
+        b.style.cssText =
+          'font-size:11px;padding:2px 8px;border-radius:6px;border:1px solid #e5e7eb;background:#fff;color:#6b7280;cursor:pointer;';
+        b.onclick = (e) => {
+          e.preventDefault();
+          this.data.status = k;
+          this.updateStatusBadge();
+        };
+        row.appendChild(b);
+      });
+      wrapper.appendChild(row);
+    }
+
+    this.updateStatusBadge();
+    return wrapper;
+  }
+
+  save(block: HTMLElement): HypothesisData {
+    const g = (c: string) =>
+      block.querySelector<HTMLElement>(c)?.innerHTML ?? '';
+    return {
+      statement: g('.cm-hyp-statement'),
+      prediction: g('.cm-hyp-prediction'),
+      status: this.data.status,
+    };
+  }
+}

--- a/src/features/evidence/blocks/SourceBlock.ts
+++ b/src/features/evidence/blocks/SourceBlock.ts
@@ -1,0 +1,130 @@
+// Custom EditorJS block: /source — cite a source (CVS-34 slice 4.5). URL, doc,
+// interview, dataset or external research. Plain DOM.
+
+type SourceKind = 'url' | 'doc' | 'interview' | 'dataset' | 'research';
+
+interface SourceData {
+  kind: SourceKind;
+  label: string;
+  url: string;
+}
+
+const KINDS: Record<SourceKind, string> = {
+  url: 'Link',
+  doc: 'Document',
+  interview: 'Interview',
+  dataset: 'Dataset',
+  research: 'Research',
+};
+
+interface BlockToolArgs {
+  data: Partial<SourceData>;
+  readOnly?: boolean;
+}
+
+export default class SourceBlock {
+  static get toolbox() {
+    return {
+      title: 'Source',
+      icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 007 0l2-2a5 5 0 00-7-7l-1 1"/><path d="M14 11a5 5 0 00-7 0l-2 2a5 5 0 007 7l1-1"/></svg>',
+    };
+  }
+  static get isReadOnlySupported() {
+    return true;
+  }
+  static get sanitize() {
+    return { kind: false, label: false, url: false };
+  }
+
+  private data: SourceData;
+  private readOnly: boolean;
+
+  constructor({ data, readOnly }: BlockToolArgs) {
+    this.data = {
+      kind: (data?.kind as SourceKind) ?? 'url',
+      label: data?.label ?? '',
+      url: data?.url ?? '',
+    };
+    this.readOnly = Boolean(readOnly);
+  }
+
+  private renderReadonly(): HTMLElement {
+    const chip = document.createElement(this.data.url ? 'a' : 'div');
+    chip.style.cssText =
+      'display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid #e2e8f0;border-radius:8px;background:#fff;font-size:14px;color:#0f172a;text-decoration:none;';
+    if (this.data.url) {
+      (chip as HTMLAnchorElement).href = this.data.url;
+      (chip as HTMLAnchorElement).target = '_blank';
+      (chip as HTMLAnchorElement).rel = 'noopener noreferrer';
+    }
+    const kind = document.createElement('span');
+    kind.textContent = KINDS[this.data.kind];
+    kind.style.cssText =
+      'font-size:11px;color:#64748b;background:#f1f5f9;padding:1px 6px;border-radius:9999px;';
+    chip.appendChild(kind);
+    const label = document.createElement('span');
+    label.textContent = this.data.label || this.data.url || 'Untitled source';
+    label.style.fontWeight = '600';
+    chip.appendChild(label);
+    return chip;
+  }
+
+  private renderEditor(): HTMLElement {
+    const box = document.createElement('div');
+    box.style.cssText =
+      'border:1px solid #e5e7eb;border-radius:8px;padding:10px;background:#fff;display:flex;flex-direction:column;gap:6px;';
+
+    const select = document.createElement('select');
+    select.style.cssText =
+      'padding:5px 8px;border:1px solid #e2e8f0;border-radius:6px;font-size:13px;width:150px;';
+    (Object.keys(KINDS) as SourceKind[]).forEach((k) => {
+      const o = document.createElement('option');
+      o.value = k;
+      o.textContent = KINDS[k];
+      if (k === this.data.kind) o.selected = true;
+      select.appendChild(o);
+    });
+    select.onchange = () => {
+      this.data.kind = select.value as SourceKind;
+    };
+    box.appendChild(select);
+
+    const label = document.createElement('input');
+    label.type = 'text';
+    label.placeholder = 'Label (e.g. Q3 pricing analysis)';
+    label.value = this.data.label;
+    label.className = 'cm-src-label';
+    label.style.cssText =
+      'padding:6px 8px;border:1px solid #e2e8f0;border-radius:6px;font-size:14px;';
+    label.oninput = () => {
+      this.data.label = label.value;
+    };
+    box.appendChild(label);
+
+    const url = document.createElement('input');
+    url.type = 'url';
+    url.placeholder = 'https://… (optional)';
+    url.value = this.data.url;
+    url.className = 'cm-src-url';
+    url.style.cssText =
+      'padding:6px 8px;border:1px solid #e2e8f0;border-radius:6px;font-size:13px;color:#2563eb;';
+    url.oninput = () => {
+      this.data.url = url.value;
+    };
+    box.appendChild(url);
+    return box;
+  }
+
+  render(): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.style.margin = '6px 0';
+    wrapper.appendChild(
+      this.readOnly ? this.renderReadonly() : this.renderEditor()
+    );
+    return wrapper;
+  }
+
+  save(): SourceData {
+    return this.data;
+  }
+}

--- a/src/lib/editorjs-config.ts
+++ b/src/lib/editorjs-config.ts
@@ -32,6 +32,9 @@ import NoteBlock from "@/features/evidence/blocks/NoteBlock";
 import NodeRefBlock from "@/features/evidence/blocks/NodeRefBlock";
 import RelationshipRefBlock from "@/features/evidence/blocks/RelationshipRefBlock";
 import MetricRefBlock from "@/features/evidence/blocks/MetricRefBlock";
+import HypothesisBlock from "@/features/evidence/blocks/HypothesisBlock";
+import SourceBlock from "@/features/evidence/blocks/SourceBlock";
+import EvidenceLinkBlock from "@/features/evidence/blocks/EvidenceLinkBlock";
 // Note: DragDrop and Undo are problematic, we'll implement them later
 
 export interface EditorJSConfigOptions {
@@ -76,7 +79,10 @@ export const VALID_BLOCK_TYPES = [
   "note",
   "metricNode",
   "relationshipRef",
-  "metricValue"
+  "metricValue",
+  "hypothesisBlock",
+  "sourceCite",
+  "evidenceLink"
 ] as const;
 
 export type ValidBlockType = typeof VALID_BLOCK_TYPES[number];
@@ -292,6 +298,15 @@ export const createEditorJSTools = () => {
     },
     metricValue: {
       class: MetricRefBlock as any,
+    },
+    hypothesisBlock: {
+      class: HypothesisBlock as any,
+    },
+    sourceCite: {
+      class: SourceBlock as any,
+    },
+    evidenceLink: {
+      class: EvidenceLinkBlock as any,
     },
   };
 };


### PR DESCRIPTION
**Slice 4.5 of CVS-197** — three more blocks (same proven pattern).

- **`/hypothesis`** — structured: statement + prediction + status badge (Proposed / Validated / Invalidated).
- **`/source`** — cite a source: kind (link/doc/interview/dataset/research) + label + optional URL → citation chip.
- **`/evidence`** — link another evidence item: picker from the evidence store → chip linking to that evidence.

Registered in `createEditorJSTools()` + `VALID_BLOCK_TYPES`. **7 of 9 planned blocks are now live** (`/note` `/node` `/relationship` `/metric` `/hypothesis` `/source` `/evidence`); only `/chart` + `/snapshot` remain.

## Verification
type-check ✓, lint ✓ (0 errors), **full build ✓**. Runtime in the manual-test sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)