### PR TITLE
feat(cvs-170): expose impact fields in Strategy board & table

### DIFF
--- a/src/features/strategy/components/ImpactChip.tsx
+++ b/src/features/strategy/components/ImpactChip.tsx
@@ -1,0 +1,49 @@
+// Compact impact summary for board tiles + table cells (CVS-170): status pill +
+// target metric + expected delta. Reads a pre-computed ImpactSummary.
+
+import { Target } from 'lucide-react';
+import { cn } from '@/shared/utils';
+import type { ImpactStatus } from '@/features/strategy/impact/types';
+import type { ImpactSummary } from '@/features/strategy/impact/impactContract';
+
+const IMPACT_STATUS_STYLES: Record<ImpactStatus, string> = {
+  draft: 'bg-muted text-muted-foreground',
+  planned: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  measuring: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  won: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  lost: 'bg-red-500/10 text-red-600 dark:text-red-400',
+  inconclusive: 'bg-zinc-500/10 text-zinc-600 dark:text-zinc-400',
+};
+
+interface ImpactChipProps {
+  summary: ImpactSummary;
+  className?: string;
+}
+
+export function ImpactChip({ summary, className }: ImpactChipProps) {
+  return (
+    <span className={cn('flex flex-wrap items-center gap-1.5', className)}>
+      <span
+        className={cn(
+          'rounded px-1.5 py-0.5 text-[10px] font-medium capitalize',
+          IMPACT_STATUS_STYLES[summary.status]
+        )}
+      >
+        {summary.status}
+      </span>
+      <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+        <Target className="h-3 w-3 shrink-0" />
+        {summary.hasTarget ? (
+          <span className="max-w-[120px] truncate">{summary.targetLabel}</span>
+        ) : (
+          <span className="italic">no target</span>
+        )}
+      </span>
+      {summary.deltaText && (
+        <span className="text-[10px] font-medium text-muted-foreground">
+          {summary.deltaText}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/features/strategy/components/StrategyBoard.tsx
+++ b/src/features/strategy/components/StrategyBoard.tsx
@@ -1,5 +1,6 @@
 import type { StrategyBoardData } from '@/features/strategy/utils/groupStrategy';
 import { StrategyCardTile } from '@/features/strategy/components/StrategyCardTile';
+import type { ImpactSummary } from '@/features/strategy/impact/impactContract';
 import type { WorkflowStatus } from '@/shared/types';
 import { cn } from '@/shared/utils';
 import { useState } from 'react';
@@ -11,12 +12,14 @@ interface StrategyBoardProps {
   board: StrategyBoardData;
   onStatusChange: (cardId: string, status: WorkflowStatus) => void;
   onCardClick?: (cardId: string) => void;
+  impactSummaries?: Record<string, ImpactSummary>;
 }
 
 export function StrategyBoard({
   board,
   onStatusChange,
   onCardClick,
+  impactSummaries,
 }: StrategyBoardProps) {
   const [dragOver, setDragOver] = useState<WorkflowStatus | null>(null);
 
@@ -56,6 +59,7 @@ export function StrategyBoard({
                 key={card.id}
                 card={card}
                 onClick={onCardClick}
+                impact={impactSummaries?.[card.id]}
               />
             ))}
           </div>

--- a/src/features/strategy/components/StrategyCardTile.tsx
+++ b/src/features/strategy/components/StrategyCardTile.tsx
@@ -1,5 +1,7 @@
 import { PRIORITY_STYLES } from '@/features/canvas/utils/workflow';
 import { Badge } from '@/shared/components/ui/badge';
+import { ImpactChip } from '@/features/strategy/components/ImpactChip';
+import type { ImpactSummary } from '@/features/strategy/impact/impactContract';
 import type { MetricCard } from '@/shared/types';
 import { cn } from '@/shared/utils';
 import { CalendarDays, FlaskConical, Hammer } from 'lucide-react';
@@ -10,9 +12,10 @@ import { CalendarDays, FlaskConical, Hammer } from 'lucide-react';
 interface StrategyCardTileProps {
   card: MetricCard;
   onClick?: (cardId: string) => void;
+  impact?: ImpactSummary;
 }
 
-export function StrategyCardTile({ card, onClick }: StrategyCardTileProps) {
+export function StrategyCardTile({ card, onClick, impact }: StrategyCardTileProps) {
   const isHypothesis = card.category === 'Ideas/Hypothesis';
   const workflow = card.workflow ?? {};
   const KindIcon = isHypothesis ? FlaskConical : Hammer;
@@ -78,6 +81,12 @@ export function StrategyCardTile({ card, onClick }: StrategyCardTileProps) {
           </span>
         )}
       </div>
+
+      {impact && (
+        <div className="border-t pt-2">
+          <ImpactChip summary={impact} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/strategy/components/StrategyTable.test.tsx
+++ b/src/features/strategy/components/StrategyTable.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StrategyTable } from './StrategyTable';
+import { buildGroupStrategy } from '@/features/strategy/utils/groupStrategy';
+import type { ImpactSummary } from '@/features/strategy/impact/impactContract';
+import type { MetricCard } from '@/shared/types';
+
+const card = (id: string, over: Partial<MetricCard> = {}): MetricCard => ({
+  id,
+  title: id,
+  description: '',
+  category: 'Work/Action',
+  tags: [],
+  causalFactors: [],
+  dimensions: [],
+  position: { x: 0, y: 0 },
+  assignees: [],
+  createdAt: '',
+  updatedAt: '',
+  ...over,
+});
+
+const summary = (over: Partial<ImpactSummary> = {}): ImpactSummary => ({
+  hasTarget: true,
+  targetLabel: 'Checkout CVR',
+  status: 'measuring',
+  deltaText: '+5%',
+  confidence: 'medium',
+  measureEnd: '2026-08',
+  ...over,
+});
+
+const noop = vi.fn();
+const handlers = {
+  onStatusChange: noop,
+  onPriorityChange: noop,
+  onAssigneesChange: noop,
+  onDueDateChange: noop,
+  onOpenCard: noop,
+  onOpenComments: noop,
+  onOpenImpact: noop,
+  onCreateItem: noop,
+  onDeleteCard: noop,
+};
+
+describe('StrategyTable — impact column', () => {
+  it('renders the Impact column with a chip for items that have a contract', () => {
+    const cards = [card('a1', { title: 'Ship new checkout' }), card('a2', { title: 'Explore upsell' })];
+    render(
+      <StrategyTable
+        board={buildGroupStrategy(cards)}
+        groups={[]}
+        userMap={{}}
+        members={[]}
+        commentCounts={{}}
+        impactSummaries={{ a1: summary() }}
+        canEdit
+        {...handlers}
+      />
+    );
+    // Column header (one per rendered status section)
+    expect(screen.getAllByText('Impact').length).toBeGreaterThan(0);
+    // a1 shows its impact chip (status + target metric)
+    expect(screen.getByText('measuring')).toBeInTheDocument();
+    expect(screen.getByText('Checkout CVR')).toBeInTheDocument();
+    // a2 (no contract) offers to add impact
+    expect(screen.getByText('+ Impact')).toBeInTheDocument();
+  });
+});

--- a/src/features/strategy/components/StrategyTable.tsx
+++ b/src/features/strategy/components/StrategyTable.tsx
@@ -45,6 +45,20 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/components/ui/select';
+import { ImpactChip } from '@/features/strategy/components/ImpactChip';
+import {
+  IMPACT_FILTERS,
+  matchesImpactFilter,
+  type ImpactFilter,
+  type ImpactSummary,
+} from '@/features/strategy/impact/impactContract';
 
 const STATUS_OPTIONS: PillOption<WorkflowStatus>[] = WORKFLOW_STATUSES.map(
   (s) => ({ value: s.value, label: s.label, className: WORKFLOW_STATUS_STYLES[s.value] })
@@ -73,6 +87,7 @@ interface StrategyTableProps extends StrategyTableHandlers {
   userMap: Record<string, UserLite>;
   members: ProjectMember[];
   commentCounts: Record<string, number>;
+  impactSummaries: Record<string, ImpactSummary>;
   canEdit: boolean;
 }
 
@@ -98,6 +113,7 @@ export function StrategyTable({
   userMap,
   members,
   commentCounts,
+  impactSummaries,
   canEdit,
   onStatusChange,
   onPriorityChange,
@@ -111,6 +127,9 @@ export function StrategyTable({
 }: StrategyTableProps) {
   const [search, setSearch] = useState('');
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const [impactFilter, setImpactFilter] = useState<ImpactFilter>('all');
+  // 'YYYY-MM' — drives the "review ready" filter (window ended while measuring).
+  const currentPeriod = useMemo(() => new Date().toISOString().slice(0, 7), []);
 
   // cardId -> the groups it belongs to (dot + name), from group node_ids.
   const cardGroups = useMemo(() => {
@@ -164,11 +183,32 @@ export function StrategyTable({
           placeholder="Search items…"
           className="h-8 max-w-xs"
         />
+
+        <Select
+          value={impactFilter}
+          onValueChange={(v) => setImpactFilter(v as ImpactFilter)}
+        >
+          <SelectTrigger className="h-8 w-40" aria-label="Filter by impact">
+            <Target className="h-3.5 w-3.5 opacity-70" />
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {IMPACT_FILTERS.map((f) => (
+              <SelectItem key={f.value} value={f.value}>
+                {f.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {board.columns.map((column) => {
-        const rows = column.cards.filter(matches);
-        if (query && rows.length === 0) return null;
+        const rows = column.cards
+          .filter(matches)
+          .filter((c) =>
+            matchesImpactFilter(impactFilter, impactSummaries[c.id], currentPeriod)
+          );
+        if ((query || impactFilter !== 'all') && rows.length === 0) return null;
         const isCollapsed = collapsed[column.status];
 
         return (
@@ -206,6 +246,7 @@ export function StrategyTable({
                       </TableHead>
                       <TableHead className="w-36">Type</TableHead>
                       <TableHead className="w-40">Group</TableHead>
+                      <TableHead className="w-48">Impact</TableHead>
                       <TableHead className="w-28">People</TableHead>
                       <TableHead className="w-28">Due</TableHead>
                       <TableHead className="w-32">Status</TableHead>
@@ -266,6 +307,24 @@ export function StrategyTable({
                                   </span>
                                 )}
                               </span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {impactSummaries[card.id] ? (
+                              <button
+                                onClick={() => onOpenImpact(card.id)}
+                                className="text-left"
+                                title="Edit impact"
+                              >
+                                <ImpactChip summary={impactSummaries[card.id]} />
+                              </button>
+                            ) : (
+                              <button
+                                onClick={() => onOpenImpact(card.id)}
+                                className="text-xs text-muted-foreground opacity-0 hover:text-primary group-hover:opacity-100"
+                              >
+                                + Impact
+                              </button>
                             )}
                           </TableCell>
                           <TableCell>

--- a/src/features/strategy/impact/impactContract.test.ts
+++ b/src/features/strategy/impact/impactContract.test.ts
@@ -4,7 +4,9 @@ import {
   groupLinksByRole,
   isMeasurable,
   isValidLinkInput,
+  matchesImpactFilter,
   metricRefKey,
+  summarizeImpact,
   targetLink,
 } from './impactContract';
 import type { ImpactContract, MetricLink } from './types';
@@ -91,6 +93,60 @@ describe('describeExpectedDelta', () => {
     expect(describeExpectedDelta(contract({ expectedDirection: 'stabilize' }))).toBe('stabilize');
     expect(describeExpectedDelta(contract({ expectedDirection: 'increase' }))).toBe('increase');
     expect(describeExpectedDelta(contract())).toBeNull();
+  });
+});
+
+describe('summarizeImpact', () => {
+  const cards = [
+    { id: 'card_cvr', title: 'Checkout CVR' },
+    { id: 'card_rev', title: 'Revenue', trackedMetricId: 'tm_rev' },
+  ];
+  it('resolves a card-ref target label', () => {
+    const s = summarizeImpact(
+      contract({ impactStatus: 'measuring', measureEnd: '2026-08' }),
+      [link({ role: 'target', refSource: 'card', trackedMetricId: null, cardId: 'card_cvr' })],
+      cards
+    );
+    expect(s).toMatchObject({ hasTarget: true, targetLabel: 'Checkout CVR', status: 'measuring', measureEnd: '2026-08' });
+  });
+  it('resolves a tracked-ref target via a canvas placement, else falls back', () => {
+    expect(
+      summarizeImpact(contract(), [link({ role: 'target', refSource: 'tracked', trackedMetricId: 'tm_rev', cardId: null })], cards).targetLabel
+    ).toBe('Revenue');
+    expect(
+      summarizeImpact(contract(), [link({ role: 'target', refSource: 'tracked', trackedMetricId: 'tm_missing', cardId: null })], cards).targetLabel
+    ).toBe('Tracked metric');
+  });
+  it('reports no target when only guardrails are linked', () => {
+    const s = summarizeImpact(contract(), [link({ role: 'guardrail', refSource: 'card', trackedMetricId: null, cardId: 'card_cvr' })], cards);
+    expect(s.hasTarget).toBe(false);
+    expect(s.targetLabel).toBeNull();
+  });
+});
+
+describe('matchesImpactFilter', () => {
+  const withTarget = summarizeImpact(
+    contract({ impactStatus: 'measuring', measureEnd: '2026-06' }),
+    [link({ role: 'target' })],
+    []
+  );
+  it('all matches everything incl. no-contract items', () => {
+    expect(matchesImpactFilter('all', undefined, '2026-07')).toBe(true);
+  });
+  it('missing_target matches no-contract and target-less items', () => {
+    expect(matchesImpactFilter('missing_target', undefined, '2026-07')).toBe(true);
+    const noTarget = summarizeImpact(contract(), [], []);
+    expect(matchesImpactFilter('missing_target', noTarget, '2026-07')).toBe(true);
+    expect(matchesImpactFilter('missing_target', withTarget, '2026-07')).toBe(false);
+  });
+  it('review_ready = measuring with an ended window', () => {
+    expect(matchesImpactFilter('review_ready', withTarget, '2026-07')).toBe(true); // ended 2026-06 < 2026-07
+    expect(matchesImpactFilter('review_ready', withTarget, '2026-06')).toBe(false); // not yet ended
+  });
+  it('status filters and no-contract exclusion', () => {
+    expect(matchesImpactFilter('measuring', withTarget, '2026-07')).toBe(true);
+    expect(matchesImpactFilter('won', withTarget, '2026-07')).toBe(false);
+    expect(matchesImpactFilter('has_target', undefined, '2026-07')).toBe(false);
   });
 });
 

--- a/src/features/strategy/impact/impactContract.ts
+++ b/src/features/strategy/impact/impactContract.ts
@@ -3,7 +3,9 @@
 // trace resolver (CVS-168).
 
 import type {
+  Confidence,
   ImpactContract,
+  ImpactStatus,
   MetricLink,
   MetricLinkInput,
   MetricLinkRole,
@@ -77,4 +79,102 @@ export function isMeasurable(contract: ImpactContract, links: MetricLink[]): boo
   const hasBaseline = !!contract.baselineStart || contract.baselineIsManual;
   const hasWindow = !!contract.measureStart;
   return hasTarget && hasBaseline && hasWindow;
+}
+
+/** A minimal card shape for resolving a target metric to a readable label. */
+export interface LabelledCard {
+  id: string;
+  title: string;
+  trackedMetricId?: string | null;
+}
+
+/** Compact, scannable view of a contract for board/table columns (CVS-170). */
+export interface ImpactSummary {
+  hasTarget: boolean;
+  targetLabel: string | null;
+  status: ImpactStatus;
+  deltaText: string | null;
+  confidence: Confidence | null;
+  measureEnd: string | null;
+}
+
+export function summarizeImpact(
+  contract: ImpactContract,
+  links: MetricLink[],
+  cards: LabelledCard[]
+): ImpactSummary {
+  const t = targetLink(links);
+  let targetLabel: string | null = null;
+  if (t) {
+    if (t.refSource === 'card' && t.cardId) {
+      targetLabel = cards.find((c) => c.id === t.cardId)?.title ?? 'Metric card';
+    } else if (t.refSource === 'tracked' && t.trackedMetricId) {
+      targetLabel =
+        cards.find((c) => c.trackedMetricId === t.trackedMetricId)?.title ?? 'Tracked metric';
+    }
+  }
+  return {
+    hasTarget: !!t,
+    targetLabel,
+    status: contract.impactStatus,
+    deltaText: describeExpectedDelta(contract),
+    confidence: contract.confidence,
+    measureEnd: contract.measureEnd,
+  };
+}
+
+export type ImpactFilter =
+  | 'all'
+  | 'has_target'
+  | 'missing_target'
+  | 'measuring'
+  | 'review_ready'
+  | 'won'
+  | 'lost'
+  | 'inconclusive';
+
+export const IMPACT_FILTERS: { value: ImpactFilter; label: string }[] = [
+  { value: 'all', label: 'All impact' },
+  { value: 'has_target', label: 'Has target' },
+  { value: 'missing_target', label: 'Missing target' },
+  { value: 'measuring', label: 'Measuring' },
+  { value: 'review_ready', label: 'Review ready' },
+  { value: 'won', label: 'Won' },
+  { value: 'lost', label: 'Lost' },
+  { value: 'inconclusive', label: 'Inconclusive' },
+];
+
+/**
+ * Predicate for a strategy item given its impact summary (or undefined when the
+ * item has no contract). `currentPeriod` is a 'YYYY-MM' used for "review ready"
+ * (window has ended while still measuring).
+ */
+export function matchesImpactFilter(
+  filter: ImpactFilter,
+  summary: ImpactSummary | undefined,
+  currentPeriod: string
+): boolean {
+  if (filter === 'all') return true;
+  if (filter === 'missing_target') return !summary || !summary.hasTarget;
+  if (!summary) return false;
+  switch (filter) {
+    case 'has_target':
+      return summary.hasTarget;
+    case 'measuring':
+      return summary.status === 'measuring';
+    case 'review_ready':
+      return (
+        summary.status === 'measuring' &&
+        !!summary.measureEnd &&
+        summary.measureEnd < currentPeriod
+      );
+    case 'won':
+      return summary.status === 'won';
+    case 'lost':
+      return summary.status === 'lost';
+    case 'inconclusive':
+      return summary.status === 'inconclusive';
+    default:
+      return true;
+  }
 }

--- a/src/features/strategy/pages/StrategyPage.tsx
+++ b/src/features/strategy/pages/StrategyPage.tsx
@@ -30,6 +30,15 @@ import { StrategyBoard } from '@/features/strategy/components/StrategyBoard';
 import { StrategyTable } from '@/features/strategy/components/StrategyTable';
 import { CardCommentSheet } from '@/features/strategy/components/CardCommentSheet';
 import { StrategyImpactSheet } from '@/features/strategy/components/StrategyImpactSheet';
+import { listContractsWithLinksForProject } from '@/shared/lib/supabase/services/strategyImpact';
+import {
+  summarizeImpact,
+  type ImpactSummary,
+} from '@/features/strategy/impact/impactContract';
+import type {
+  ImpactContract,
+  MetricLink,
+} from '@/features/strategy/impact/types';
 import { ValueJourneyStrip } from '@/features/strategy/components/ValueJourneyStrip';
 import { TaskPanel } from '@/features/canvas/components/panels/task-panel/TaskPanel';
 import {
@@ -81,6 +90,10 @@ export default function StrategyPage() {
   const [settingsCardId, setSettingsCardId] = useState<string | null>(null);
   const [commentCardId, setCommentCardId] = useState<string | null>(null);
   const [impactCardId, setImpactCardId] = useState<string | null>(null);
+  const [impactEntries, setImpactEntries] = useState<
+    Array<{ contract: ImpactContract; links: MetricLink[] }>
+  >([]);
+  const [impactReload, setImpactReload] = useState(0);
 
   // Prefer the live in-canvas store when it matches this canvas (fresher,
   // holds unsaved edits); otherwise fall back to what we loaded from the DB.
@@ -157,6 +170,22 @@ export default function StrategyPage() {
   useEffect(() => {
     refreshCommentCounts();
   }, [refreshCommentCounts]);
+
+  // Impact contracts for this canvas → keyed summaries for board/table columns.
+  useEffect(() => {
+    if (!client || !canvasId) return;
+    listContractsWithLinksForProject(canvasId, client)
+      .then(setImpactEntries)
+      .catch(() => setImpactEntries([]));
+  }, [client, canvasId, impactReload]);
+
+  const impactSummaries = useMemo(() => {
+    const map: Record<string, ImpactSummary> = {};
+    for (const { contract, links } of impactEntries) {
+      map[contract.strategyNodeId] = summarizeImpact(contract, links, cards);
+    }
+    return map;
+  }, [impactEntries, cards]);
 
   // Members carry avatars too — merge so a just-assigned person resolves before
   // the batched user fetch returns.
@@ -437,7 +466,12 @@ export default function StrategyPage() {
       </div>
 
       {viewMode === 'board' ? (
-        <StrategyBoard board={board} onStatusChange={handleStatusChange} />
+        <StrategyBoard
+          board={board}
+          onStatusChange={handleStatusChange}
+          onCardClick={setSettingsCardId}
+          impactSummaries={impactSummaries}
+        />
       ) : (
         <StrategyTable
           board={board}
@@ -445,6 +479,7 @@ export default function StrategyPage() {
           userMap={userMap}
           members={members}
           commentCounts={commentCounts}
+          impactSummaries={impactSummaries}
           canEdit={canEdit}
           onStatusChange={handleStatusChange}
           onPriorityChange={handlePriorityChange}
@@ -486,7 +521,12 @@ export default function StrategyPage() {
         relationships={edges}
         canEdit={canEdit}
         open={Boolean(impactCardId)}
-        onOpenChange={(open) => !open && setImpactCardId(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setImpactCardId(null);
+            setImpactReload((n) => n + 1);
+          }
+        }}
       />
     </div>
   );

--- a/src/shared/lib/supabase/services/strategyImpact.ts
+++ b/src/shared/lib/supabase/services/strategyImpact.ts
@@ -99,6 +99,38 @@ export async function listContractsForWorkspace(client?: Client): Promise<Impact
   return (data ?? []).map((r) => rowToContract(r as ContractRow));
 }
 
+/**
+ * All contracts originating on a canvas, each with its metric links — for the
+ * Strategy board/table impact columns + filters (CVS-170). Two queries.
+ */
+export async function listContractsWithLinksForProject(
+  projectId: string,
+  client?: Client
+): Promise<Array<{ contract: ImpactContract; links: MetricLink[] }>> {
+  const c = client || supabase();
+  const contracts = await listContractsForProject(projectId, c);
+  if (!contracts.length) return [];
+  const { data, error } = await c
+    .from('strategy_metric_links')
+    .select(LINK_COLS)
+    .in(
+      'contract_id',
+      contracts.map((ct) => ct.id)
+    );
+  if (error) throw new Error(error.message);
+  const linksByContract = new Map<string, MetricLink[]>();
+  for (const r of data ?? []) {
+    const link = rowToLink(r as LinkRow);
+    const list = linksByContract.get(link.contractId) ?? [];
+    list.push(link);
+    linksByContract.set(link.contractId, list);
+  }
+  return contracts.map((contract) => ({
+    contract,
+    links: linksByContract.get(contract.id) ?? [],
+  }));
+}
+
 export interface UpsertContractInput {
   strategyNodeId: string;
   projectId?: string | null;


### PR DESCRIPTION
Closes **CVS-170** (Strategy impact — Milestone 2). **Stacked on [#64](https://github.com/nadeemramli/metrimap/pull/64) → #60 → #59.**

## What
Surfaces impact contracts as scannable metadata across the Strategy board & table.

- **Table:** new **Impact column** (status pill + target metric + expected delta via a reused `ImpactChip`; "+ Impact" affordance when none) and an **impact filter** Select — *has / missing target, measuring, review-ready (window ended), won / lost / inconclusive*.
- **Board:** compact impact chip on each tile.
- **Data:** `listContractsWithLinksForProject()` batch loader; `StrategyPage` builds keyed summaries and reloads them when the Impact sheet closes.
- **Pure logic:** `summarizeImpact()` + `matchesImpactFilter()` (unit-tested).

## Verification
- `type-check` ✅ · lint (my files) ✅ · **full vitest 192/192** ✅ — adds filter/summary unit tests + a `StrategyTable` render test.

**Scope note:** sort-by (measure-end/confidence/delta) is in the issue's *Scope* but **not** its acceptance criteria; the table is sectioned by status, so a global sort is a clean follow-up rather than part of this PR. All acceptance criteria (columns, filters, find-missing-target, find-measuring/review, stability) are met. Backward compatible — items without a contract are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)