### PR TITLE
feat(CVS-103): Connect-your-agent settings page + MCP docs

### DIFF
--- a/docs/features/mcp-connect.md
+++ b/docs/features/mcp-connect.md
@@ -1,0 +1,76 @@
+# Connect your agent to Metrimap (MCP)
+
+User-facing setup for pointing an agent (Claude Cowork/Code, Codex, any HTTP MCP
+client) at Metrimap's MCP server so it can **build and populate your metric
+trees**. This is the source for the `docs.canvasm.app` connect guide; the in-app
+version lives at **Settings → Connect your agent** (`/settings/connect`, CVS-103).
+
+Every tool call runs under **your** account (RLS-scoped) — your key is never
+shared, and the server never uses a service-role key.
+
+## 1. Get an API key
+
+In Metrimap: **Settings → Connect your agent → Generate key** (or Account
+Settings → API keys). Copy it once — it's shown only once. Non-interactive
+clients authenticate with `Authorization: Bearer <key>`. (OAuth "sign in →
+connected" is coming.)
+
+## 2. Add the server
+
+**Claude Code / Cowork (CLI):**
+
+```bash
+claude mcp add --transport http metrimap https://mcp.canvasm.app/mcp \
+  --header "Authorization: Bearer <YOUR_API_KEY>"
+```
+
+**claude.ai:** Settings → Connectors → Add custom connector → paste
+`https://mcp.canvasm.app/mcp` and set the `Authorization: Bearer <key>` header.
+
+**Codex / other MCP clients:** point them at the same URL with the same
+`Authorization` header.
+
+## 3. Example — build a driver tree from your data
+
+A typical agent session (the agent pulls data with **Composio**/other MCPs, then
+pushes structure + values into Metrimap):
+
+1. `create_canvas` → "SaaS growth model" (returns a canvas id).
+2. `create_value` → "Profit" (the outcome).
+3. `create_driver_node` → "MRR", "Churn", "CAC" (input drivers).
+4. `create_relationship` → MRR → Profit (`Causal`), Churn → Profit (`Causal`), …
+5. `layout_tree` → tidy Dagre layout so it renders sensibly.
+6. Pull GA4 / Stripe series via Composio, then `upload_csv` (or `stage_series`)
+   → `materialize` onto the matching card. The canvas now visualises the data.
+
+Tip: call `get_tree` first so the agent **extends** an existing tree instead of
+duplicating nodes.
+
+## Tool reference (v1)
+
+| Tool | Scope | What it does |
+|---|---|---|
+| `list_canvases` | read | Your canvases (projects) + ids |
+| `get_tree` | read | A canvas's full structure (cards + relationships) |
+| `list_nodes` / `list_relationships` | read | Nodes / relationships on a canvas |
+| `create_canvas` / `update_canvas` / `delete_canvas` | write | Canvas CRUD |
+| `create_metric` | write | A `Data/Metric` card |
+| `create_value` | write | A `Core/Value` (outcome) card |
+| `create_driver_node` | write | An input-driver metric (`Input Metric`) |
+| `create_action` | write | A `Work/Action` card |
+| `update_node` / `delete_node` | write | Node update / delete |
+| `create_relationship` / `delete_relationship` | write | Typed link: Deterministic / Probabilistic / Causal / Compositional |
+| `layout_tree` | write | Auto-layout (Dagre) so a built tree renders well |
+| `push_values` | write | Upsert a tracked-metric value series |
+| `stage_series` / `upload_csv` | write | Stage data (TTL) for mapping |
+| `materialize` | write | Map a staged batch onto a card → the canvas shows it |
+
+## Limits & safety
+
+- **Rate-limited** per key; **payload caps** (CSV ≤ ~1 MB); calls are **audited**.
+- **Scopes**: keys are read+write by default (finer per-key scopes are coming).
+- **Revoke** a key anytime in Account Settings → API keys; it stops working
+  immediately.
+
+_Server status: the MCP server (CVS-100) is built; hosting + deploy is being set
+up. Until it's live, the URL above won't accept connections yet._

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ CVS). See the **Docs policy** in [`../AGENTS.md`](../AGENTS.md).
   [userback-customer-requests](features/userback-customer-requests.md),
   [security-scanning](features/security-scanning.md),
   [programmatic-api](features/programmatic-api.md),
-  [mcp-server](features/mcp-server.md),
+  [mcp-server](features/mcp-server.md), [mcp-connect](features/mcp-connect.md),
   [metrics-api](features/metrics-api.md)
 
 Anything product-facing (feature narratives, changelogs, methodology, PRD) belongs

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import CatalogPage from './features/catalog/pages/CatalogPage';
 import FeedPage from './features/notifications/pages/FeedPage';
 import WorkspaceSettingsPage from './features/settings/pages/WorkspaceSettingsPage';
 import AccountSettingsPage from './features/settings/pages/AccountSettingsPage';
