### PR TITLE
CVS-72 (slice 1): discharge @ts-nocheck on the 3 canvas stores

### DIFF
--- a/docs/architecture/TYPE_CHECK_DEBT.md
+++ b/docs/architecture/TYPE_CHECK_DEBT.md
@@ -28,7 +28,11 @@ It now runs **`tsc -b --noEmit`**, which actually checks the app. Turning that o
 - `lib/workers/compute.worker.ts` (2)
 - `features/canvas/components/CanvasDebugPanels.tsx`, `features/canvas/components/CanvasModals.tsx`, `features/canvas/components/panels/chart-panel/chart-builder.tsx`, `shared/lib/supabase/services/relationships.ts`, `shared/lib/supabase/services/version-history.ts` (1 each)
 
-## Quarantined files (37 files, 219 errors)
+## Quarantined files
+
+> Being discharged incrementally (CVS-72). ✅ Done: the 3 canvas stores
+> (`useEdgeStore`, `useNodeStore`, `useGroupStore`). The table below lists what
+> remains; counts drift as files change — re-measure by stripping the directives.
 
 Paths are relative to `src/`. The "Codes" column shows `TSxxxx(count)`.
 
@@ -55,10 +59,7 @@ Paths are relative to `src/`. The "Codes" column shows `TSxxxx(count)`.
 | `features/canvas/components/settings/cards/ImportExportCard.tsx` | 1 | TS2339(1) |
 | `features/canvas/pages/CanvasPage.tsx` | 5 | TS6133(4) TS2322(1) |
 | `features/canvas/stores/useCanvasStore.ts` | 3 | TS2349(3) |
-| `features/canvas/stores/useEdgeStore.ts` | 1 | TS2322(1) |
-| `features/canvas/stores/useGroupStore.ts` | 2 | TS6133(1) TS2322(1) |
 | `features/canvas/stores/useNewNodeTypesStore.ts` | 7 | TS2353(4) TS6133(1) TS2352(1) TS2345(1) |
-| `features/canvas/stores/useNodeStore.ts` | 2 | TS2322(2) |
 | `lib/services/typed-canvas.ts` | 3 | TS2322(3) |
 | `lib/services/typed-operations.ts` | 23 | TS2345(20) TS2740(1) TS2352(1) TS2322(1) |
 | `lib/services/typed-projects.ts` | 3 | TS2345(1) TS2304(1) TS1484(1) |

--- a/src/features/canvas/stores/useEdgeStore.ts
+++ b/src/features/canvas/stores/useEdgeStore.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // TODO(type-debt): pre-existing type errors quarantined when strict type-checking
 // was enabled. See docs/architecture/TYPE_CHECK_DEBT.md. Fix the errors and remove
 // this directive — do not add new code here assuming it is type-checked.
@@ -29,7 +28,9 @@ export interface EdgeStoreState {
   persistEdgeDelete: (edgeId: string) => Promise<void>;
 
   // Local Edge management (for optimistic updates)
-  addEdgeLocal: (edge: Relationship) => Relationship[];
+  addEdgeLocal: (
+    edge: Relationship
+  ) => (currentEdges: Relationship[]) => Relationship[];
   updateEdgeLocal: (
     edges: Relationship[],
     edgeId: string,
@@ -110,7 +111,7 @@ export const useEdgeStore = create<EdgeStoreState>()(
     },
 
     // Local Edge management (for optimistic updates)
-    addEdgeLocal: (edge: Relationship): Relationship[] => {
+    addEdgeLocal: (edge: Relationship) => {
       return (currentEdges: Relationship[]) => [...currentEdges, edge];
     },
 

--- a/src/features/canvas/stores/useGroupStore.ts
+++ b/src/features/canvas/stores/useGroupStore.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // TODO(type-debt): pre-existing type errors quarantined when strict type-checking
 // was enabled. See docs/architecture/TYPE_CHECK_DEBT.md. Fix the errors and remove
 // this directive — do not add new code here assuming it is type-checked.
@@ -20,7 +19,9 @@ export interface GroupStoreState {
   deleteGroup: (groupId: string) => Promise<void>;
 
   // Local Group management (for optimistic updates and realtime)
-  addGroupLocal: (group: GroupNode) => GroupNode[];
+  addGroupLocal: (
+    group: GroupNode
+  ) => (currentGroups: GroupNode[]) => GroupNode[];
   updateGroupLocal: (
     groups: GroupNode[],
     groupId: string,
@@ -69,7 +70,7 @@ export interface GroupStoreState {
 }
 
 export const useGroupStore = create<GroupStoreState>()(
-  subscribeWithSelector((set, get) => ({
+  subscribeWithSelector((_set, get) => ({
     // Async Group management (Supabase)
     createGroup: async (group: GroupNode, canvasId: string) => {
       try {
@@ -127,7 +128,7 @@ export const useGroupStore = create<GroupStoreState>()(
     },
 
     // Local Group management (for optimistic updates and realtime)
-    addGroupLocal: (group: GroupNode): GroupNode[] => {
+    addGroupLocal: (group: GroupNode) => {
       return (currentGroups: GroupNode[]) => [...currentGroups, group];
     },
 

--- a/src/features/canvas/stores/useNodeStore.ts
+++ b/src/features/canvas/stores/useNodeStore.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // TODO(type-debt): pre-existing type errors quarantined when strict type-checking
 // was enabled. See docs/architecture/TYPE_CHECK_DEBT.md. Fix the errors and remove
 // this directive — do not add new code here assuming it is type-checked.
@@ -122,8 +121,8 @@ export const useNodeStore = create<NodeStoreState>()(
     },
 
     // Local Node management (for optimistic updates)
-    addNodeLocal: (node: MetricCard): MetricCard[] => {
-      // This returns the new nodes array for the canvas store to use
+    addNodeLocal: (node: MetricCard) => {
+      // Returns an updater the canvas store applies to its nodes array.
       return (currentNodes: MetricCard[]) => [...currentNodes, node];
     },
 


### PR DESCRIPTION
Slice 1 of CVS-72 (P1: stores/services first). Un-quarantines `useEdgeStore`, `useNodeStore`, `useGroupStore`.

The errors were all the same mistype: `addEdgeLocal`/`addNodeLocal`/`addGroupLocal` are curried updater factories `(x) => (current) => [...]` but their **return type was annotated as the array**. Corrected the types to match the impl — **behavior-neutral** (impls unchanged; and they have no callers) — plus renamed one unused `set` param.

192 errors across 35 files remain quarantined (biggest: version-history.ts 44, useNewNodeTypesStore 14). Discharging incrementally.

Verify: type-check clean · 0 lint errors · 166 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)