### PR TITLE
feat(CVS-100): runnable Node MCP server (Streamable HTTP) + deploy runbook

### DIFF
--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -1,0 +1,11 @@
+# metrimap-mcp-server — copy to .env (git-ignored) and fill in.
+# Server-only secrets — NEVER ship to the browser bundle.
+
+SUPABASE_URL=https://iqrclwolhookzzmiedun.supabase.co
+SUPABASE_ANON_KEY=<your Supabase anon/publishable key>
+
+# The signer for per-user RLS tokens. Supabase dashboard →
+# Project Settings → API → JWT Secret.
+SUPABASE_JWT_SECRET=<your Supabase JWT secret>
+
+PORT=8787

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,20 @@
+# Build from the REPO ROOT:  docker build -f mcp-server/Dockerfile -t metrimap-mcp .
+# The server imports shared code from src/, so it needs the app's root deps.
+FROM node:22-slim
+WORKDIR /app
+
+# App runtime deps (the tool registry pulls supabase-js / zod / dagre from here).
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+# App source the server imports + the server itself.
+COPY tsconfig*.json ./
+COPY src ./src
+COPY mcp-server ./mcp-server
+
+WORKDIR /app/mcp-server
+RUN npm install --no-audit --no-fund
+
+ENV PORT=8787
+EXPOSE 8787
+CMD ["npm", "start"]

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,90 @@
+# Metrimap MCP server (Node)
+
+A tiny Node service that serves Metrimap's MCP tools over **Streamable HTTP**. It
+just wires together the already-shipped, unit-tested pieces:
+
+- tool registry + dispatch — `src/shared/lib/api/mcp` (CVS-100/101/102)
+- API-key auth → per-user RLS-scoped client — `…/mcp/auth` (CVS-99)
+- rate limit + payload caps + audit log — `…/mcp/guards` + `…/mcp/audit` (CVS-104)
+
+`server.ts` only does HTTP + per-request auth. **Node was chosen over Vercel
+functions** because MCP wants a long-lived Streamable-HTTP connection, which a
+persistent Node process handles cleanly (and stays cheap on scale-to-zero hosts).
+
+## What you need (the only manual bits)
+
+1. **`SUPABASE_JWT_SECRET`** — Supabase dashboard → Project Settings → API →
+   **JWT Secret**. This signs the short-lived per-user tokens. Server-only; never
+   put it in the browser bundle or git.
+2. `SUPABASE_URL` + `SUPABASE_ANON_KEY` (already public).
+3. Before it works end to end, **merge + `db push` PR #69** (the
+   `mcp_resolve_api_key` RPC) and #62 (audit log). Then generate an API key in
+   the app (Settings → Connect your agent).
+
+Copy `.env.example` → `.env` and fill those in.
+
+## Run locally
+
+```bash
+# from the repo root — install app deps once (the server imports src/):
+npm install
+# then the server's own deps + start it:
+cd mcp-server
+npm install
+cp .env.example .env    # edit it
+npm start               # → http://localhost:8787  (GET /health, POST /mcp)
+curl localhost:8787/health   # {"ok":true,...}
+```
+
+Point an agent at it:
+
+```bash
+claude mcp add --transport http metrimap http://localhost:8787/mcp \
+  --header "Authorization: Bearer <your mk_live_ key>"
+```
+
+## Deploy to Fly.io (cheap, scales to zero)
+
+```bash
+# one-time
+curl -L https://fly.io/install.sh | sh      # install flyctl
+fly auth login
+fly launch --no-deploy                       # creates the app (uses fly.toml)
+
+# secrets (server-only)
+fly secrets set \
+  SUPABASE_URL=https://iqrclwolhookzzmiedun.supabase.co \
+  SUPABASE_ANON_KEY=<anon key> \
+  SUPABASE_JWT_SECRET=<jwt secret>
+
+fly deploy                                   # builds mcp-server/Dockerfile
+fly status                                   # note the *.fly.dev URL
+```
+
+Then set `VITE_MCP_URL=https://<app>.fly.dev/mcp` for the app's Connect page, or
+map `mcp.canvasm.app` to the Fly app.
+
+## Deploy anywhere else (Docker)
+
+`Dockerfile` builds from the **repo root** (it needs `src/`):
+
+```bash
+docker build -f mcp-server/Dockerfile -t metrimap-mcp .
+docker run -p 8787:8787 --env-file mcp-server/.env metrimap-mcp
+```
+
+Works the same on Render / Railway / a VPS — set the 3 env vars, expose 8787,
+health-check `/health`.
+
+## Notes
+
+- **First run:** the `@modelcontextprotocol/sdk` transport / `registerTool` API
+  shifts a bit between versions. If `npm start` throws on an SDK call, pin the
+  version in `package.json` and re-run — the two SDK touch-points are the
+  `McpServer`/`registerTool` loop and the `StreamableHTTPServerTransport` in
+  `server.ts`. Everything imported from `@/shared/lib/api/mcp` is version-stable
+  and tested.
+- **Scaling:** the rate limiter is in-memory (per instance). Fine for one
+  machine; for multiple, back it with Postgres/Redis.
+- **OAuth "Connect"** (sign-in instead of a key) is a follow-up — this server does
+  the API-key path (CVS-99).

