### PR TITLE
feat(CVS-99): MCP auth — API-key resolver + Supabase JWT minting

### DIFF
--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -29,10 +29,15 @@ Transport-agnostic and unit-tested (no server/DB needed):
   `unauthenticated` / `forbidden` / `not_found` / `internal`). `listTools()` feeds
   `tools/list`.
 - **`authContext.ts`** — the **auth seam**: `McpAuthContext { userId, client, scopes }`
-  and the `AuthContextResolver` type that **CVS-99** implements (OAuth token
-  exchange / API-key lookup → a Clerk-authenticated, RLS-scoped client). Until
-  then `unimplementedAuthResolver` refuses calls. The service-role key is never
-  used.
+  and the `AuthContextResolver` type. Service-role key is never used.
+- **`auth/` (CVS-99)** — the **API-key resolver**: `createApiKeyAuthResolver` reads
+  `Authorization: Bearer <key>` (or `x-api-key`), hashes it (SHA-256, same as
+  `apiKeys.ts`), resolves the owner via the `mcp_resolve_api_key` SECURITY DEFINER
+  RPC (anon-callable, exact-hash match, bumps `last_used_at`), then **mints a
+  short-lived Supabase JWT** (`mintSupabaseJwt`, HS256 with the Supabase JWT
+  secret) whose `sub`/`o.id` claims make every DB call run under that user's RLS.
+  Works for Codex/CLI and claude.ai via a static token. **OAuth "Connect"
+  sign-in is the follow-up** (see below).
 - **`errors.ts`** — the structured error codes.
 
 Tools wired (finalized in **CVS-101**): `list_canvases`, `get_tree`, `list_nodes`,
@@ -58,7 +63,14 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { listTools, dispatchTool, McpToolError } from '@/shared/lib/api/mcp';
 
