### PR TITLE
feat(settings): workspace groups/departments + membership (CVS-119)

### DIFF
--- a/src/features/settings/components/GroupsPanel.tsx
+++ b/src/features/settings/components/GroupsPanel.tsx
@@ -1,0 +1,314 @@
+import { useOrganization } from '@clerk/react-router';
+import { Button } from '@/shared/components/ui/button';
+import { Input } from '@/shared/components/ui/input';
+import { Badge } from '@/shared/components/ui/badge';
+import { Checkbox } from '@/shared/components/ui/checkbox';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/shared/components/ui/alert-dialog';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import {
+  addGroupMember,
+  createGroup,
+  deleteGroup,
+  listGroupMembers,
+  listGroups,
+  removeGroupMember,
+  updateGroup,
+  type WorkspaceGroupWithCount,
+} from '@/shared/lib/supabase/services/groups';
+import { ChevronDown, ChevronRight, Loader2, Pencil, Trash2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+type OrgMember = { userId: string; label: string };
+
+/**
+ * Create/rename/delete workspace groups (Finance, Marketing, Exec…) and assign
+ * members from the Clerk org. Groups are the audience unit the access-tag +
+ * RLS layers (CVS-120/121) key off. Workspace-scoped by RLS.
+ */
+export function GroupsPanel() {
+  const client = useClerkSupabase();
+  const { organization, memberships } = useOrganization({
+    memberships: { pageSize: 100, keepPreviousData: true },
+  });
+
+  const [groups, setGroups] = useState<WorkspaceGroupWithCount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newName, setNewName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [membersOf, setMembersOf] = useState<Record<string, Set<string>>>({});
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+
+  const orgMembers: OrgMember[] = (memberships?.data ?? []).map((m) => ({
+    userId: m.publicUserData?.userId ?? '',
+    label:
+      [m.publicUserData?.firstName, m.publicUserData?.lastName]
+        .filter(Boolean)
+        .join(' ') ||
+      m.publicUserData?.identifier ||
+      m.publicUserData?.userId ||
+      'Unknown',
+  }));
+
+  useEffect(() => {
+    if (!client) return;
+    setLoading(true);
+    listGroups(client)
+      .then(setGroups)
+      .catch(() => setGroups([]))
+      .finally(() => setLoading(false));
+  }, [client]);
+
+  if (!organization) {
+    return (
+      <p className="text-sm text-muted-foreground/70">
+        Groups apply to a workspace organization. Create or switch to an
+        organization to define departments and their members.
+      </p>
+    );
+  }
+
+  const create = async () => {
+    const name = newName.trim();
+    if (!client || !name) return;
+    setCreating(true);
+    try {
+      const g = await createGroup({ name }, client);
+      setGroups((prev) =>
+        [...prev, { ...g, member_count: 0 }].sort((a, b) =>
+          a.name.localeCompare(b.name)
+        )
+      );
+      setNewName('');
+      toast.success(`Group “${g.name}” created`);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Failed to create group';
+      toast.error(msg.includes('duplicate') ? 'A group with that name already exists' : msg);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const remove = async (id: string, name: string) => {
+    if (!client) return;
+    try {
+      await deleteGroup(id, client);
+      setGroups((prev) => prev.filter((g) => g.id !== id));
+      toast.success(`Group “${name}” deleted`);
+    } catch {
+      toast.error('Failed to delete group');
+    }
+  };
+
+  const saveRename = async (id: string) => {
+    const name = editName.trim();
+    if (!client || !name) return setEditingId(null);
+    try {
+      await updateGroup(id, { name }, client);
+      setGroups((prev) =>
+        prev
+          .map((g) => (g.id === id ? { ...g, name } : g))
+          .sort((a, b) => a.name.localeCompare(b.name))
+      );
+      toast.success('Group renamed');
+    } catch {
+      toast.error('Failed to rename group');
+    } finally {
+      setEditingId(null);
+    }
+  };
+
+  const toggleExpand = async (id: string) => {
+    if (expandedId === id) return setExpandedId(null);
+    setExpandedId(id);
+    if (!membersOf[id] && client) {
+      try {
+        const rows = await listGroupMembers(id, client);
+        setMembersOf((prev) => ({
+          ...prev,
+          [id]: new Set(rows.map((r) => r.user_id)),
+        }));
+      } catch {
+        toast.error('Failed to load members');
+      }
+    }
+  };
+
+  const toggleMember = async (groupId: string, userId: string, next: boolean) => {
+    if (!client || !userId) return;
+    // optimistic
+    setMembersOf((prev) => {
+      const set = new Set(prev[groupId] ?? []);
+      if (next) set.add(userId);
+      else set.delete(userId);
+      return { ...prev, [groupId]: set };
+    });
+    setGroups((prev) =>
+      prev.map((g) =>
+        g.id === groupId
+          ? { ...g, member_count: g.member_count + (next ? 1 : -1) }
+          : g
+      )
+    );
+    try {
+      if (next) await addGroupMember(groupId, userId, client);
+      else await removeGroupMember(groupId, userId, client);
+    } catch {
+      toast.error('Failed to update membership');
+      // revert
+      setMembersOf((prev) => {
+        const set = new Set(prev[groupId] ?? []);
+        if (next) set.delete(userId);
+        else set.add(userId);
+        return { ...prev, [groupId]: set };
+      });
+      setGroups((prev) =>
+        prev.map((g) =>
+          g.id === groupId
+            ? { ...g, member_count: g.member_count + (next ? -1 : 1) }
+            : g
+        )
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && create()}
+          placeholder="New group (e.g. Finance)"
+          className="max-w-xs"
+        />
+        <Button onClick={create} disabled={creating || !newName.trim()} size="sm">
+          {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Add group'}
+        </Button>
+      </div>
+
+      {loading ? (
+        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+      ) : groups.length === 0 ? (
+        <p className="text-sm text-muted-foreground/70">
+          No groups yet. Add departments so you can control which teams see which
+          nodes.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {groups.map((g) => {
+            const expanded = expandedId === g.id;
+            const memberSet = membersOf[g.id] ?? new Set<string>();
+            return (
+              <div key={g.id} className="rounded-md border border-border">
+                <div className="flex items-center gap-2 px-3 py-2">
+                  <button
+                    className="flex flex-1 items-center gap-2 text-left"
+                    onClick={() => toggleExpand(g.id)}
+                  >
+                    {expanded ? (
+                      <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    )}
+                    {editingId === g.id ? (
+                      <Input
+                        autoFocus
+                        value={editName}
+                        onChange={(e) => setEditName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') saveRename(g.id);
+                          if (e.key === 'Escape') setEditingId(null);
+                        }}
+                        onBlur={() => saveRename(g.id)}
+                        onClick={(e) => e.stopPropagation()}
+                        className="h-7 max-w-[12rem]"
+                      />
+                    ) : (
+                      <span className="text-sm font-medium">{g.name}</span>
+                    )}
+                    <Badge variant="secondary" className="ml-1">
+                      {g.member_count}
+                    </Badge>
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    title="Rename"
+                    onClick={() => {
+                      setEditingId(g.id);
+                      setEditName(g.name);
+                    }}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button variant="ghost" size="sm" title="Delete group">
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Delete “{g.name}”?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Members are unassigned and any node audiences using this
+                          group lose it. This can’t be undone.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => remove(g.id, g.name)}>
+                          Delete
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+
+                {expanded && (
+                  <div className="border-t border-border px-3 py-2">
+                    {orgMembers.length === 0 ? (
+                      <p className="text-xs text-muted-foreground/70">
+                        No workspace members found.
+                      </p>
+                    ) : (
+                      <div className="space-y-1.5">
+                        {orgMembers.map((m) => (
+                          <label
+                            key={m.userId}
+                            className="flex cursor-pointer items-center gap-2 text-sm"
+                          >
+                            <Checkbox
+                              checked={memberSet.has(m.userId)}
+                              onCheckedChange={(v) =>
+                                toggleMember(g.id, m.userId, v === true)
+                              }
+                            />
+                            <span className="text-muted-foreground">{m.label}</span>
+                          </label>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/settings/pages/WorkspaceSettingsPage.tsx
+++ b/src/features/settings/pages/WorkspaceSettingsPage.tsx
@@ -1,7 +1,8 @@
 import { OrganizationProfile } from '@clerk/react-router';
 import { Button } from '@/shared/components/ui/button';
 import { ConnectionsPanel } from '@/features/data/components/ConnectionsPanel';
-import { ArrowLeft, Database, User, Users } from 'lucide-react';
+import { GroupsPanel } from '@/features/settings/components/GroupsPanel';
+import { ArrowLeft, Database, ShieldCheck, User, Users } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 function Section({
@@ -77,6 +78,15 @@ export default function WorkspaceSettingsPage() {
           <div className="overflow-hidden rounded-md border border-border">
             <OrganizationProfile routing="hash" />
           </div>
+        </Section>
+
+        {/* Groups & departments (node-level visibility audiences) */}
+        <Section
+          icon={ShieldCheck}
+          title="Groups & departments"
+          description="Group members into departments (Finance, Marketing, Exec…). Groups are the audiences that access tags and node visibility are granted to."
+        >
+          <GroupsPanel />
         </Section>
       </div>
     </div>

--- a/src/shared/lib/supabase/services/groups.ts
+++ b/src/shared/lib/supabase/services/groups.ts
@@ -1,0 +1,129 @@
+import { supabase } from '@/shared/lib/supabase/client';
+import type { Tables } from '@/shared/lib/supabase/types';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '../types';
+
+/**
+ * Workspace groups / departments (CVS-119) — within-workspace tiering that
+ * feeds the node-level visibility model (access-tags CVS-120 + RLS CVS-121).
+ * Thin, RLS-scoped wrappers: the DB defaults workspace_id/created_by from the
+ * Clerk token, and RLS scopes every row to the requester's workspace, so the
+ * client never passes workspace_id. Pass the authenticated client so RLS holds.
+ */
+
+export type WorkspaceGroup = Tables<'workspace_groups'>;
+export type GroupMember = Tables<'group_members'>;
+export type WorkspaceGroupWithCount = WorkspaceGroup & { member_count: number };
+
+function db(client?: SupabaseClient<Database>) {
+  return client || supabase();
+}
+
+/** All groups in the current workspace, with member counts. */
+export async function listGroups(
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<WorkspaceGroupWithCount[]> {
+  const client = db(authenticatedClient);
+  const [{ data: groups, error }, { data: members, error: mErr }] =
+    await Promise.all([
+      client.from('workspace_groups').select('*').order('name', { ascending: true }),
+      client.from('group_members').select('group_id'),
+    ]);
+  if (error) throw error;
+  if (mErr) throw mErr;
+
+  const counts = new Map<string, number>();
+  for (const m of members ?? []) {
+    counts.set(m.group_id, (counts.get(m.group_id) ?? 0) + 1);
+  }
+  return (groups ?? []).map((g) => ({
+    ...g,
+    member_count: counts.get(g.id) ?? 0,
+  }));
+}
+
+export async function createGroup(
+  input: { name: string; description?: string | null; color?: string | null },
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<WorkspaceGroup> {
+  const client = db(authenticatedClient);
+  const { data, error } = await client
+    .from('workspace_groups')
+    .insert({
+      name: input.name.trim(),
+      description: input.description ?? null,
+      color: input.color ?? null,
+    })
+    .select('*')
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export async function updateGroup(
+  id: string,
+  patch: { name?: string; description?: string | null; color?: string | null },
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<WorkspaceGroup> {
+  const client = db(authenticatedClient);
+  const { data, error } = await client
+    .from('workspace_groups')
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .select('*')
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export async function deleteGroup(
+  id: string,
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<void> {
+  const client = db(authenticatedClient);
+  const { error } = await client.from('workspace_groups').delete().eq('id', id);
+  if (error) throw error;
+}
+
+/** User ids belonging to a group. */
+export async function listGroupMembers(
+  groupId: string,
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<GroupMember[]> {
+  const client = db(authenticatedClient);
+  const { data, error } = await client
+    .from('group_members')
+    .select('*')
+    .eq('group_id', groupId);
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function addGroupMember(
+  groupId: string,
+  userId: string,
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<void> {
+  const client = db(authenticatedClient);
+  const { error } = await client
+    .from('group_members')
+    .upsert(
+      { group_id: groupId, user_id: userId },
+      { onConflict: 'group_id,user_id', ignoreDuplicates: true }
+    );
+  if (error) throw error;
+}
+
+export async function removeGroupMember(
+  groupId: string,
+  userId: string,
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<void> {
+  const client = db(authenticatedClient);
+  const { error } = await client
+    .from('group_members')
+    .delete()
+    .eq('group_id', groupId)
+    .eq('user_id', userId);
+  if (error) throw error;
+}

--- a/src/shared/lib/supabase/types.ts
+++ b/src/shared/lib/supabase/types.ts
@@ -395,6 +395,68 @@ export type Database = {
         }
         Relationships: []
       }
+      group_members: {
+        Row: {
+          added_at: string
+          added_by: string
+          group_id: string
+          user_id: string
+        }
+        Insert: {
+          added_at?: string
+          added_by?: string
+          group_id: string
+          user_id: string
+        }
+        Update: {
+          added_at?: string
+          added_by?: string
+          group_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "group_members_group_id_fkey"
+            columns: ["group_id"]
+            isOneToOne: false
+            referencedRelation: "workspace_groups"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      workspace_groups: {
+        Row: {
+          color: string | null
+          created_at: string
+          created_by: string
+          description: string | null
+          id: string
+          name: string
+          updated_at: string
+          workspace_id: string
+        }
+        Insert: {
+          color?: string | null
+          created_at?: string
+          created_by?: string
+          description?: string | null
+          id?: string
+          name: string
+          updated_at?: string
+          workspace_id?: string
+        }
+        Update: {
+          color?: string | null
+          created_at?: string
+          created_by?: string
+          description?: string | null
+          id?: string
+          name?: string
+          updated_at?: string
+          workspace_id?: string
+        }
+        Relationships: []
+      }
       metric_values: {
         Row: {
           change_percent: number | null
@@ -1516,7 +1578,10 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      my_groups: {
+        Args: Record<PropertyKey, never>
+        Returns: string[]
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/20260710120000_workspace_groups.sql
+++ b/supabase/migrations/20260710120000_workspace_groups.sql
@@ -1,0 +1,113 @@
+-- =====================================================================
+-- WORKSPACE GROUPS / DEPARTMENTS (CVS-119) — foundation for node-level
+-- visibility (Access & Visibility, spike CVS-118).
+--
+-- Introduces WITHIN-workspace tiering that doesn't exist today: the Clerk
+-- org stays the tenant boundary (org = collaborative, every member writes),
+-- but members can now be grouped (Finance, Marketing, Exec…) so later
+-- access-tags (CVS-120) + RLS (CVS-121) can gate which nodes/values a
+-- group may see. This migration only adds the membership model + the
+-- my_groups() helper the visibility policy will key off.
+--
+-- Scope note: group management is gated to workspace (org) membership, not
+-- org-admin-only, consistent with the current "org = collaborative" model.
+-- Admin-only tightening is a documented follow-up tied to workspace-settings
+-- roles (CVS-93). The real data boundary lands in CVS-121.
+-- =====================================================================
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.workspace_groups (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id text NOT NULL DEFAULT public.requesting_org_id(),
+  name         text NOT NULL,
+  description  text,
+  color        text,
+  created_by   text NOT NULL DEFAULT public.requesting_user_id(),
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (workspace_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS public.group_members (
+  group_id uuid NOT NULL REFERENCES public.workspace_groups(id) ON DELETE CASCADE,
+  user_id  text NOT NULL,
+  added_by text NOT NULL DEFAULT public.requesting_user_id(),
+  added_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (group_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_groups_ws ON public.workspace_groups(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_group_members_user   ON public.group_members(user_id);
+
+-- ---------------------------------------------------------------------
+-- my_groups(): the requesting user's group ids in the current workspace.
+-- SECURITY DEFINER so the visibility helpers/policies can call it without
+-- needing direct select on the membership tables. Fail-closed: no org / no
+-- user => empty set.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.my_groups()
+RETURNS SETOF uuid
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT gm.group_id
+  FROM public.group_members gm
+  JOIN public.workspace_groups g ON g.id = gm.group_id
+  WHERE public.requesting_user_id() IS NOT NULL
+    AND gm.user_id = public.requesting_user_id()
+    AND g.workspace_id = public.requesting_org_id();
+$$;
+GRANT EXECUTE ON FUNCTION public.my_groups() TO authenticated, anon;
+
+-- ---------------------------------------------------------------------
+-- RLS — everything scoped to the requester's workspace (Clerk org).
+-- ---------------------------------------------------------------------
+ALTER TABLE public.workspace_groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.group_members    ENABLE ROW LEVEL SECURITY;
+
+-- workspace_groups: any workspace member reads/manages groups in their org.
+DROP POLICY IF EXISTS workspace_groups_select ON public.workspace_groups;
+CREATE POLICY workspace_groups_select ON public.workspace_groups
+  FOR SELECT USING (workspace_id = public.requesting_org_id());
+
+DROP POLICY IF EXISTS workspace_groups_insert ON public.workspace_groups;
+CREATE POLICY workspace_groups_insert ON public.workspace_groups
+  FOR INSERT WITH CHECK (
+    workspace_id = public.requesting_org_id()
+    AND public.requesting_user_id() IS NOT NULL
+  );
+
+DROP POLICY IF EXISTS workspace_groups_update ON public.workspace_groups;
+CREATE POLICY workspace_groups_update ON public.workspace_groups
+  FOR UPDATE USING (workspace_id = public.requesting_org_id())
+  WITH CHECK (workspace_id = public.requesting_org_id());
+
+DROP POLICY IF EXISTS workspace_groups_delete ON public.workspace_groups;
+CREATE POLICY workspace_groups_delete ON public.workspace_groups
+  FOR DELETE USING (workspace_id = public.requesting_org_id());
+
+-- group_members: readable/manageable when the parent group is in the org.
+DROP POLICY IF EXISTS group_members_select ON public.group_members;
+CREATE POLICY group_members_select ON public.group_members
+  FOR SELECT USING (EXISTS (
+    SELECT 1 FROM public.workspace_groups g
+    WHERE g.id = group_members.group_id
+      AND g.workspace_id = public.requesting_org_id()
+  ));
+
+DROP POLICY IF EXISTS group_members_insert ON public.group_members;
+CREATE POLICY group_members_insert ON public.group_members
+  FOR INSERT WITH CHECK (EXISTS (
+    SELECT 1 FROM public.workspace_groups g
+    WHERE g.id = group_members.group_id
+      AND g.workspace_id = public.requesting_org_id()
+  ) AND public.requesting_user_id() IS NOT NULL);
+
+DROP POLICY IF EXISTS group_members_delete ON public.group_members;
+CREATE POLICY group_members_delete ON public.group_members
+  FOR DELETE USING (EXISTS (
+    SELECT 1 FROM public.workspace_groups g
+    WHERE g.id = group_members.group_id
+      AND g.workspace_id = public.requesting_org_id()
+  ));
+
+COMMIT;


### PR DESCRIPTION
Closes the foundation issue for the **Access & Visibility** lane (node-level transparency). Design decisions locked in **CVS-118**.

## What
Introduces within-workspace tiering (groups/departments) on top of the org-collaborative model, so later access tags (CVS-120) and RLS (CVS-121) can gate which teams see which nodes/values.

- **Migration `20260710120000_workspace_groups.sql`**: `workspace_groups` + `group_members` tables, RLS-scoped to `requesting_org_id()`, plus a `my_groups()` `SECURITY DEFINER` helper (fail-closed) that the visibility policy will key off.
- **`services/groups.ts`**: RLS-scoped CRUD + membership wrappers (thin, mirror `collaborators.ts`/`sourceConnections.ts`).
- **`settings/components/GroupsPanel.tsx`**: create / rename / delete groups and assign members from the Clerk org; wired as a new **Groups & departments** section in Workspace Settings.
- **`types.ts`**: hand-added the two tables + `my_groups` (the repo's `prisma:types` generator is broken).

## Acceptance criteria (CVS-119)
- [x] Create/rename/delete groups; assign/remove members
- [x] Membership is workspace-scoped + RLS-protected
- [x] Exposed to the visibility policy + RLS predicates (`my_groups()`)

## Notes for review
- **Group management is workspace-member-level for v1** (consistent with "org = collaborative"). Admin-only tightening is a documented follow-up tied to workspace-settings roles (CVS-93). The real data boundary lands in **CVS-121**.
- ⚠️ **DB PR — do not self-merge.** The migration has **not** been applied to prod (`iqrclwolhookzzmiedun`); apply on review. No RLS regression to existing tables — only new tables + a new function.
- `type-check`, full `lint`, and `vitest` pass via the Husky pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)