+import ConnectAgentPage from './features/settings/pages/ConnectAgentPage';
 import EmbedCanvasPage from './features/canvas/pages/EmbedCanvasPage';
 import HomePage from './features/projects/pages/HomePage';
 
@@ -160,6 +161,14 @@ export default function App() {
                   element={
                     <ProtectedRoute>
                       <WorkspaceSettingsPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/settings/connect"
+                  element={
+                    <ProtectedRoute>
+                      <ConnectAgentPage />
                     </ProtectedRoute>
                   }
                 />

--- a/src/features/settings/pages/ConnectAgentPage.tsx
+++ b/src/features/settings/pages/ConnectAgentPage.tsx
@@ -1,0 +1,266 @@
+import { Badge } from '@/shared/components/ui/badge';
+import { Button } from '@/shared/components/ui/button';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import {
+  createApiKey,
+  listApiKeys,
+  type ApiKey,
+} from '@/shared/lib/supabase/services/apiKeys';
+import {
+  ArrowLeft,
+  Bot,
+  Copy,
+  KeyRound,
+  Link2,
+  Plug,
+  Terminal,
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+// The hosted MCP endpoint. Overridable per environment; defaults to the planned
+// production URL. (The server itself is CVS-100; hosting is being set up.)
+const MCP_URL =
+  (import.meta.env.VITE_MCP_URL as string | undefined) ||
+  'https://mcp.canvasm.app/mcp';
+
+function Section({
+  icon: Icon,
+  title,
+  description,
+  action,
+  children,
+}: {
+  icon: React.ElementType;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="mb-4 flex items-center gap-2">
+        <Icon className="h-4 w-4 text-primary" />
+        <h2 className="text-base font-semibold">{title}</h2>
+        {action && <div className="ml-auto">{action}</div>}
+      </div>
+      {description && (
+        <p className="-mt-3 mb-4 text-sm text-muted-foreground">{description}</p>
+      )}
+      {children}
+    </section>
+  );
+}
+
+function CopyBlock({ text }: { text: string }) {
+  return (
+    <div className="flex items-start gap-2">
+      <code className="flex-1 overflow-x-auto whitespace-pre rounded bg-background px-3 py-2 font-mono text-xs">
+        {text}
+      </code>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() =>
+          navigator.clipboard.writeText(text).then(
+            () => toast.success('Copied'),
+            () => toast.error('Copy failed')
+          )
+        }
+      >
+        <Copy className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * "Connect your agent" — the in-app setup for pointing an agent (Claude
+ * Cowork/Code, Codex) at Metrimap's MCP server (CVS-103). Shows the MCP URL, a
+ * ready-to-paste `claude mcp add` snippet, and an inline API-key generator (keys
+ * are also managed under Account Settings). OAuth "Connect" sign-in is a
+ * follow-up (CVS-99). Reachable at /settings/connect.
+ */
+export default function ConnectAgentPage() {
+  const navigate = useNavigate();
+  const client = useClerkSupabase();
+
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [freshKey, setFreshKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!client) return;
+    listApiKeys(client)
+      .then(setKeys)
+      .catch(() => setKeys([]));
+  }, [client]);
+
+  const generateKey = async () => {
+    if (!client) return;
+    const name = window.prompt('Name this key (e.g. "Claude Code")')?.trim();
+    if (!name) return;
+    try {
+      const { key, row } = await createApiKey(name, client);
+      setKeys((prev) => [row, ...prev]);
+      setFreshKey(key);
+    } catch {
+      toast.error('Failed to create API key');
+    }
+  };
+
+  const keyForSnippet = freshKey ?? '<YOUR_API_KEY>';
+  const cliSnippet = useMemo(
+    () =>
+      `claude mcp add --transport http metrimap ${MCP_URL} \\\n  --header "Authorization: Bearer ${keyForSnippet}"`,
+    [keyForSnippet]
+  );
+
+  const lastUsed = keys
+    .map((k) => k.last_used_at)
+    .filter(Boolean)
+    .sort()
+    .pop();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="sticky top-0 z-10 border-b border-border bg-card/50 backdrop-blur-sm">
+        <div className="flex items-center gap-3 px-6 py-3">
+          <Button variant="ghost" size="sm" onClick={() => navigate('/')}>
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Home
+          </Button>
+          <h1 className="text-xl font-bold">Connect your agent</h1>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto"
+            onClick={() => navigate('/settings')}
+          >
+            <KeyRound className="mr-1 h-4 w-4" />
+            Manage keys
+          </Button>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-3xl space-y-5 px-6 py-6">
+        <p className="text-sm text-muted-foreground">
+          Point your own agent (Claude Cowork/Code, Codex) at Metrimap's MCP
+          server so it can build & populate your metric trees. Every call runs
+          under your account (RLS-scoped) — your key is never shared.
+        </p>
+
+        {/* MCP endpoint */}
+        <Section
+          icon={Link2}
+          title="MCP server URL"
+          description="The endpoint your agent connects to."
+        >
+          <CopyBlock text={MCP_URL} />
+        </Section>
+
+        {/* API key */}
+        <Section
+          icon={KeyRound}
+          title="1. Get an API key"
+          description="Non-interactive clients authenticate with a personal key (Authorization: Bearer). Copy it now — it's shown only once."
+          action={
+            <Button variant="outline" size="sm" onClick={generateKey}>
+              Generate key
+            </Button>
+          }
+        >
+          {freshKey ? (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/50 dark:bg-amber-950/30">
+              <p className="mb-2 text-xs font-medium text-amber-800 dark:text-amber-300">
+                Copy your key now — it won't be shown again.
+              </p>
+              <CopyBlock text={freshKey} />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mt-2"
+                onClick={() => setFreshKey(null)}
+              >
+                Done
+              </Button>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground/70">
+              {keys.length > 0
+                ? `${keys.length} key(s) exist. Generate a new one for this agent, or manage them under Account Settings.`
+                : 'No keys yet — generate one to use in the command below.'}
+            </p>
+          )}
+        </Section>
+
+        {/* Claude */}
+        <Section
+          icon={Terminal}
+          title="2. Add to Claude Code / Cowork"
+          description="Run this in your terminal (fill in your key), or add it as an HTTP connector on claude.ai."
+        >
+          <CopyBlock text={cliSnippet} />
+          <p className="mt-3 text-xs text-muted-foreground">
+            claude.ai → Settings → Connectors → Add custom connector → paste the
+            URL above and set the <code>Authorization: Bearer</code> header.
+          </p>
+        </Section>
+
+        {/* Codex / other */}
+        <Section
+          icon={Bot}
+          title="3. Codex & other MCP clients"
+          description="Any HTTP MCP client works — point it at the URL and send the same Authorization header."
+        >
+          <CopyBlock
+            text={`Authorization: Bearer ${keyForSnippet}`}
+          />
+        </Section>
+
+        {/* OAuth (follow-up) */}
+        <Section
+          icon={Plug}
+          title="Connect with sign-in (OAuth)"
+          description="One-click “sign in → connected”, no key to copy."
+        >
+          <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
+            <span className="text-sm text-muted-foreground">
+              OAuth “Connect” flow
+            </span>
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary" className="font-normal">
+                Soon
+              </Badge>
+              <Button variant="outline" size="sm" disabled>
+                Connect
+              </Button>
+            </div>
+          </div>
+        </Section>
+
+        {/* Status */}
+        <Section
+          icon={Bot}
+          title="Connection status"
+          description="Recent activity from your keys. Detailed per-client usage lands with the audit log."
+        >
+          <div className="rounded-md border border-border px-3 py-2 text-sm">
+            {keys.length === 0 ? (
+              <span className="text-muted-foreground/70">
+                No keys yet — not connected.
+              </span>
+            ) : (
+              <span>
+                {keys.length} key(s) ·{' '}
+                {lastUsed
+                  ? `last used ${new Date(lastUsed).toLocaleString()}`
+                  : 'never used yet'}
+              </span>
+            )}
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
The in-app "Connect your agent" setup + the docs.canvasm.app connect guide.

## In-app — `/settings/connect` (`ConnectAgentPage`)
- **MCP URL** (copyable; `VITE_MCP_URL`, defaults to `mcp.canvasm.app/mcp`).
- **Generate an API key** inline (reuses `apiKeys.ts` — shown once, auto-fills the snippet) + link to Account Settings to manage keys.
- **`claude mcp add`** snippet (copyable) with the `Authorization: Bearer` header; claude.ai connector + Codex instructions.
- **Connection status** (from keys' `last_used_at`; richer per-client usage arrives with the audit log).
- **OAuth "Connect"** — "Soon" placeholder (CVS-99 follow-up).
- New self-contained page + **one route** — deliberately does **not** edit `AccountSettingsPage` (Account & Settings lane).

## Docs — `docs/features/mcp-connect.md`
Setup for Claude Code/Cowork + claude.ai + Codex, a Composio "build my driver tree from GA4/Stripe" walkthrough, and the v1 **tool reference**. Source for docs.canvasm.app.

## Acceptance criteria
- [x] In-app "Connect your agent" with URL + CLI snippet (+ OAuth placeholder).
- [x] Connection status shown.
- [x] Docs page with setup + end-to-end example + tool reference.

Follow-up: a nav entry to `/settings/connect` (small, in the Account & Settings lane / CVS-92) so it's linked, not just routable.

Verify: type-check + eslint + `vitest run` (166 passing) green.

Ref: CVS-103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)