-const resolveAuth = /* CVS-99 AuthContextResolver */;
+// CVS-99 API-key resolver (needs SUPABASE_JWT_SECRET at deploy):
+import { createApiKeyAuthResolver, supabaseApiKeyLookup } from '@/shared/lib/api/mcp';
+import { createClient } from '@supabase/supabase-js';
+const anon = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const resolveAuth = createApiKeyAuthResolver({
+  jwtSecret: SUPABASE_JWT_SECRET, supabaseUrl: SUPABASE_URL, anonKey: SUPABASE_ANON_KEY,
+  lookupKey: supabaseApiKeyLookup(anon),
+});
 
 export async function handler(req, res) {
   const server = new McpServer({ name: 'metrimap', version: '0.1.0' });
@@ -83,6 +95,21 @@ Plus a `GET /health` returning `{ ok: true, version }`.
 Reachable at `https://mcp.canvasm.app/mcp`, addable via
 `claude mcp add --transport http metrimap https://mcp.canvasm.app/mcp` and the
 claude.ai connector. Add request logging + a `mcp_audit_log` (CVS-104).
+
+## OAuth "Connect" — follow-up
+
+Nicer UX ("sign in → connected" in the Claude connector) but more setup: an OAuth
+2.1 authorization server (dynamic client registration + `/authorize` + `/token`)
+backed by Clerk sign-in, storing tokens server-side. It resolves the same way — a
+bearer token → user → `mintSupabaseJwt` → RLS-scoped client — so it slots into the
+same seam. Needs a Clerk **OAuth application** (client id/secret, redirect URIs).
+Ship API-key auth first; add this once hosting + Clerk OAuth are set up.
+
+## Deploy secrets (CVS-99)
+
+The API-key resolver needs, as **server env** (never client):
+`SUPABASE_URL`, `SUPABASE_ANON_KEY` (public), and **`SUPABASE_JWT_SECRET`**
+(Supabase → Project Settings → API → JWT Secret) to sign the per-user tokens.
 
 ## Status vs acceptance criteria
 - [x] Tool registry wired to the API layer; structured errors — **done + tested**.

--- a/src/shared/lib/api/mcp/auth/apiKeyResolver.test.ts
+++ b/src/shared/lib/api/mcp/auth/apiKeyResolver.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createApiKeyAuthResolver } from './apiKeyResolver';
+import { decodeJwtPayload, hashApiKey } from './jwt';
+import { McpToolError } from '../errors';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const base = {
+  jwtSecret: 'secret',
+  supabaseUrl: 'https://x.supabase.co',
+  anonKey: 'anon',
+};
+
+let scopedClientFactory: ReturnType<typeof vi.fn>;
+beforeEach(() => {
+  scopedClientFactory = vi.fn((jwt: string) => ({ __jwt: jwt }) as unknown as SupabaseClient);
+});
+
+describe('createApiKeyAuthResolver', () => {
+  it('rejects a request with no key', async () => {
+    const resolve = createApiKeyAuthResolver({ ...base, lookupKey: vi.fn(), scopedClientFactory });
+    await expect(resolve({ headers: {} })).rejects.toMatchObject({
+      name: 'McpToolError',
+      code: 'unauthenticated',
+    });
+  });
+
+  it('rejects an unknown/revoked key', async () => {
+    const lookupKey = vi.fn(async () => null);
+    const resolve = createApiKeyAuthResolver({ ...base, lookupKey, scopedClientFactory });
+    await expect(
+      resolve({ headers: { authorization: 'Bearer mk_live_nope' } })
+    ).rejects.toBeInstanceOf(McpToolError);
+  });
+
+  it('resolves a valid key → user + RLS-scoped client under a minted JWT', async () => {
+    const lookupKey = vi.fn(async () => ({ userId: 'user_1', orgId: 'org_1' }));
+    const resolve = createApiKeyAuthResolver({ ...base, lookupKey, scopedClientFactory });
+
+    const ctx = await resolve({ headers: { authorization: 'Bearer mk_live_secret' } });
+
+    // looked up by the sha-256 hash of the raw key
+    expect(lookupKey).toHaveBeenCalledWith(await hashApiKey('mk_live_secret'));
+    expect(ctx.userId).toBe('user_1');
+    expect(ctx.scopes).toEqual(['read', 'write']);
+
+    // the client was built from a JWT carrying the user + org claims
+    const jwt = scopedClientFactory.mock.calls[0][0] as string;
+    expect(decodeJwtPayload(jwt)).toMatchObject({ sub: 'user_1', o: { id: 'org_1' } });
+    expect(ctx.client).toBe(scopedClientFactory.mock.results[0].value);
+  });
+
+  it('accepts a raw key and x-api-key header too', async () => {
+    const lookupKey = vi.fn(async () => ({ userId: 'u', orgId: null }));
+    const resolve = createApiKeyAuthResolver({ ...base, lookupKey, scopedClientFactory });
+
+    await resolve({ headers: { authorization: 'mk_live_raw' } });
+    await resolve({ headers: { 'x-api-key': 'mk_live_x' } });
+    expect(lookupKey).toHaveBeenNthCalledWith(1, await hashApiKey('mk_live_raw'));
+    expect(lookupKey).toHaveBeenNthCalledWith(2, await hashApiKey('mk_live_x'));
+  });
+
+  it('honors custom scopes', async () => {
+    const resolve = createApiKeyAuthResolver({
+      ...base,
+      lookupKey: vi.fn(async () => ({ userId: 'u', orgId: null })),
+      scopedClientFactory,
+      scopes: ['read'],
+    });
+    const ctx = await resolve({ headers: { authorization: 'Bearer k' } });
+    expect(ctx.scopes).toEqual(['read']);
+  });
+});

