### PR TITLE
feat(cvs-171): Strategy Tree view (KPI → pillar → action → metrics)

### DIFF
--- a/src/features/strategy/components/StrategyTree.test.tsx
+++ b/src/features/strategy/components/StrategyTree.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StrategyTree } from './StrategyTree';
+import type { MetricCard, Relationship } from '@/shared/types';
+import type { ImpactContract, MetricLink } from '@/features/strategy/impact/types';
+
+const card = (id: string, over: Partial<MetricCard> = {}): MetricCard => ({
+  id,
+  title: id,
+  description: '',
+  category: 'Work/Action',
+  tags: [],
+  causalFactors: [],
+  dimensions: [],
+  position: { x: 0, y: 0 },
+  assignees: [],
+  createdAt: '',
+  updatedAt: '',
+  ...over,
+});
+
+const contract = (nodeId: string): ImpactContract => ({
+  id: `c_${nodeId}`,
+  workspaceId: null,
+  projectId: null,
+  strategyNodeId: nodeId,
+  expectedDirection: 'increase',
+  expectedDeltaValue: 5,
+  expectedDeltaUnit: 'percent',
+  baselineStart: null,
+  baselineEnd: null,
+  measureStart: null,
+  measureEnd: null,
+  baselineIsManual: false,
+  confidence: 'medium',
+  impactStatus: 'measuring',
+  ownerLabel: null,
+  resultNote: null,
+  createdBy: 'u',
+  createdAt: '',
+  updatedAt: '',
+});
+
+const link = (contractId: string, cardId: string): MetricLink => ({
+  id: `l_${cardId}`,
+  contractId,
+  role: 'target',
+  refSource: 'card',
+  trackedMetricId: null,
+  cardId,
+});
+
+describe('StrategyTree', () => {
+  const cards: MetricCard[] = [
+    card('kpi', { title: 'North Star', category: 'Core/Value' }),
+    card('cvr', { title: 'Checkout CVR', category: 'Data/Metric' }),
+    card('act_with', { title: 'Ship new checkout' }),
+    card('act_without', { title: 'Explore upsell' }),
+  ];
+  // act_with targets cvr, which rolls up to the KPI.
+  const relationships: Relationship[] = [
+    {
+      id: 'e1',
+      sourceId: 'cvr',
+      targetId: 'kpi',
+      type: 'Deterministic',
+      confidence: 'High',
+      evidence: [],
+      createdAt: '',
+      updatedAt: '',
+    },
+  ];
+  const impactByNode = {
+    act_with: { contract: contract('act_with'), links: [link('c_act_with', 'cvr')] },
+  };
+
+  it('renders KPI header, work items, target path, and empty state', () => {
+    render(
+      <StrategyTree
+        cards={cards}
+        groups={[]}
+        relationships={relationships}
+        impactByNode={impactByNode}
+        onOpenImpact={vi.fn()}
+      />
+    );
+    // KPI header
+    expect(screen.getByText('North Star')).toBeInTheDocument();
+    // Both work items present (grouped under "Ungrouped")
+    expect(screen.getByText('Ship new checkout')).toBeInTheDocument();
+    expect(screen.getByText('Explore upsell')).toBeInTheDocument();
+    // Item with a target shows the roll-up path to the KPI
+    expect(screen.getByText('Checkout CVR → North Star')).toBeInTheDocument();
+    // Item without a contract shows the actionable empty state
+    expect(
+      screen.getByText('+ Add a target metric to measure impact')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/strategy/components/StrategyTree.tsx
+++ b/src/features/strategy/components/StrategyTree.tsx
@@ -1,0 +1,251 @@
+// Strategy Tree view (CVS-171): KPI → pillar (group) → hypothesis/action →
+// linked metrics. Adapts the Speero-style strategy tree to Metrimap — work cards
+// anchor to tracked metrics and roll up to the KPI via the CVS-168 resolver.
+// Pillars/problems = canvas groups (per the CVS-166 locked decision). Read-only
+// structure view; editing happens in the Impact panel (opens via onOpenImpact).
+
+import { useMemo, useState } from 'react';
+import { FlaskConical, Hammer, Target, TrendingUp } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/components/ui/select';
+import { ImpactChip } from '@/features/strategy/components/ImpactChip';
+import { isWorkCard } from '@/features/strategy/utils/groupStrategy';
+import {
+  IMPACT_FILTERS,
+  matchesImpactFilter,
+  summarizeImpact,
+  type ImpactFilter,
+} from '@/features/strategy/impact/impactContract';
+import { resolveImpactTrace } from '@/features/strategy/impact/impactTrace';
+import type { ImpactContract, MetricLink } from '@/features/strategy/impact/types';
+import type { GroupNode, MetricCard, Relationship } from '@/shared/types';
+
+interface StrategyTreeProps {
+  cards: MetricCard[];
+  groups: GroupNode[];
+  relationships: Relationship[];
+  impactByNode: Record<string, { contract: ImpactContract; links: MetricLink[] }>;
+  onOpenImpact: (cardId: string) => void;
+}
+
+const UNGROUPED = '__ungrouped__';
+
+export function StrategyTree({
+  cards,
+  groups,
+  relationships,
+  impactByNode,
+  onOpenImpact,
+}: StrategyTreeProps) {
+  const [filter, setFilter] = useState<ImpactFilter>('all');
+  const currentPeriod = useMemo(() => new Date().toISOString().slice(0, 7), []);
+
+  // KPIs = the Core/Value backbone of the canvas.
+  const kpis = useMemo(
+    () => cards.filter((c) => c.category === 'Core/Value'),
+    [cards]
+  );
+
+  const workCards = useMemo(() => {
+    const work = cards.filter(isWorkCard);
+    return work.filter((c) => {
+      const entry = impactByNode[c.id];
+      const summary = entry
+        ? summarizeImpact(entry.contract, entry.links, cards)
+        : undefined;
+      return matchesImpactFilter(filter, summary, currentPeriod);
+    });
+  }, [cards, impactByNode, filter, currentPeriod]);
+
+  // Bucket work cards under their pillar (group), or Ungrouped.
+  const pillars = useMemo(() => {
+    const groupOf = (card: MetricCard): GroupNode | null =>
+      groups.find(
+        (g) => (g.nodeIds || []).includes(card.id) || card.parentId === g.id
+      ) ?? null;
+    const buckets = new Map<string, { group: GroupNode | null; items: MetricCard[] }>();
+    for (const card of workCards) {
+      const g = groupOf(card);
+      const key = g?.id ?? UNGROUPED;
+      if (!buckets.has(key)) buckets.set(key, { group: g, items: [] });
+      buckets.get(key)!.items.push(card);
+    }
+    // Groups first (stable order), Ungrouped last.
+    return Array.from(buckets.values()).sort((a, b) => {
+      if (!a.group) return 1;
+      if (!b.group) return -1;
+      return a.group.name.localeCompare(b.group.name);
+    });
+  }, [workCards, groups]);
+
+  return (
+    <div className="space-y-5">
+      {/* KPI header */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          KPIs
+        </span>
+        {kpis.length === 0 ? (
+          <span className="text-xs text-muted-foreground">
+            Add Core/Value nodes on the canvas to anchor the tree.
+          </span>
+        ) : (
+          kpis.map((k) => (
+            <span
+              key={k.id}
+              className="inline-flex items-center gap-1.5 rounded-full border bg-primary/5 px-3 py-1 text-sm font-medium"
+            >
+              <TrendingUp className="h-3.5 w-3.5 text-primary" />
+              {k.title || 'Untitled'}
+            </span>
+          ))
+        )}
+        <div className="ml-auto">
+          <Select value={filter} onValueChange={(v) => setFilter(v as ImpactFilter)}>
+            <SelectTrigger className="h-8 w-40" aria-label="Filter tree by impact">
+              <Target className="h-3.5 w-3.5 opacity-70" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {IMPACT_FILTERS.map((f) => (
+                <SelectItem key={f.value} value={f.value}>
+                  {f.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {pillars.length === 0 ? (
+        <p className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          No strategy items match this filter.
+        </p>
+      ) : (
+        pillars.map(({ group, items }) => (
+          <div key={group?.id ?? UNGROUPED} className="space-y-2">
+            {/* Pillar / problem grouping */}
+            <div className="flex items-center gap-2">
+              <span
+                className="h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: group?.color || '#94a3b8' }}
+              />
+              <span className="text-sm font-semibold">
+                {group?.name ?? 'Ungrouped'}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {items.length} item{items.length === 1 ? '' : 's'}
+              </span>
+            </div>
+
+            <div className="ml-1.5 space-y-2 border-l pl-4">
+              {items.map((card) => (
+                <StrategyTreeItem
+                  key={card.id}
+                  card={card}
+                  entry={impactByNode[card.id]}
+                  cards={cards}
+                  relationships={relationships}
+                  onOpenImpact={onOpenImpact}
+                />
+              ))}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+interface StrategyTreeItemProps {
+  card: MetricCard;
+  entry?: { contract: ImpactContract; links: MetricLink[] };
+  cards: MetricCard[];
+  relationships: Relationship[];
+  onOpenImpact: (cardId: string) => void;
+}
+
+function StrategyTreeItem({
+  card,
+  entry,
+  cards,
+  relationships,
+  onOpenImpact,
+}: StrategyTreeItemProps) {
+  const isHypothesis = card.category === 'Ideas/Hypothesis';
+  const KindIcon = isHypothesis ? FlaskConical : Hammer;
+
+  const links = useMemo(() => entry?.links ?? [], [entry]);
+  const trace = useMemo(
+    () =>
+      resolveImpactTrace({
+        strategyNodeId: card.id,
+        links,
+        cards,
+        relationships,
+        widgets: [],
+      }),
+    [card.id, links, cards, relationships]
+  );
+  const summary = entry
+    ? summarizeImpact(entry.contract, entry.links, cards)
+    : undefined;
+
+  const kpiPathLabels = trace.kpiPath.map((c) => c.title || 'Untitled');
+
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="flex items-start justify-between gap-2">
+        <button
+          onClick={() => onOpenImpact(card.id)}
+          className="flex items-center gap-2 text-left text-sm font-medium hover:text-primary"
+        >
+          <KindIcon
+            className={isHypothesis ? 'h-4 w-4 text-purple-500' : 'h-4 w-4 text-blue-500'}
+          />
+          {card.title || 'Untitled'}
+        </button>
+        {summary && <ImpactChip summary={summary} />}
+      </div>
+
+      {!trace.target ? (
+        <button
+          onClick={() => onOpenImpact(card.id)}
+          className="mt-2 text-xs text-muted-foreground hover:text-primary"
+        >
+          + Add a target metric to measure impact
+        </button>
+      ) : (
+        <div className="mt-2 space-y-1 text-xs">
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground">Target:</span>
+            <span className="font-medium">
+              {kpiPathLabels.length > 0
+                ? kpiPathLabels.join(' → ')
+                : `${trace.target.label}${
+                    trace.missing.targetNotOnCanvas ? ' (not on this canvas)' : ' (no KPI path yet)'
+                  }`}
+            </span>
+          </div>
+          {trace.leading.length > 0 && (
+            <div className="flex items-center gap-1.5">
+              <span className="text-muted-foreground">Leading:</span>
+              <span>{trace.leading.map((l) => l.label ?? '—').join(', ')}</span>
+            </div>
+          )}
+          {trace.guardrails.length > 0 && (
+            <div className="flex items-center gap-1.5">
+              <span className="text-muted-foreground">Guardrails:</span>
+              <span>{trace.guardrails.map((g) => g.label ?? '—').join(', ')}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/strategy/pages/StrategyPage.tsx
+++ b/src/features/strategy/pages/StrategyPage.tsx
@@ -28,6 +28,7 @@ import type { PriorityLevel } from '@/features/canvas/utils/workflow';
 import { resolveGroupMembers } from '@/features/dashboard/utils/groupDashboard';
 import { StrategyBoard } from '@/features/strategy/components/StrategyBoard';
 import { StrategyTable } from '@/features/strategy/components/StrategyTable';
+import { StrategyTree } from '@/features/strategy/components/StrategyTree';
 import { CardCommentSheet } from '@/features/strategy/components/CardCommentSheet';
 import { StrategyImpactSheet } from '@/features/strategy/components/StrategyImpactSheet';
 import { listContractsWithLinksForProject } from '@/shared/lib/supabase/services/strategyImpact';
@@ -47,7 +48,7 @@ import {
 } from '@/features/strategy/utils/groupStrategy';
 import { buildValueJourney } from '@/features/strategy/utils/valueJourney';
 import { cn } from '@/shared/utils';
-import { Loader2, Plus, SquareKanban, Table as TableIcon } from 'lucide-react';
+import { Loader2, Plus, SquareKanban, Table as TableIcon, Target } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -57,7 +58,7 @@ import { toast } from 'sonner';
 // (Monday.com-style) views over the same work cards.
 
 const ALL_VIEW = '__all__';
-type ViewMode = 'board' | 'table';
+type ViewMode = 'board' | 'table' | 'tree';
 
 export default function StrategyPage() {
   const { canvasId } = useParams();
@@ -186,6 +187,12 @@ export default function StrategyPage() {
     }
     return map;
   }, [impactEntries, cards]);
+
+  const impactByNode = useMemo(() => {
+    const map: Record<string, { contract: ImpactContract; links: MetricLink[] }> = {};
+    for (const e of impactEntries) map[e.contract.strategyNodeId] = e;
+    return map;
+  }, [impactEntries]);
 
   // Members carry avatars too — merge so a just-assigned person resolves before
   // the batched user fetch returns.
@@ -449,11 +456,20 @@ export default function StrategyPage() {
           <Button
             variant={viewMode === 'table' ? 'default' : 'ghost'}
             size="sm"
-            className="h-8 gap-1.5 rounded-l-none"
+            className="h-8 gap-1.5 rounded-none"
             onClick={() => setViewMode('table')}
           >
             <TableIcon className="h-3.5 w-3.5" />
             Table
+          </Button>
+          <Button
+            variant={viewMode === 'tree' ? 'default' : 'ghost'}
+            size="sm"
+            className="h-8 gap-1.5 rounded-l-none"
+            onClick={() => setViewMode('tree')}
+          >
+            <Target className="h-3.5 w-3.5" />
+            Tree
           </Button>
         </div>
       </div>
@@ -471,6 +487,14 @@ export default function StrategyPage() {
           onStatusChange={handleStatusChange}
           onCardClick={setSettingsCardId}
           impactSummaries={impactSummaries}
+        />
+      ) : viewMode === 'tree' ? (
+        <StrategyTree
+          cards={scopedCards}
+          groups={groups}
+          relationships={edges}
+          impactByNode={impactByNode}
+          onOpenImpact={setImpactCardId}
         />
       ) : (
         <StrategyTable


### PR DESCRIPTION
Closes **CVS-171** (Strategy impact — Milestone 2, completes it). **Stacked on [#71](https://github.com/nadeemramli/metrimap/pull/71) → #64 → #60 → #59.**

## What
A third Strategy view beside Board/Table that visualizes strategy structure top-down.

- **KPI** row = the Core/Value backbone of the canvas.
- **Pillars** = canvas groups (per the CVS-166 decision); work cards bucket under their group, else "Ungrouped".
- Each **hypothesis/action** shows its impact chip + linked **target / leading / guardrail** metrics and the **roll-up path** `Target → … → KPI` (via the CVS-168 resolver).
- Items with **no target** show an actionable empty state (**+ Add a target metric**); clicking any item opens the Impact panel.
- A **local impact filter** (has/missing target, measuring, review-ready, won/lost/inconclusive) that does **not** touch Board/Table state; the existing group pills still scope the tree.

## Verification
- `type-check` ✅ · lint (my files) ✅ · **full vitest 193/193** ✅ — adds a tree render test (KPI header, items, roll-up path, empty state).

Structure/links only — measured deltas are CVS-174. Readable for medium trees; responsive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)