### PR TITLE
fix(evidence): populate edit dialog + auto-owner + notebook preview on card (CVS-34)

### DIFF
--- a/src/features/evidence/components/EvidenceEditor.tsx
+++ b/src/features/evidence/components/EvidenceEditor.tsx
@@ -92,6 +92,26 @@ export default function EvidenceEditor({
     tags: evidence?.tags || [],
   });
 
+  // useState only runs once, so when the dialog is reused for a different (or
+  // existing) evidence, the form kept its original empty values → blank dialog.
+  // Re-sync from `evidence` whenever the dialog opens or a different item loads.
+  // Owner auto-populates with the creator's name for brand-new evidence.
+  useEffect(() => {
+    if (!isOpen) return;
+    setFormData({
+      id: evidence?.id || `evidence_${Date.now()}`,
+      title: evidence?.title || '',
+      type: evidence?.type || 'Analysis',
+      date: evidence?.date || new Date().toISOString().split('T')[0],
+      owner: evidence?.owner || user?.name || '',
+      link: evidence?.link || '',
+      hypothesis: evidence?.hypothesis || '',
+      impactOnConfidence: evidence?.impactOnConfidence || '',
+      tags: evidence?.tags || [],
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, evidence?.id]);
+
   const autoSave = useCallback(
     debounce(async (content: any, metadata: Partial<EvidenceItem>) => {
       if (!editorRef.current) return;

--- a/src/features/evidence/pages/EvidenceRepositoryPage.tsx
+++ b/src/features/evidence/pages/EvidenceRepositoryPage.tsx
@@ -70,6 +70,20 @@ const evidenceTypeOptions = [
   { value: 'User Interview', icon: Users, variant: 'pink' },
 ] as const;
 
+// Card preview: first real text from the notebook content, falling back to the
+// summary — so the card reflects what's actually written in the notebook.
+function contentPreview(ev: EvidenceItem): string {
+  const blocks = (ev.content as any)?.blocks;
+  if (Array.isArray(blocks)) {
+    for (const b of blocks) {
+      const raw = b?.data?.text ?? b?.data?.items?.[0] ?? '';
+      const text = String(raw).replace(/<[^>]+>/g, '').trim();
+      if (text) return text;
+    }
+  }
+  return ev.summary || '';
+}
+
 export default function EvidenceRepositoryPage() {
   const { canvasId } = useParams();
   const isCanvasScoped = Boolean(canvasId);
@@ -460,7 +474,7 @@ export default function EvidenceRepositoryPage() {
                   </div>
                   <CardTitle className="text-lg">{evidence.title}</CardTitle>
                   <CardDescription className="line-clamp-2">
-                    {evidence.summary}
+                    {contentPreview(evidence)}
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-3">


### PR DESCRIPTION
Three issues found while testing evidence:

**1. Edit dialog opened blank** (Image 14) — for existing/seed evidence the fields were empty. Cause: `formData` used a `useState` **initializer** (runs once); the dialog stays mounted and just gets a new `evidence` prop. **Fix:** re-sync `formData` from `evidence` whenever the dialog opens or a different item loads (`[isOpen, evidence?.id]`).

**2. Owner** now **auto-populates with the creator's name** (`user.name`) for new evidence.

**3. Notebook content not on the card** (Image 17) — the repo card showed only `summary`. **Fix:** `contentPreview()` extracts the first real text block from the notebook `content` (falls back to summary).

## Still to do (bigger — next)
- Hypothesis / Impact / Tags → **dropdowns**; **Hypothesis linked to hypothesis nodes**.
- `EvidencePage` full-page editor is missing the hypothesis/impact/tags fields.

## Verification
type-check ✓, lint ✓ (0 errors), full build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)