--- a/src/shared/lib/api/mcp/auth/apiKeyResolver.ts
+++ b/src/shared/lib/api/mcp/auth/apiKeyResolver.ts
@@ -1,0 +1,105 @@
+// Personal/workspace API-key auth for the MCP server (CVS-99). Implements the
+// AuthContextResolver seam (CVS-100): resolve an incoming request's API key to a
+// user + an RLS-scoped Supabase client, so non-interactive clients (Codex/CLI,
+// claude.ai with a static token) can call tools. The OAuth "Connect" sign-in flow
+// is the documented follow-up (see docs/features/mcp-server.md).
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import type {
+  AuthContextResolver,
+  McpRequestLike,
+  McpScope,
+} from '../authContext';
+import { McpToolError } from '../errors';
+import { hashApiKey, mintSupabaseJwt } from './jwt';
+
+/** Resolves a key hash → the owning user (never exposes the raw key store). */
+export type ApiKeyLookup = (
+  keyHash: string
+) => Promise<{ userId: string; orgId: string | null } | null>;
+
+/**
+ * Build an ApiKeyLookup backed by the `mcp_resolve_api_key` SECURITY DEFINER RPC
+ * (migration 20260704160000). The RPC matches on the exact hash, bumps
+ * last_used_at, and returns the key owner — callable with a plain anon client, so
+ * the service-role key is never needed.
+ */
+export function supabaseApiKeyLookup(
+  anonClient: SupabaseClient<Database>
+): ApiKeyLookup {
+  const rpc = anonClient.rpc as unknown as (
+    fn: string,
+    args: Record<string, unknown>
+  ) => Promise<{ data: unknown; error: { message: string } | null }>;
+  return async (keyHash) => {
+    const { data, error } = await rpc('mcp_resolve_api_key', { p_key_hash: keyHash });
+    if (error) throw new Error(error.message);
+    const row = (Array.isArray(data) ? data[0] : data) as
+      | { user_id?: string; workspace_id?: string | null }
+      | null
+      | undefined;
+    return row?.user_id
+      ? { userId: row.user_id, orgId: row.workspace_id ?? null }
+      : null;
+  };
+}
+
+export interface ApiKeyAuthOptions {
+  /** Supabase JWT secret (server-only) used to mint the per-user token. */
+  jwtSecret: string;
+  supabaseUrl: string;
+  anonKey: string;
+  /** Key-hash → owner resolver (see supabaseApiKeyLookup). */
+  lookupKey: ApiKeyLookup;
+  tokenTtlSec?: number;
+  /** Scopes granted to key-authenticated connections (per-key scopes = CVS-89). */
+  scopes?: McpScope[];
+  /** Override the scoped-client factory (tests). */
+  scopedClientFactory?: (jwt: string) => SupabaseClient<Database>;
+}
+
+function extractApiKey(headers: Record<string, string | undefined>): string | null {
+  const auth = headers['authorization'] ?? headers['Authorization'];
+  if (auth) {
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    return (m ? m[1] : auth).trim() || null;
+  }
+  const x = headers['x-api-key'] ?? headers['X-API-Key'];
+  return x?.trim() || null;
+}
+
+export function createApiKeyAuthResolver(
+  opts: ApiKeyAuthOptions
+): AuthContextResolver {
+  const makeScopedClient =
+    opts.scopedClientFactory ??
+    ((jwt: string) =>
+      createClient<Database>(opts.supabaseUrl, opts.anonKey, {
+        global: { headers: { Authorization: `Bearer ${jwt}` } },
+        auth: { persistSession: false, autoRefreshToken: false },
+      }));
+
+  return async (req: McpRequestLike) => {
+    const key = extractApiKey(req.headers);
+    if (!key) {
+      throw new McpToolError(
+        'unauthenticated',
+        'Missing API key — send it as `Authorization: Bearer <key>`.'
+      );
+    }
+    const found = await opts.lookupKey(await hashApiKey(key));
+    if (!found) {
+      throw new McpToolError('unauthenticated', 'Invalid or revoked API key.');
+    }
+    const jwt = await mintSupabaseJwt(
+      { sub: found.userId, orgId: found.orgId },
+      opts.jwtSecret,
+      opts.tokenTtlSec
+    );
+    return {
+      userId: found.userId,
+      client: makeScopedClient(jwt),
+      scopes: opts.scopes ?? ['read', 'write'],
+    };
+  };
+}

