### PR TITLE
fix(evidence): stop editor destroy→re-init loop (lost text + double editor)

### DIFF
--- a/src/features/evidence/components/EvidenceEditor.tsx
+++ b/src/features/evidence/components/EvidenceEditor.tsx
@@ -143,6 +143,12 @@ export default function EvidenceEditor({
     }, 100);
   }, [autoSave, formData]);
 
+  // Route onChange through a ref so it isn't a dependency of the init effect.
+  // Depending on it (and on evidence?.content) destroyed + re-created the editor
+  // on every autosave → repeated "Editor ready", lost text, duplicate editor.
+  const handleEditorChangeRef = useRef(handleEditorChange);
+  handleEditorChangeRef.current = handleEditorChange;
+
   const handleFormDataChange = useCallback(
     (newFormData: Partial<EvidenceItem>) => {
       setFormData(newFormData);
@@ -167,7 +173,7 @@ export default function EvidenceEditor({
           placeholder:
             "Start writing your evidence notebook... Press '/' for commands",
           minHeight: 300,
-          onChange: handleEditorChange,
+          onChange: () => handleEditorChangeRef.current?.(),
           onReady: () =>
             toast.success('📝 Editor ready!', {
               duration: 1500,
@@ -193,7 +199,7 @@ export default function EvidenceEditor({
           },
           placeholder: "Start writing... Press '/' for the full command menu",
           minHeight: 300,
-          onChange: handleEditorChange,
+          onChange: () => handleEditorChangeRef.current?.(),
         });
         editorRef.current = fallback;
       }
@@ -208,7 +214,10 @@ export default function EvidenceEditor({
         editorRef.current = null;
       }
     };
-  }, [isOpen, evidence?.content, handleEditorChange]);
+    // Re-init only when the dialog opens or a DIFFERENT evidence loads (id) —
+    // never on content/handler changes (those come from the editor itself and
+    // caused the destroy→re-init loop / duplicate editor). onChange uses a ref.
+  }, [isOpen, evidence?.id]);
 
   const handleSave = async () => {
     if (!editorRef.current) return;


### PR DESCRIPTION
**Bugs (reported in testing):** the evidence editor kept "refreshing" ("Editor ready" over and over), **typed text disappeared**, and there were **two editors** stacked on the page.

**Root cause:** `EvidenceEditor`'s init `useEffect` depended on `[isOpen, evidence?.content, handleEditorChange]` and its cleanup *always* destroys the editor. So: type → autosave → `updateEvidence` (store) → the `evidence.content` prop gets a **new reference** → the effect's cleanup **destroys** the editor → it re-inits with the *old* content. That loop reloads old content (losing your text) and leaves a duplicate editor in the DOM. (`EvidenceNode`'s editor is protected by a `!isEditing` cleanup guard, so it wasn't affected.)

**Fix:**
- Init effect deps → `[isOpen, evidence?.id]`. `id` is stable while editing (only `content` changes), so it re-inits **only** when the dialog opens or a different evidence loads — never on autosave.
- `onChange` routed through a ref so the latest handler is always used without being an effect dependency (no stale closure, no re-init).

## Verification
type-check ✓, lint ✓ (0 errors), full build ✓.

Note: this is separate from the date-persist fix (#73). Once the deploy includes both, editing should be smooth + persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)