### PR TITLE
CVS-72 (slice 2): discharge nodeTypes + edgeConnectionHandler

### DIFF
--- a/docs/architecture/TYPE_CHECK_DEBT.md
+++ b/docs/architecture/TYPE_CHECK_DEBT.md
@@ -31,8 +31,9 @@ It now runs **`tsc -b --noEmit`**, which actually checks the app. Turning that o
 ## Quarantined files
 
 > Being discharged incrementally (CVS-72). ✅ Done: the 3 canvas stores
-> (`useEdgeStore`, `useNodeStore`, `useGroupStore`). The table below lists what
-> remains; counts drift as files change — re-measure by stripping the directives.
+> (`useEdgeStore`/`useNodeStore`/`useGroupStore`), plus `nodeTypes.ts` +
+> `edgeConnectionHandler.ts`. The table below lists what remains; counts drift
+> as files change — re-measure by stripping the directives.
 
 Paths are relative to `src/`. The "Codes" column shows `TSxxxx(count)`.
 
@@ -70,8 +71,6 @@ Paths are relative to `src/`. The "Codes" column shows `TSxxxx(count)`.
 | `shared/lib/supabase/services/newNodeTypes.ts` | 9 | TS2339(5) TS2353(4) |
 | `shared/lib/supabase/services/relationships.ts` | 1 | TS2307(1) |
 | `shared/lib/supabase/services/version-history.ts` | 19 | TS2769(13) TS2339(5) TS2307(1) |
-| `shared/types/nodeTypes.ts` | 2 | TS2304(2) |
-| `shared/utils/edgeConnectionHandler.ts` | 3 | TS6133(2) TS2339(1) |
 
 ## Notes
 

--- a/src/shared/types/nodeTypes.ts
+++ b/src/shared/types/nodeTypes.ts
@@ -1,7 +1,5 @@
-// @ts-nocheck
-// TODO(type-debt): pre-existing type errors quarantined when strict type-checking
-// was enabled. See docs/architecture/TYPE_CHECK_DEBT.md. Fix the errors and remove
-// this directive — do not add new code here assuming it is type-checked.
+import type { MetricValue } from '@/shared/types';
+
 /**
  * Node Type Definitions According to PRD
  * Separating the monolithic MetricCard into distinct node types

--- a/src/shared/utils/edgeConnectionHandler.ts
+++ b/src/shared/utils/edgeConnectionHandler.ts
@@ -1,7 +1,3 @@
-// @ts-nocheck
-// TODO(type-debt): pre-existing type errors quarantined when strict type-checking
-// was enabled. See docs/architecture/TYPE_CHECK_DEBT.md. Fix the errors and remove
-// this directive — do not add new code here assuming it is type-checked.
 /**
  * Enhanced Edge Connection Handler
  * Handles creating connections between nodes with proper validation and edge type selection
@@ -161,7 +157,7 @@ function handleRelationshipEdge(
   connection: Connection,
   sourceNode: Node,
   targetNode: Node,
-  edgeInfo: { relationshipType?: any },
+  _edgeInfo: { relationshipType?: any },
   onCreateRelationship?: (data: any) => Promise<void>
 ): ConnectionResult {
   const relationshipData = {
@@ -264,7 +260,7 @@ function handleReferenceEdge(
  */
 function getNodeTitle(node: Node): string {
   return (
-    node.data?.card?.title ||
+    (node.data?.card as any)?.title ||
     node.data?.title ||
     node.data?.label ||
     `${node.type} (${node.id.slice(0, 8)})`
@@ -300,7 +296,7 @@ function getDataFlowLabel(sourceNode: Node, targetNode: Node): string {
 /**
  * Get appropriate label for reference edges
  */
-function getReferenceLabel(sourceNode: Node, targetNode: Node): string {
+function getReferenceLabel(sourceNode: Node, _targetNode: Node): string {
   const sourceType = sourceNode.type;
 
   switch (sourceType) {


### PR DESCRIPTION
Slice 2 of CVS-72. Un-quarantines `nodeTypes.ts` (missing MetricValue import) + `edgeConnectionHandler.ts` (2 unused params + a node.data cast). Behavior-neutral. Deferred the tricky ones (chart.tsx Recharts generics; typed-projects possible real bug; relationships — in the open CVS-82 PR). type-check/lint/166 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)