--- a/src/shared/lib/api/mcp/auth/jwt.test.ts
+++ b/src/shared/lib/api/mcp/auth/jwt.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { mintSupabaseJwt, decodeJwtPayload, hashApiKey } from './jwt';
+
+const SECRET = 'test-jwt-secret-please-ignore';
+
+describe('mintSupabaseJwt', () => {
+  it('mints an HS256 JWT with Supabase/RLS claims', async () => {
+    const token = await mintSupabaseJwt({ sub: 'user_123', orgId: 'org_9' }, SECRET, 300);
+    expect(token.split('.')).toHaveLength(3);
+    const p = decodeJwtPayload(token);
+    expect(p).toMatchObject({
+      sub: 'user_123',
+      role: 'authenticated',
+      aud: 'authenticated',
+      iss: 'metrimap-mcp',
+      o: { id: 'org_9' },
+    });
+    expect((p.exp as number) - (p.iat as number)).toBe(300);
+  });
+
+  it('omits the org claim when no org', async () => {
+    const p = decodeJwtPayload(await mintSupabaseJwt({ sub: 'u1' }, SECRET));
+    expect(p.o).toBeUndefined();
+  });
+
+  it('throws without a secret', async () => {
+    await expect(mintSupabaseJwt({ sub: 'u1' }, '')).rejects.toThrow(/secret/i);
+  });
+
+  it('produces a signature that verifies against the secret (HS256)', async () => {
+    const token = await mintSupabaseJwt({ sub: 'u1' }, SECRET);
+    const [h, pl, sig] = token.split('.');
+    const key = await crypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode(SECRET),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign']
+    );
+    const raw = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(`${h}.${pl}`));
+    const expected = btoa(String.fromCharCode(...new Uint8Array(raw)))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    expect(sig).toBe(expected);
+  });
+});
+
+describe('hashApiKey', () => {
+  it('is a deterministic 64-char sha-256 hex', async () => {
+    const a = await hashApiKey('mk_live_abc');
+    const b = await hashApiKey('mk_live_abc');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(await hashApiKey('mk_live_xyz')).not.toBe(a);
+  });
+});

