### PR TITLE
CVS-82: consolidate Supabase client selection (drop anon fallback from authed paths)

### DIFF
--- a/src/shared/lib/supabase/services/alertRules.ts
+++ b/src/shared/lib/supabase/services/alertRules.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { Database } from '../types';
 import type { MetricValue } from '@/shared/types';
 
@@ -36,7 +36,7 @@ export async function listAlertRules(
   cardId: string,
   client?: Client
 ): Promise<AlertRule[]> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('alert_rules')
     .select(SELECT)
@@ -56,7 +56,7 @@ export async function createAlertRule(
   },
   client?: Client
 ): Promise<AlertRule> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('alert_rules')
     .insert({
@@ -77,7 +77,7 @@ export async function updateAlertRule(
   updates: Partial<Pick<AlertRule, 'name' | 'enabled' | 'config' | 'rule_type'>>,
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c
     .from('alert_rules')
     .update(updates as never)
@@ -89,7 +89,7 @@ export async function deleteAlertRule(
   id: string,
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c.from('alert_rules').delete().eq('id', id);
   if (error) throw new Error(error.message);
 }
@@ -102,7 +102,7 @@ export async function emitCardAlert(
   metadata: Record<string, unknown>,
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c.rpc('emit_card_alert' as never, {
     p_rule_id: ruleId,
     p_title: title,

--- a/src/shared/lib/supabase/services/apiKeys.ts
+++ b/src/shared/lib/supabase/services/apiKeys.ts
@@ -2,7 +2,7 @@
 // The full key is shown to the user ONCE; only its SHA-256 hash is stored.
 
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { Database } from '../types';
 
 type Client = SupabaseClient<Database>;
@@ -30,7 +30,7 @@ function randomKey(): string {
 }
 
 export async function listApiKeys(client?: Client): Promise<ApiKey[]> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('api_keys')
     .select('id, name, key_prefix, created_at, last_used_at')
@@ -44,7 +44,7 @@ export async function createApiKey(
   name: string,
   client?: Client
 ): Promise<{ key: string; row: ApiKey }> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const key = randomKey();
   const key_hash = await sha256hex(key);
   const key_prefix = key.slice(0, 12); // e.g. "mk_live_a1b2"
@@ -58,7 +58,7 @@ export async function createApiKey(
 }
 
 export async function deleteApiKey(id: string, client?: Client): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c.from('api_keys').delete().eq('id', id);
   if (error) throw new Error(error.message);
 }

--- a/src/shared/lib/supabase/services/changelog.ts
+++ b/src/shared/lib/supabase/services/changelog.ts
@@ -1,6 +1,6 @@
 import { CreateChangelogSchema } from '@/shared/lib/validation/zod';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
 import type { Database, Tables, TablesInsert } from '../types';
 
 export type ChangelogRow = Tables<'changelog'>;
@@ -62,7 +62,7 @@ export async function logChangelogEntry(
     console.error('Validation error creating changelog entry:', e);
     throw e;
   }
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
 
   const { data, error } = await client
     .from('changelog')
@@ -84,7 +84,7 @@ export async function getChangelogForTarget(
   target: string = 'relationship',
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('changelog')
     .select('*')
@@ -106,7 +106,7 @@ export async function getProjectChangelog(
   limit?: number,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   let query = client
     .from('changelog')
     .select('*')
@@ -133,7 +133,7 @@ export async function getWorkspaceChangelog(
   limit: number = 100,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('changelog')
     .select('*')

--- a/src/shared/lib/supabase/services/collaboration.ts
+++ b/src/shared/lib/supabase/services/collaboration.ts
@@ -12,7 +12,7 @@ import {
   UpdateNotificationSchema,
 } from '@/shared/lib/validation/zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { Database, Tables, TablesInsert, TablesUpdate } from '../types';
 
 export type CommentThreadRow = Tables<'comment_threads'>;
@@ -35,7 +35,7 @@ export async function createCommentThread(
   params: CreateThreadParams,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const insert: CommentThreadInsert = {
     project_id: params.projectId,
     source: params.source,
@@ -66,7 +66,7 @@ export async function listCommentThreads(
   projectId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('comment_threads')
     .select('*')
@@ -85,7 +85,7 @@ export async function updateCommentThread(
   updates: Partial<Pick<CommentThreadRow, 'is_resolved' | 'context'>>,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const patch = {
     is_resolved: updates.is_resolved ?? undefined,
     context: (updates.context as any) ?? undefined,
@@ -115,7 +115,7 @@ export async function deleteCommentThread(
   threadId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client
     .from('comment_threads')
     .delete()
@@ -137,7 +137,7 @@ export async function createComment(
   params: CreateCommentParams,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const insert: CommentInsert = {
     thread_id: params.threadId,
     author_id: params.authorId ?? null,
@@ -167,7 +167,7 @@ export async function listComments(
   threadId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('comments')
     .select('*')
@@ -186,7 +186,7 @@ export async function updateComment(
   updates: Partial<Pick<CommentRow, 'content' | 'resolved'>>,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const patch: CommentUpdate = {
     content: updates.content ?? undefined,
     resolved: updates.resolved ?? undefined,
@@ -217,7 +217,7 @@ export async function deleteComment(
   commentId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client.from('comments').delete().eq('id', commentId);
 
   if (error) {
@@ -231,7 +231,7 @@ export async function addMention(
   mentionedUserId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const payload = {
     comment_id: commentId,
     mentioned_user_id: mentionedUserId,
@@ -259,7 +259,7 @@ export async function listMentionsForUser(
   userId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('comment_mentions')
     .select('*')
@@ -285,7 +285,7 @@ export async function createNotification(
   params: CreateNotificationParams,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const payload = {
     user_id: params.userId,
     type: params.type,
@@ -324,7 +324,7 @@ export async function notifyCardAssigned(
   authenticatedClient?: SupabaseClient<Database>
 ): Promise<void> {
   if (!userIds || userIds.length === 0) return;
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client.rpc('notify_card_assigned' as never, {
     p_card_id: cardId,
     p_user_ids: userIds,
@@ -348,7 +348,7 @@ export async function listNotifications(
   options?: NotificationFilter,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   let query = client
     .from('notifications')
     .select('*')
@@ -381,7 +381,7 @@ export async function getUnreadNotificationCount(
   userId: string,
   authenticatedClient?: SupabaseClient<Database>
 ): Promise<number> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { count, error } = await client
     .from('notifications')
     .select('id', { count: 'exact', head: true })
@@ -398,7 +398,7 @@ export async function markAllNotificationsRead(
   userId: string,
   authenticatedClient?: SupabaseClient<Database>
 ): Promise<void> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client
     .from('notifications')
     .update({ read: true })
@@ -415,7 +415,7 @@ export async function markNotificationRead(
   read: boolean = true,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const patch = { read } as const;
   try {
     UpdateNotificationSchema.parse(patch as unknown);
@@ -447,7 +447,7 @@ export async function getCommentCountsByCard(
   projectId: string,
   authenticatedClient?: SupabaseClient<Database>
 ): Promise<Record<string, number>> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
 
   const threads = await listCommentThreads(projectId, client);
   const threadToCard: Record<string, string> = {};

--- a/src/shared/lib/supabase/services/collaborators.ts
+++ b/src/shared/lib/supabase/services/collaborators.ts
@@ -1,5 +1,5 @@
-import { supabase } from '@/shared/lib/supabase/client';
 import type { Tables } from '@/shared/lib/supabase/types';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import {
   CreateProjectCollaboratorSchema,
   UpdateProjectCollaboratorSchema,
@@ -21,7 +21,7 @@ export async function getProjectCollaborators(
   projectId: string,
   authenticatedClient?: SupabaseClient<Database>
 ): Promise<Collaborator[]> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('project_collaborators')
     .select(
@@ -71,7 +71,7 @@ export async function getMyProjectPermission(
   projectId: string,
   authenticatedClient?: SupabaseClient<Database>
 ): Promise<'none' | 'view' | 'comment' | 'edit'> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client.rpc('my_project_permission' as never, {
     pid: projectId,
   } as never);
@@ -88,7 +88,7 @@ export async function addCollaborator(
   authenticatedClient?: SupabaseClient<Database>
 ) {
   const perms = permissions ?? permissionsForRole(role);
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
 
   // First, find the user by email
   const { data: userData, error: userError } = await client
@@ -148,7 +148,7 @@ export async function updateCollaborator(
   },
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('project_collaborators')
     .update(
@@ -184,7 +184,7 @@ export async function removeCollaborator(
   collaboratorId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client
     .from('project_collaborators')
     .delete()

--- a/src/shared/lib/supabase/services/dashboards.ts
+++ b/src/shared/lib/supabase/services/dashboards.ts
@@ -3,7 +3,7 @@
 // = all rows for a project_id. See the dashboard_widgets migration.
 
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { Database, Json } from '../types';
 import type {
   DashboardWidget,
@@ -41,7 +41,7 @@ export async function listWidgets(
   projectId: string,
   client?: Client
 ): Promise<DashboardWidget[]> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('dashboard_widgets')
     .select(COLS)
@@ -64,7 +64,7 @@ export async function createWidget(
   input: CreateWidgetInput,
   client?: Client
 ): Promise<DashboardWidget> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('dashboard_widgets')
     .insert({
@@ -92,7 +92,7 @@ export async function updateWidget(
   }>,
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const row: Record<string, unknown> = { updated_at: new Date().toISOString() };
   if (patch.title !== undefined) row.title = patch.title;
   if (patch.widgetType !== undefined) row.widget_type = patch.widgetType;
@@ -112,7 +112,7 @@ export async function updateLayouts(
   client?: Client
 ): Promise<void> {
   if (!positions.length) return;
-  const c = client || supabase();
+  const c = resolveClient(client);
   await Promise.all(
     positions.map(({ id, layout }) =>
       c
@@ -127,7 +127,7 @@ export async function deleteWidget(
   id: string,
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c.from('dashboard_widgets').delete().eq('id', id);
   if (error) throw new Error(error.message);
 }

--- a/src/shared/lib/supabase/services/errorReports.ts
+++ b/src/shared/lib/supabase/services/errorReports.ts
@@ -27,6 +27,8 @@ export async function submitErrorReport(
   payload: ErrorReportPayload,
   client?: Client
 ): Promise<void> {
+  // Deliberately the anon singleton — the crash sink must work even for
+  // logged-out / broken-session users (CVS-82: this path is the exception).
   const c = client || supabase();
   const { error } = await c.from('error_reports').insert({
     message: payload.message,

--- a/src/shared/lib/supabase/services/eventTaxonomy.ts
+++ b/src/shared/lib/supabase/services/eventTaxonomy.ts
@@ -3,7 +3,7 @@
 // catalog-only; RLS scopes rows to the owner (see the event_taxonomy migration).
 
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { Database, Json } from '../types';
 
 type Client = SupabaseClient<Database>;
@@ -72,7 +72,7 @@ const PROPERTY_COLS =
 export async function listEvents(
   authenticatedClient?: Client
 ): Promise<EventDefinition[]> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('event_definitions')
     .select(EVENT_COLS)
@@ -85,7 +85,7 @@ export async function createEvent(
   input: EventDefinitionInput,
   authenticatedClient?: Client
 ): Promise<EventDefinition> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('event_definitions')
     .insert(input)
@@ -100,7 +100,7 @@ export async function updateEvent(
   patch: Partial<EventDefinitionInput>,
   authenticatedClient?: Client
 ): Promise<void> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client
     .from('event_definitions')
     .update({ ...patch, updated_at: new Date().toISOString() })
@@ -112,7 +112,7 @@ export async function deleteEvent(
   id: string,
   authenticatedClient?: Client
 ): Promise<void> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client
     .from('event_definitions')
     .delete()
@@ -125,7 +125,7 @@ export async function listProperties(
   eventId: string,
   authenticatedClient?: Client
 ): Promise<EventProperty[]> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('event_properties')
     .select(PROPERTY_COLS)
@@ -139,7 +139,7 @@ export async function upsertProperty(
   input: EventPropertyInput & { id?: string },
   authenticatedClient?: Client
 ): Promise<EventProperty> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('event_properties')
     .upsert(input)
@@ -153,7 +153,7 @@ export async function deleteProperty(
   id: string,
   authenticatedClient?: Client
 ): Promise<void> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client.from('event_properties').delete().eq('id', id);
   if (error) throw new Error(error.message);
 }

--- a/src/shared/lib/supabase/services/evidence.ts
+++ b/src/shared/lib/supabase/services/evidence.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { Database, Json, Tables } from '../types';
 import type { EvidenceItem } from '@/shared/types';
 
@@ -30,7 +30,7 @@ export async function getCardEvidence(
   cardId: string,
   client?: Client
 ): Promise<EvidenceItem[]> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('evidence_items')
     .select('*')
@@ -45,7 +45,7 @@ export async function getEvidenceItemById(
   id: string,
   client?: Client
 ): Promise<EvidenceItem | null> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('evidence_items')
     .select('*')
@@ -63,7 +63,7 @@ export async function createCardEvidence(
   userId: string,
   client?: Client
 ): Promise<EvidenceItem> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('evidence_items')
     .insert({
@@ -94,7 +94,7 @@ export async function createProjectEvidence(
   userId: string,
   client?: Client
 ): Promise<EvidenceItem> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('evidence_items')
     .insert({

--- a/src/shared/lib/supabase/services/feedBookmarks.ts
+++ b/src/shared/lib/supabase/services/feedBookmarks.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 
 // Persistent "saved" primitive for the update feed. item_key is the feed item's
 // composite id ('c:<id>' changelog, 'n:<id>' notification). RLS scopes rows to
@@ -9,7 +9,7 @@ import { supabase } from '../client';
 export async function listFeedBookmarks(
   client?: SupabaseClient
 ): Promise<string[]> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c.from('feed_bookmarks').select('item_key');
   if (error) throw new Error(error.message);
   return (data ?? []).map((r: { item_key: string }) => r.item_key);
@@ -19,7 +19,7 @@ export async function addFeedBookmark(
   itemKey: string,
   client?: SupabaseClient
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   // Ignore duplicate-PK conflicts so re-bookmarking is a no-op.
   const { error } = await c
     .from('feed_bookmarks')
@@ -31,7 +31,7 @@ export async function removeFeedBookmark(
   itemKey: string,
   client?: SupabaseClient
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c
     .from('feed_bookmarks')
     .delete()

--- a/src/shared/lib/supabase/services/metric-cards.ts
+++ b/src/shared/lib/supabase/services/metric-cards.ts
@@ -3,8 +3,8 @@ import {
   UpdateMetricCardSchema,
 } from '@/shared/lib/validation/zod';
 import type { MetricCard } from '@/shared/types';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
 import type { Database, Tables, TablesInsert, TablesUpdate } from '../types';
 import { createLogger } from '@/shared/utils/logger';
 
@@ -121,7 +121,7 @@ async function executeUpdate(
   updateData: MetricCardUpdate,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('metric_cards')
     .update(updateData)
@@ -161,7 +161,7 @@ export async function createMetricCard(
   }
   log.debug('🔍 Insert data:', insertData);
 
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
 
   const { data, error } = await client
     .from('metric_cards')
@@ -195,7 +195,7 @@ export async function deleteMetricCard(
   id: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client.from('metric_cards').delete().eq('id', id);
 
   if (error) {
@@ -209,7 +209,7 @@ export async function getProjectMetricCards(
   projectId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('metric_cards')
     .select('*')
@@ -231,7 +231,7 @@ export async function updateMetricCardPosition(
 ) {
   log.debug(`💾 Updating position for metric card ${id}:`, position);
 
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('metric_cards')
     .update({

--- a/src/shared/lib/supabase/services/projects.ts
+++ b/src/shared/lib/supabase/services/projects.ts
@@ -5,9 +5,9 @@ import {
   UpdateProjectSchema,
 } from '@/shared/lib/validation/zod';
 import type { CanvasProject } from '@/shared/types';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import { transformCanvasProject } from '@/shared/utils/dataTransformers';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
 import type { Database, Tables, TablesInsert, TablesUpdate } from '../types';
 import { createLogger } from '@/shared/utils/logger';
 
@@ -36,7 +36,7 @@ export async function getUserProjects(
       '⚠️ getUserProjects called without an authenticated client; falling back to anon (RLS will hide non-public rows). This usually means the Clerk client was not threaded through.'
     );
   }
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('projects')
     .select(
@@ -69,7 +69,7 @@ export async function getUserProjects(
 export async function listTemplates(
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('projects')
     .select(`*, metric_cards(count), relationships(count), groups(count)`)
@@ -86,7 +86,7 @@ export async function saveAsTemplate(
   userId: string,
   authenticatedClient?: SupabaseClient<Database>
 ): Promise<string> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data: orig } = await client
     .from('projects')
     .select('name')
@@ -105,7 +105,7 @@ export async function saveAsTemplate(
 export async function getShowcaseProjects(
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('projects')
     .select(`*, metric_cards(count), relationships(count), groups(count)`)
@@ -127,7 +127,7 @@ export async function duplicateProjectDeep(
   userId: string,
   authenticatedClient?: SupabaseClient<Database>
 ): Promise<string> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
 
   const { data: orig, error: origErr } = await client
     .from('projects')
@@ -260,7 +260,7 @@ export async function setProjectStarred(
   starred: boolean,
   authenticatedClient?: SupabaseClient<Database>
 ): Promise<void> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client
     .from('projects')
     .update({ is_starred: starred })
@@ -273,7 +273,7 @@ export async function setProjectArchived(
   archived: boolean,
   authenticatedClient?: SupabaseClient<Database>
 ): Promise<void> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client
     .from('projects')
     .update({ archived_at: archived ? new Date().toISOString() : null })
@@ -289,7 +289,7 @@ export async function getProjectById(
   log.debug('🔍 getProjectById called with projectId:', projectId);
   log.debug('🔍 authenticatedClient provided:', !!authenticatedClient);
 
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
 
   // First, fetch the project
   const { data: project, error: projectError } = await client
@@ -459,7 +459,7 @@ export async function createProject(
   project: Omit<ProjectInsert, 'id'>,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   // Validate payload using Prisma-generated Zod schema
   try {
     CreateProjectSchema.parse(project as unknown);
@@ -487,7 +487,7 @@ export async function updateProject(
   updates: ProjectUpdate,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   // Validate update payload
   try {
     UpdateProjectSchema.parse(updates as unknown);
@@ -516,7 +516,7 @@ export async function setProjectPublic(
   isPublic: boolean,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const updateData = { is_public: isPublic } as any;
   try {
     UpdateProjectSchema.parse(updateData as unknown);
@@ -553,7 +553,7 @@ export async function mergeProjectSettings(
   authenticatedClient?: SupabaseClient<Database>
 ) {
   const run = async () => {
-    const client = authenticatedClient || supabase();
+    const client = resolveClient(authenticatedClient);
     const { data: proj, error: fetchErr } = await client
       .from('projects')
       .select('settings')
@@ -587,7 +587,7 @@ export async function deleteProject(
   id: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client.from('projects').delete().eq('id', id);
 
   if (error) {
@@ -641,7 +641,7 @@ export async function createGroup(
   },
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const insertData = {
     id: group.id,
     name: group.name,
@@ -709,7 +709,7 @@ export async function updateGroup(
     updateData.height = updates.size.height;
   }
 
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   try {
     UpdateGroupSchema.parse(updateData as unknown);
   } catch (error) {
@@ -735,7 +735,7 @@ export async function deleteGroup(
   groupId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client.from('groups').delete().eq('id', groupId);
 
   if (error) {

--- a/src/shared/lib/supabase/services/relationships.ts
+++ b/src/shared/lib/supabase/services/relationships.ts
@@ -9,8 +9,8 @@ import {
   UpdateRelationshipSchema,
 } from '@/shared/lib/validation/zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { EvidenceItem, Relationship } from '../../types';
-import { supabase } from '../client';
 import type {
   Database,
   Json,
@@ -92,7 +92,7 @@ export async function createRelationship(
     console.error('Validation error creating relationship:', error);
     throw error;
   }
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
 
   const { data, error } = await client
     .from('relationships')
@@ -121,7 +121,7 @@ export async function updateRelationship(
     updateData.confidence = updates.confidence;
   if (updates.weight !== undefined) updateData.weight = updates.weight;
 
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   try {
     UpdateRelationshipSchema.parse(updateData as unknown);
   } catch (error) {
@@ -148,7 +148,7 @@ export async function deleteRelationship(
   id: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client.from('relationships').delete().eq('id', id);
 
   if (error) {
@@ -162,7 +162,7 @@ export async function getProjectRelationships(
   projectId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('relationships')
     .select(
@@ -217,7 +217,7 @@ export async function createEvidenceItem(
     insertData.content = (evidence.content ?? null) as Json;
   }
 
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('evidence_items')
     .insert(insertData)
@@ -251,7 +251,7 @@ export async function updateEvidenceItem(
   if (updates.impactOnConfidence !== undefined)
     updateData.impact_on_confidence = updates.impactOnConfidence;
 
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   try {
     UpdateEvidenceItemSchema.parse(updateData as unknown);
   } catch (error) {
@@ -283,7 +283,7 @@ export async function deleteEvidenceItem(
   id: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client.from('evidence_items').delete().eq('id', id);
 
   if (error) {
@@ -297,7 +297,7 @@ export async function getRelationshipEvidence(
   relationshipId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('evidence_items')
     .select('*')

--- a/src/shared/lib/supabase/services/sourceConnections.ts
+++ b/src/shared/lib/supabase/services/sourceConnections.ts
@@ -6,8 +6,8 @@
 // be read by the browser (see the product vault).
 
 import type { MetricValue } from '@/shared/types';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
 import type { Database } from '../types';
 import { seriesFromRows } from '@/features/canvas/utils/sourceBinding';
 
@@ -32,7 +32,7 @@ type Client = SupabaseClient<Database>;
 export async function listConnections(
   authenticatedClient?: Client
 ): Promise<SourceConnection[]> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('source_connections')
     .select(
@@ -49,7 +49,7 @@ export async function testConnection(
   password: string,
   authenticatedClient?: Client
 ): Promise<void> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client.functions.invoke('warehouse-proxy', {
     body: { action: 'test', connection, password },
   });
@@ -63,7 +63,7 @@ export async function saveConnection(
   password: string,
   authenticatedClient?: Client
 ): Promise<string> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client.functions.invoke('warehouse-proxy', {
     body: { action: 'save', connection, password },
   });
@@ -77,7 +77,7 @@ export async function deleteConnection(
   id: string,
   authenticatedClient?: Client
 ): Promise<void> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client
     .from('source_connections')
     .delete()
@@ -94,7 +94,7 @@ export async function runWarehouseQuery(
   sql: string,
   authenticatedClient?: Client
 ): Promise<MetricValue[]> {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client.functions.invoke('warehouse-proxy', {
     body: { action: 'query', connectionId, sql },
   });

--- a/src/shared/lib/supabase/services/spaces.ts
+++ b/src/shared/lib/supabase/services/spaces.ts
@@ -2,7 +2,7 @@
 // workspace later). A canvas (project) belongs to 0..1 space via projects.space_id.
 
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { Database } from '../types';
 
 type Client = SupabaseClient<Database>;
@@ -15,7 +15,7 @@ export interface Space {
 }
 
 export async function listSpaces(client?: Client): Promise<Space[]> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('spaces')
     .select('id, name, color, sort_order')
@@ -30,7 +30,7 @@ export async function createSpace(
   color?: string | null,
   client?: Client
 ): Promise<Space> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('spaces')
     .insert({ name, color: color ?? null })
@@ -45,7 +45,7 @@ export async function renameSpace(
   name: string,
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c
     .from('spaces')
     .update({ name, updated_at: new Date().toISOString() })
@@ -59,7 +59,7 @@ export async function updateSpace(
   patch: { name?: string; color?: string | null },
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c
     .from('spaces')
     .update({ ...patch, updated_at: new Date().toISOString() })
@@ -69,7 +69,7 @@ export async function updateSpace(
 
 /** Delete a space; its canvases unlink to Uncategorized via FK ON DELETE SET NULL. */
 export async function deleteSpace(id: string, client?: Client): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c.from('spaces').delete().eq('id', id);
   if (error) throw new Error(error.message);
 }
@@ -80,7 +80,7 @@ export async function setProjectSpace(
   spaceId: string | null,
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c
     .from('projects')
     .update({ space_id: spaceId })

--- a/src/shared/lib/supabase/services/tags.ts
+++ b/src/shared/lib/supabase/services/tags.ts
@@ -1,6 +1,6 @@
 import { CreateTagSchema, UpdateTagSchema } from '@/shared/lib/validation/zod';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
 import type { Database, Tables, TablesInsert, TablesUpdate } from '../types';
 import { createLogger } from '@/shared/utils/logger';
 
@@ -17,7 +17,7 @@ export async function getProjectTags(
 ) {
   // log.debug("🔍 Fetching project tags for projectId:", projectId);
 
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('tags')
     .select('*')
@@ -44,7 +44,7 @@ export async function createTag(
   tag: Omit<TagInsert, 'id' | 'created_at' | 'updated_at'>,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   try {
     CreateTagSchema.parse(tag as unknown);
   } catch (error) {
@@ -75,7 +75,7 @@ export async function updateTag(
   updates: TagUpdate,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   try {
     UpdateTagSchema.parse(updates as unknown);
   } catch (error) {
@@ -105,7 +105,7 @@ export async function deleteTag(
   tagId: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { error } = await client.from('tags').delete().eq('id', tagId);
 
   if (error) {
@@ -120,7 +120,7 @@ export async function searchProjectTags(
   query: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('tags')
     .select('*')
@@ -143,7 +143,7 @@ export async function getTagUsageStats(
   authenticatedClient?: SupabaseClient<Database>
 ) {
   // Get tags with their usage counts
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
   const { data, error } = await client
     .from('tags')
     .select(
@@ -171,7 +171,7 @@ export async function getMetricCardTags(
   // log.debug("🔍 Getting database tags for metric card:", metricCardId);
 
   try {
-    const client = authenticatedClient || supabase();
+    const client = resolveClient(authenticatedClient);
     const { data, error } = await client
       .from('metric_card_tags')
       .select(
@@ -205,7 +205,7 @@ export async function addTagsToMetricCard(
   // log.debug("🏷️ Adding database tags to metric card:", metricCardId, tagNames);
 
   try {
-    const client = authenticatedClient || supabase();
+    const client = resolveClient(authenticatedClient);
     // Get project ID for the metric card
     const { data: metricCard, error: fetchError } = await client
       .from('metric_cards')
@@ -266,7 +266,7 @@ export async function removeTagsFromMetricCard(
   // log.debug("🗑️ Removing database tags from metric card:", metricCardId, tagNames);
 
   try {
-    const client = authenticatedClient || supabase();
+    const client = resolveClient(authenticatedClient);
     // Get project ID for the metric card
     const { data: metricCard, error: fetchError } = await client
       .from('metric_cards')
@@ -324,7 +324,7 @@ export async function getRelationshipTags(
   // log.debug("🔍 Getting database tags for relationship:", relationshipId);
 
   try {
-    const client = authenticatedClient || supabase();
+    const client = resolveClient(authenticatedClient);
     const { data, error } = await client
       .from('relationship_tags')
       .select(
@@ -358,7 +358,7 @@ export async function addTagsToRelationship(
   // log.debug("🏷️ Adding database tags to relationship:", relationshipId, tagNames);
 
   try {
-    const client = authenticatedClient || supabase();
+    const client = resolveClient(authenticatedClient);
     // Get project ID for the relationship
     const { data: relationship, error: fetchError } = await client
       .from('relationships')
@@ -419,7 +419,7 @@ export async function removeTagsFromRelationship(
   // log.debug("🗑️ Removing database tags from relationship:", relationshipId, tagNames);
 
   try {
-    const client = authenticatedClient || supabase();
+    const client = resolveClient(authenticatedClient);
     // Get project ID for the relationship
     const { data: relationship, error: fetchError } = await client
       .from('relationships')
@@ -478,7 +478,7 @@ export async function getTagIdsByNames(
   // log.debug("🔄 Converting tag names to IDs:", tagNames);
 
   try {
-    const client = authenticatedClient || supabase();
+    const client = resolveClient(authenticatedClient);
     const { data: tags, error } = await client
       .from('tags')
       .select('id, name')

--- a/src/shared/lib/supabase/services/trackedMetrics.ts
+++ b/src/shared/lib/supabase/services/trackedMetrics.ts
@@ -5,8 +5,8 @@
 // Owner-scoped for now (created_by); re-scoped to the Clerk-org workspace later.
 
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import type { MetricValue } from '@/shared/types';
-import { supabase } from '../client';
 import type { Database } from '../types';
 
 type Client = SupabaseClient<Database>;
@@ -21,7 +21,7 @@ export async function getMetricValues(
   trackedMetricId: string,
   client?: Client
 ): Promise<MetricValue[]> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('metric_values')
     .select('period, value, change_percent, trend')
@@ -42,7 +42,7 @@ export async function getMetricValuesByMetricIds(
   client?: Client
 ): Promise<Record<string, MetricValue[]>> {
   if (!ids.length) return {};
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('metric_values')
     .select('tracked_metric_id, period, value, change_percent, trend')
@@ -69,7 +69,7 @@ export async function writeMetricValues(
   client?: Client
 ): Promise<void> {
   if (!series.length) return;
-  const c = client || supabase();
+  const c = resolveClient(client);
   const rows = series.map((p) => ({
     tracked_metric_id: trackedMetricId,
     period: p.period,
@@ -142,7 +142,7 @@ async function getExampleProjectIds(c: Client): Promise<Set<string>> {
 export async function listTrackedMetrics(
   client?: Client
 ): Promise<TrackedMetric[]> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const [exampleIds, { data, error }] = await Promise.all([
     getExampleProjectIds(c),
     c
@@ -169,7 +169,7 @@ export async function getTrackedMetricsByIds(
   client?: Client
 ): Promise<Record<string, TrackedMetric>> {
   if (!ids.length) return {};
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('tracked_metrics')
     .select(
@@ -190,7 +190,7 @@ export async function getTrackedMetricsByIds(
 export async function listCandidateCards(
   client?: Client
 ): Promise<CandidateCard[]> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const [exampleIds, { data, error }] = await Promise.all([
     getExampleProjectIds(c),
     c
@@ -236,7 +236,7 @@ export async function promoteCardToTrackedMetric(
   input: PromoteInput,
   client?: Client
 ): Promise<string> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('tracked_metrics')
     .insert({
@@ -279,7 +279,7 @@ export async function linkCardToMetric(
   trackedMetricId: string | null,
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c
     .from('metric_cards')
     .update({ tracked_metric_id: trackedMetricId })
@@ -292,7 +292,7 @@ export async function updateTrackedMetric(
   updates: Partial<Pick<TrackedMetric, 'name' | 'unit' | 'formula' | 'owner_label'>>,
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c
     .from('tracked_metrics')
     .update({ ...updates, updated_at: new Date().toISOString() })
@@ -313,7 +313,7 @@ export async function getMetricUsage(
   trackedMetricId: string,
   client?: Client
 ): Promise<MetricUsage[]> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('metric_cards')
     .select('id, title, project_id, projects(name)')
@@ -332,7 +332,7 @@ export async function deleteTrackedMetric(
   id: string,
   client?: Client
 ): Promise<void> {
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { error } = await c.from('tracked_metrics').delete().eq('id', id);
   if (error) throw new Error(error.message);
 }

--- a/src/shared/lib/supabase/services/users.ts
+++ b/src/shared/lib/supabase/services/users.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { supabase } from '../client';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 
 export interface UserLite {
   id: string;
@@ -14,7 +14,7 @@ export async function getUsersByIds(
   client?: SupabaseClient
 ): Promise<Record<string, UserLite>> {
   if (!ids.length) return {};
-  const c = client || supabase();
+  const c = resolveClient(client);
   const { data, error } = await c
     .from('users')
     .select('id, name, email, avatar_url')

--- a/src/shared/utils/authenticatedClient.ts
+++ b/src/shared/utils/authenticatedClient.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '../lib/supabase/types';
+import { supabase } from '../lib/supabase/client';
 
 // This is a temporary solution to get authenticated client in stores
 // In a real app, you'd want to pass the client through props or use a different pattern
@@ -16,6 +17,20 @@ export function setAuthenticatedClient(client: SupabaseClient<Database>) {
 
 export function getAuthenticatedClient(): SupabaseClient<Database> | null {
   return authenticatedClient;
+}
+
+/**
+ * Resolve the Supabase client for a data operation (CVS-82). An explicitly
+ * passed client wins; otherwise use the memoized Clerk-authenticated client;
+ * fall back to the anon client ONLY in genuinely anonymous contexts (public
+ * embed / showcase). Authenticated paths therefore never silently query as
+ * anon (which RLS would return empty), replacing the old `client || supabase()`
+ * fallback that reached for anon whenever no client was threaded through.
+ */
+export function resolveClient(
+  client?: SupabaseClient<Database> | null
+): SupabaseClient<Database> {
+  return client ?? getAuthenticatedClient() ?? supabase();
 }
 
 export function isAuthenticatedClientReady(): boolean {

--- a/src/shared/utils/devUserSync.ts
+++ b/src/shared/utils/devUserSync.ts
@@ -1,5 +1,5 @@
-import { supabase } from '@/shared/lib/supabase/client';
 import type { Database } from '@/shared/lib/supabase/types';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
 import { CreateUserSchema } from '@/shared/lib/validation/zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
@@ -9,7 +9,7 @@ export async function syncDevUserToProduction(
   name?: string,
   authenticatedClient?: SupabaseClient<Database>
 ) {
-  const client = authenticatedClient || supabase();
+  const client = resolveClient(authenticatedClient);
 
   try {
     // Check if user already exists


### PR DESCRIPTION
Closes CVS-82. (The Rules-of-Hooks half landed in CVS-64.)

> ⚠️ **Build-for-review — touches the whole data layer.** Safe-superset semantics + all checks green, but I can't runtime-verify auth without a live session. Smoke-test the auth paths (manual test) before merging.

## Problem
~120 spots did `client || supabase()`, so any service called without an explicit client silently queried as **anon** — under RLS that returns empty for a logged-in user's own data (silent load failures mid-session).

## Fix
- **`resolveClient(client?)`** (authenticatedClient.ts): explicit client → memoized Clerk-authenticated client → anon **only** as last resort.
- Migrated all **19 service/util files** off `client || supabase()`.
- **Exception preserved:** `errorReports` (crash sink) deliberately keeps the anon singleton so it works for logged-out / broken-session users.
- Anonymous **embed** + **showcase** still fall to anon (no authed client present) — verified those are the load-bearing anon paths.

Verify: type-check clean · 0 lint errors · 166 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)