--- a/mcp-server/fly.toml
+++ b/mcp-server/fly.toml
@@ -1,0 +1,26 @@
+# Fly.io config for the Metrimap MCP server (cheap, scales to zero).
+# First run `fly launch --no-deploy` to create the app + set the name, then set
+# secrets and `fly deploy`. See README.md.
+app = "metrimap-mcp"
+primary_region = "sin"
+
+[build]
+  dockerfile = "mcp-server/Dockerfile"
+
+[http_service]
+  internal_port = 8787
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    method = "GET"
+    path = "/health"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "metrimap-mcp-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Runnable Node MCP server for Metrimap — Streamable HTTP transport over the shared tool registry (src/shared/lib/api/mcp).",
+  "engines": { "node": ">=18" },
+  "scripts": {
+    "start": "tsx server.ts",
+    "dev": "tsx watch server.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.8.0"
+  }
+}

--- a/mcp-server/server.ts
+++ b/mcp-server/server.ts
@@ -1,0 +1,157 @@
+// Metrimap MCP server — runnable Node transport (CVS-100 deploy).
+//
+// Thin adapter: it wires the shipped, tested pieces together and serves them over
+// Streamable HTTP. All the logic lives in src/shared/lib/api/mcp (registry +
+// dispatch + API-key auth + guards); this file only does HTTP + per-request auth.
+//
+// Run:   cd mcp-server && npm install && npm start   (needs the repo's root deps —
+//        see README). Env: SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_JWT_SECRET.
+//
+// NOTE: the @modelcontextprotocol/sdk transport/registerTool API evolves between
+// versions — if `npm start` errors on the SDK surface, pin the version in
+// package.json (or adjust the two SDK calls below) and re-run. Everything it
+// imports from `@/shared/lib/api/mcp` is already unit-tested.
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+import {
+  listTools,
+  dispatchTool,
+  McpToolError,
+  createApiKeyAuthResolver,
+  supabaseApiKeyLookup,
+  supabaseAuditSink,
+  RateLimiter,
+  DEFAULT_MAX_PAYLOAD_BYTES,
+} from '@/shared/lib/api/mcp';
+
+const VERSION = '0.1.0';
+const {
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  SUPABASE_JWT_SECRET,
+  PORT = '8787',
+} = process.env;
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SUPABASE_JWT_SECRET) {
+  console.error(
+    'Missing env. Required: SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_JWT_SECRET.'
+  );
+  process.exit(1);
+}
+
+// One anon client for key lookups; the resolver mints a per-user JWT + client.
+const anon = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const resolveAuth = createApiKeyAuthResolver({
+  jwtSecret: SUPABASE_JWT_SECRET,
+  supabaseUrl: SUPABASE_URL,
+  anonKey: SUPABASE_ANON_KEY,
+  lookupKey: supabaseApiKeyLookup(anon),
+});
+
+// 120 calls burst, 2/s sustained, per user (in-memory — see README for scaling).
+const rateLimiter = new RateLimiter(120, 2);
+
+function headersOf(req: IncomingMessage): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(req.headers)) {
+    out[k.toLowerCase()] = Array.isArray(v) ? v.join(',') : v;
+  }
+  return out;
+}
+
+function readJson(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (c) => (data += c));
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : undefined);
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+// Build a fresh MCP server bound to one HTTP request's headers. Auth is resolved
+// lazily + once per request; each tool runs under that user's RLS + guards.
+function buildMcpServer(reqHeaders: Record<string, string | undefined>): McpServer {
+  const server = new McpServer({ name: 'metrimap', version: VERSION });
+  let ctx: ReturnType<typeof resolveAuth> | undefined;
+  const getCtx = () => {
+    if (!ctx) ctx = resolveAuth({ headers: reqHeaders });
+    return ctx;
+  };
+
+  for (const t of listTools()) {
+    const shape =
+      t.inputSchema instanceof z.ZodObject ? t.inputSchema.shape : undefined;
+    server.registerTool(
+      t.name,
+      {
+        title: t.title,
+        description: t.description,
+        ...(shape ? { inputSchema: shape } : {}),
+      },
+      async (args: unknown) => {
+        try {
+          const authed = await getCtx();
+          const result = await dispatchTool(t.name, args, authed, {
+            rateLimiter,
+            maxPayloadBytes: DEFAULT_MAX_PAYLOAD_BYTES,
+            audit: supabaseAuditSink(authed.client),
+          });
+          return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+        } catch (e) {
+          const code = e instanceof McpToolError ? e.code : 'internal';
+          const message = e instanceof Error ? e.message : String(e);
+          return {
+            isError: true,
+            content: [{ type: 'text' as const, text: `${code}: ${message}` }],
+          };
+        }
+      }
+    );
+  }
+  return server;
+}
+
+const http = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  try {
+    if (req.method === 'GET' && (req.url === '/health' || req.url === '/')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, name: 'metrimap-mcp', version: VERSION }));
+      return;
+    }
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Method not allowed' }));
+      return;
+    }
+
+    const body = await readJson(req);
+    const server = buildMcpServer(headersOf(req));
+    // Stateless: one transport per request (sessionIdGenerator: undefined).
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    res.on('close', () => {
+      transport.close();
+      server.close();
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, body);
+  } catch (e) {
+    console.error('MCP request error:', e);
+    if (!res.headersSent) {
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Internal error' }));
+    }
+  }
+});
+
+http.listen(Number(PORT), () => {
+  console.log(`metrimap-mcp v${VERSION} listening on :${PORT} (POST /mcp, GET /health)`);
+});

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": { "@/*": ["../src/*"] },
+    "types": ["node"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["server.ts"]
+}


### PR DESCRIPTION
The **transport/deploy** half of CVS-100 — a runnable Node server so you can deploy the MCP cheaply. Self-contained in `mcp-server/`; **leaves the app's `package.json`/lock/`src` untouched** (app stays green).

## What it does
`server.ts` is a thin adapter over the already-shipped, tested pieces:
- tool registry + dispatch (CVS-100/101/102)
- API-key auth → per-user RLS-scoped client (CVS-99)
- rate limit + payload caps + audit log (CVS-104)

Serves **Streamable HTTP** (`POST /mcp`), resolves auth **per request** from the `Authorization` header, runs each tool under the caller's RLS with the guards, and exposes `GET /health`.

## Files
- `server.ts` — HTTP + per-request auth wiring.
- `package.json` / `tsconfig.json` — own deps (`@modelcontextprotocol/sdk`, `tsx`); imports app `src/` via the `@` alias.
- `Dockerfile` (build from repo root), `fly.toml` (scale-to-zero), `.env.example`, `README.md` — full **Fly.io / Docker deploy runbook**.

## Why Node (not Vercel)
MCP wants a long-lived Streamable-HTTP connection — a persistent Node process handles it cleanly and stays cheap on scale-to-zero hosts (Fly/Render). Agreed re: Vercel cost.

## To go live (your part)
1. Merge + `db push` the auth/audit PRs (**#69**, **#62**).
2. `cd mcp-server && npm install && npm start` locally to smoke-test (`/health`), then `fly launch` + `fly secrets set … SUPABASE_JWT_SECRET=…` + `fly deploy` (README has exact commands).
3. Set `VITE_MCP_URL` to the deployed URL for the Connect page.

## Review notes
⚠️ **Not self-merged** — deploy infra, and `server.ts` isn't run in CI (needs the SDK install + `SUPABASE_JWT_SECRET` + a host). Everything it imports from `@/shared/lib/api/mcp` is unit-tested; the two SDK touch-points (`registerTool` loop, `StreamableHTTPServerTransport`) should be confirmed on first `npm start` — README flags this. App type-check + eslint green (`mcp-server/` is outside the app scope).

Ref: CVS-100 (transport/deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)