--- a/src/shared/lib/api/mcp/auth/jwt.ts
+++ b/src/shared/lib/api/mcp/auth/jwt.ts
@@ -1,0 +1,71 @@
+// MCP auth crypto (CVS-99). The server mints a short-lived Supabase JWT for the
+// authenticated user so every DB call runs under that user's RLS — the DB derives
+// the user from the `sub` claim (requesting_user_id()) and the org from `o.id`
+// (requesting_org_id()). Signed HS256 with the Supabase JWT secret (server-only
+// env). Uses Web Crypto (Deno/Node/browser) — no extra dependency, and the same
+// SHA-256 hashing convention as apiKeys.ts.
+const enc = new TextEncoder();
+
+function b64urlFromBytes(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function b64urlFromString(s: string): string {
+  return b64urlFromBytes(enc.encode(s));
+}
+
+/** SHA-256 hex of an API key — matches apiKeys.ts so lookups line up. */
+export async function hashApiKey(key: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', enc.encode(key));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export interface SupabaseJwtInput {
+  /** Clerk user id → JWT `sub` → requesting_user_id(). */
+  sub: string;
+  /** Optional org/workspace id → JWT `o.id` → requesting_org_id(). */
+  orgId?: string | null;
+}
+
+/**
+ * Mint a short-lived (default 5 min) Supabase-compatible JWT for a user.
+ * @param secret the Supabase JWT secret (server-only). Throws if missing.
+ */
+export async function mintSupabaseJwt(
+  input: SupabaseJwtInput,
+  secret: string,
+  ttlSec = 300
+): Promise<string> {
+  if (!secret) throw new Error('mintSupabaseJwt: missing Supabase JWT secret');
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const payload: Record<string, unknown> = {
+    sub: input.sub,
+    role: 'authenticated',
+    aud: 'authenticated',
+    iss: 'metrimap-mcp',
+    iat: now,
+    exp: now + ttlSec,
+  };
+  if (input.orgId) payload.o = { id: input.orgId };
+
+  const data = `${b64urlFromString(JSON.stringify(header))}.${b64urlFromString(JSON.stringify(payload))}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(data));
+  return `${data}.${b64urlFromBytes(new Uint8Array(sig))}`;
+}
+
+/** Decode (does NOT verify) a JWT's payload — for tests / debugging. */
+export function decodeJwtPayload(token: string): Record<string, unknown> {
+  const part = token.split('.')[1] ?? '';
+  const b64 = part.replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(atob(b64));
+}

--- a/src/shared/lib/api/mcp/index.ts
+++ b/src/shared/lib/api/mcp/index.ts
@@ -10,3 +10,11 @@ export {
   type McpRequestLike,
   type AuthContextResolver,
 } from './authContext';
+// Auth (CVS-99): API-key resolver + JWT minting. OAuth "Connect" is a follow-up.
+export {
+  createApiKeyAuthResolver,
+  supabaseApiKeyLookup,
+  type ApiKeyAuthOptions,
+  type ApiKeyLookup,
+} from './auth/apiKeyResolver';
+export { mintSupabaseJwt, hashApiKey, decodeJwtPayload } from './auth/jwt';

--- a/supabase/migrations/20260704160000_mcp_resolve_api_key.sql
+++ b/supabase/migrations/20260704160000_mcp_resolve_api_key.sql
@@ -1,0 +1,35 @@
+-- =====================================================================
+-- MCP AUTH — resolve an API key to its owner (CVS-99). SECURITY DEFINER so the
+-- MCP server can look a key up pre-auth with a plain anon client (no service-role
+-- key). Matches on the EXACT sha-256 hash (the caller must present the raw key),
+-- bumps last_used_at, and returns the owning user + workspace. Returns no row for
+-- an unknown/revoked key. This anon-executable SECURITY DEFINER grant is
+-- intentional (see docs/database/SECURITY_ADVISORS.md).
+-- =====================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.mcp_resolve_api_key(p_key_hash text)
+RETURNS TABLE (user_id text, workspace_id text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_key_hash IS NULL OR length(p_key_hash) < 32 THEN
+    RETURN;
+  END IF;
+
+  UPDATE public.api_keys SET last_used_at = now() WHERE key_hash = p_key_hash;
+
+  RETURN QUERY
+  SELECT k.created_by, k.workspace_id
+  FROM public.api_keys k
+  WHERE k.key_hash = p_key_hash
+  LIMIT 1;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.mcp_resolve_api_key(text) FROM public;
+GRANT EXECUTE ON FUNCTION public.mcp_resolve_api_key(text) TO anon, authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
Fills the CVS-100 `AuthContextResolver` seam so non-interactive clients (Codex/CLI, claude.ai via a static token) can call MCP tools — RLS-scoped, no service-role key. **OAuth "Connect" sign-in is the documented follow-up.**

## How it works
`Authorization: Bearer <key>` → SHA-256 hash (same as `apiKeys.ts`) → resolve the owner via the `mcp_resolve_api_key` RPC → **mint a short-lived Supabase JWT** (`sub` = Clerk id, `o.id` = org) → build a Supabase client with it. The DB derives the user from `sub` (`requesting_user_id()`), so every call runs under that user's RLS.

## Files
- `auth/jwt.ts` — `mintSupabaseJwt` (HS256 via Web Crypto, no new dep) + `hashApiKey`.
- `auth/apiKeyResolver.ts` — `createApiKeyAuthResolver` (+ `supabaseApiKeyLookup`); reads `Authorization`/`x-api-key`, defaults scopes to `[read, write]` (per-key scopes = CVS-89).
- **Migration** `20260704160000` — `mcp_resolve_api_key(text)` SECURITY DEFINER, anon-callable exact-hash lookup + `last_used_at` bump.
- 10 tests (JWT claims + HS256 signature verify, hashing, resolver paths). Doc updated (auth section, OAuth follow-up, deploy secret).

## Acceptance criteria
- [x] Server calls scoped to the authenticated user (RLS) — via the minted JWT.
- [x] API-key auth works for non-interactive clients.
- [x] Keys never exposed client-side; revoke works (delete the `api_keys` row → `mcp_resolve_api_key` returns nothing).
- [ ] OAuth "Connect" sign-in — **follow-up** (needs a Clerk OAuth app).

## Deploy (your part — deploy-time only)
Set `SUPABASE_JWT_SECRET` (Supabase → Settings → API → JWT Secret) as a **server** env var; wire the resolver into the transport (reference in the doc). Nothing needed to build/review this.

## Review notes
⚠️ **Not self-merged** — adds an anon-executable SECURITY DEFINER RPC. Please review + `npx supabase db push`. No `types.ts` change (RPC called via a typed cast) → no conflict with #56/#62.

Verify: type-check + eslint + `vitest run` (**176 passing**) green.

Ref: CVS-99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)