### PR TITLE
feat(cvs-173): visual Impact Trace view

### DIFF
--- a/src/features/dashboard/components/WidgetCard.tsx
+++ b/src/features/dashboard/components/WidgetCard.tsx
@@ -32,6 +32,7 @@ interface WidgetCardProps {
   strategyLinks?: WidgetStrategyLink[];
   currentPeriod?: string;
   onOpenStrategy?: (nodeId: string) => void;
+  onOpenTrace?: (nodeId: string) => void;
 }
 
 const CHART_TYPES: ChartType[] = ['line', 'area', 'bar', 'pie'];
@@ -45,6 +46,7 @@ export function WidgetCard({
   strategyLinks,
   currentPeriod,
   onOpenStrategy,
+  onOpenTrace,
 }: WidgetCardProps) {
   const isChart = (CHART_TYPES as string[]).includes(widget.widget_type);
 
@@ -63,6 +65,7 @@ export function WidgetCard({
               links={strategyLinks}
               currentPeriod={currentPeriod ?? new Date().toISOString().slice(0, 7)}
               onOpenStrategy={onOpenStrategy}
+              onOpenTrace={onOpenTrace}
             />
           )}
           {editMode && (

--- a/src/features/dashboard/pages/DashboardPage.tsx
+++ b/src/features/dashboard/pages/DashboardPage.tsx
@@ -21,6 +21,7 @@ import {
   linkedStrategyForWidget,
   type WidgetStrategyLink,
 } from '@/features/strategy/impact/widgetLinks';
+import { ImpactTraceDialog } from '@/features/strategy/components/ImpactTraceDialog';
 import type {
   ImpactContract,
   MetricLink,
@@ -95,6 +96,7 @@ export default function DashboardPage() {
   const [configOpen, setConfigOpen] = useState(false);
   const [editing, setEditing] = useState<DashboardWidget | null>(null);
   const [view, setView] = useState<string>(CUSTOM_VIEW);
+  const [traceNodeId, setTraceNodeId] = useState<string | null>(null);
 
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -538,6 +540,7 @@ export default function DashboardPage() {
                 strategyLinks={strategyLinksByWidget[w.id]}
                 currentPeriod={currentPeriod}
                 onOpenStrategy={openStrategyItem}
+                onOpenTrace={setTraceNodeId}
               />
             </div>
           ))}
@@ -551,6 +554,13 @@ export default function DashboardPage() {
         trackedOptions={trackedOptions}
         cardOptions={cardOptions}
         onSave={handleSave}
+      />
+
+      <ImpactTraceDialog
+        nodeId={traceNodeId}
+        projectId={canvasId}
+        open={Boolean(traceNodeId)}
+        onOpenChange={(o) => !o && setTraceNodeId(null)}
       />
     </div>
   );

--- a/src/features/strategy/components/ImpactTraceDialog.test.tsx
+++ b/src/features/strategy/components/ImpactTraceDialog.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// Fixtures are inlined inside each factory — vi.mock is hoisted above module consts.
+vi.mock('@/shared/hooks/useClerkSupabase', () => {
+  const client = {};
+  return { useClerkSupabase: () => client };
+});
+vi.mock('@/shared/lib/supabase/services/projects', () => ({
+  getProjectById: async () => ({
+    nodes: [
+      { id: 'act1', title: 'Ship checkout', description: '', category: 'Work/Action', tags: [], causalFactors: [], dimensions: [], position: { x: 0, y: 0 }, assignees: [], createdAt: '', updatedAt: '' },
+      { id: 'cvr', title: 'Checkout CVR', description: '', category: 'Data/Metric', tags: [], causalFactors: [], dimensions: [], position: { x: 0, y: 0 }, assignees: [], createdAt: '', updatedAt: '', trackedMetricId: 'tm_cvr' },
+      { id: 'kpi', title: 'North Star', description: '', category: 'Core/Value', tags: [], causalFactors: [], dimensions: [], position: { x: 0, y: 0 }, assignees: [], createdAt: '', updatedAt: '' },
+    ],
+    edges: [
+      { id: 'e', sourceId: 'cvr', targetId: 'kpi', type: 'Deterministic', confidence: 'High', evidence: [], createdAt: '', updatedAt: '' },
+    ],
+  }),
+}));
+vi.mock('@/shared/lib/supabase/services/dashboards', () => ({
+  listWidgets: async () => [
+    { id: 'w1', title: 'CVR chart', config: { source: 'tracked', trackedMetricIds: ['tm_cvr'] } },
+  ],
+}));
+vi.mock('@/shared/lib/supabase/services/trackedMetrics', () => ({
+  listTrackedMetrics: async () => [{ id: 'tm_cvr', name: 'Checkout CVR' }],
+}));
+vi.mock('@/shared/lib/supabase/services/strategyImpact', () => ({
+  getContractForNode: async () => ({ id: 'c1', strategyNodeId: 'act1' }),
+  getMetricLinks: async () => [
+    { id: 'l1', contractId: 'c1', role: 'target', refSource: 'card', trackedMetricId: null, cardId: 'cvr' },
+  ],
+}));
+
+import { ImpactTraceDialog } from './ImpactTraceDialog';
+
+describe('ImpactTraceDialog', () => {
+  it('renders the full trace: item → target → KPI, shown_on a widget', async () => {
+    render(
+      <MemoryRouter>
+        <ImpactTraceDialog nodeId="act1" projectId="canvas1" open onOpenChange={() => {}} />
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('North Star')).toBeInTheDocument();
+    expect(screen.getByText('Ship checkout')).toBeInTheDocument();
+    expect(screen.getByText('Checkout CVR')).toBeInTheDocument();
+    expect(screen.getByText('targets')).toBeInTheDocument();
+    expect(screen.getByText('rolls_up_to')).toBeInTheDocument();
+    expect(screen.getByText('CVR chart')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /open dashboard/i })).toBeInTheDocument();
+  });
+});

--- a/src/features/strategy/components/ImpactTraceDialog.tsx
+++ b/src/features/strategy/components/ImpactTraceDialog.tsx
@@ -1,0 +1,290 @@
+// Visual Impact Trace (CVS-173). For any Action/Hypothesis, renders the straight
+// line from the work item → target/leading/guardrail metrics → KPI roll-up path →
+// dashboard widget, with relationship labels and actionable gaps. Self-contained:
+// loads its own data from the canvas so it can be opened from the Strategy panel,
+// the Strategy Tree, and the Dashboard impact overlay.
+
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ArrowRight,
+  ExternalLink,
+  FlaskConical,
+  Hammer,
+  LayoutGrid,
+  Loader2,
+  Target,
+  TrendingUp,
+} from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
+import { Button } from '@/shared/components/ui/button';
+import { cn } from '@/shared/utils';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import { getProjectById } from '@/shared/lib/supabase/services/projects';
+import { listWidgets } from '@/shared/lib/supabase/services/dashboards';
+import { listTrackedMetrics } from '@/shared/lib/supabase/services/trackedMetrics';
+import {
+  getContractForNode,
+  getMetricLinks,
+} from '@/shared/lib/supabase/services/strategyImpact';
+import {
+  resolveImpactTrace,
+  type ImpactTrace,
+  type TraceMetricRef,
+  type TraceWidget,
+} from '@/features/strategy/impact/impactTrace';
+import type { MetricCard, Relationship } from '@/shared/types';
+import type { MetricLink } from '@/features/strategy/impact/types';
+
+interface ImpactTraceDialogProps {
+  nodeId: string | null;
+  projectId?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ImpactTraceDialog({
+  nodeId,
+  projectId,
+  open,
+  onOpenChange,
+}: ImpactTraceDialogProps) {
+  const client = useClerkSupabase();
+  const navigate = useNavigate();
+
+  const [loading, setLoading] = useState(false);
+  const [cards, setCards] = useState<MetricCard[]>([]);
+  const [relationships, setRelationships] = useState<Relationship[]>([]);
+  const [links, setLinks] = useState<MetricLink[]>([]);
+  const [widgets, setWidgets] = useState<TraceWidget[]>([]);
+  const [trackedNames, setTrackedNames] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!open || !nodeId || !projectId || !client) return;
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const [project, w, metrics, contract] = await Promise.all([
+          getProjectById(projectId, client).catch(() => null),
+          listWidgets(projectId, client).catch(() => []),
+          listTrackedMetrics(client).catch(() => []),
+          getContractForNode(nodeId, client).catch(() => null),
+        ]);
+        if (cancelled) return;
+        setCards(project?.nodes ?? []);
+        setRelationships(project?.edges ?? []);
+        setWidgets(
+          w.map((x) => ({ id: x.id, title: x.title, config: x.config }))
+        );
+        setTrackedNames(Object.fromEntries(metrics.map((m) => [m.id, m.name])));
+        const l = contract ? await getMetricLinks(contract.id, client) : [];
+        if (!cancelled) setLinks(l);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, nodeId, projectId, client]);
+
+  const node = useMemo(
+    () => cards.find((c) => c.id === nodeId) ?? null,
+    [cards, nodeId]
+  );
+  const trace: ImpactTrace | null = useMemo(() => {
+    if (!nodeId) return null;
+    return resolveImpactTrace({ strategyNodeId: nodeId, links, cards, relationships, widgets });
+  }, [nodeId, links, cards, relationships, widgets]);
+
+  const label = (ref: TraceMetricRef) =>
+    ref.label ?? (ref.trackedMetricId ? trackedNames[ref.trackedMetricId] : null) ?? 'Metric';
+
+  const isHypothesis = node?.category === 'Ideas/Hypothesis';
+  const NodeIcon = isHypothesis ? FlaskConical : Hammer;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Target className="h-4 w-4" />
+            Impact trace
+          </DialogTitle>
+          <DialogDescription>
+            How this work item connects to business impact.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading || !trace ? (
+          <div className="flex h-40 items-center justify-center">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {/* Primary path: item → target → … → KPI */}
+            <div className="flex flex-wrap items-center gap-1.5 rounded-lg border bg-muted/30 p-3">
+              <TraceNode
+                icon={<NodeIcon className={isHypothesis ? 'h-3.5 w-3.5 text-purple-500' : 'h-3.5 w-3.5 text-blue-500'} />}
+                title={node?.title || 'Strategy item'}
+                emphasis
+              />
+              {trace.target ? (
+                <>
+                  <Connector label="targets" />
+                  {trace.kpiPath.length > 0 ? (
+                    trace.kpiPath.map((c, i) => (
+                      <span key={c.id} className="flex items-center gap-1.5">
+                        {i > 0 && <Connector label="rolls_up_to" />}
+                        <TraceNode
+                          icon={i === trace.kpiPath.length - 1 ? <TrendingUp className="h-3.5 w-3.5 text-primary" /> : <Target className="h-3.5 w-3.5 text-muted-foreground" />}
+                          title={c.title || 'Untitled'}
+                        />
+                      </span>
+                    ))
+                  ) : (
+                    <TraceNode
+                      icon={<Target className="h-3.5 w-3.5 text-muted-foreground" />}
+                      title={label(trace.target)}
+                      muted={!trace.target.onCanvas}
+                    />
+                  )}
+                </>
+              ) : (
+                <Gap text="No target metric — add one in the Impact panel." />
+              )}
+            </div>
+
+            {/* shown_on: dashboard widgets */}
+            {trace.target && (
+              <TraceRow
+                label="shown_on"
+                emptyText="Target metric isn't on any dashboard widget yet."
+                refs={trace.target.widgets.map((w) => ({ id: w.id, title: w.title || 'Widget' }))}
+                icon={<LayoutGrid className="h-3.5 w-3.5 text-muted-foreground" />}
+              />
+            )}
+
+            {/* leads_to */}
+            <TraceRow
+              label="leads_to"
+              emptyText="No leading metrics linked."
+              refs={trace.leading.map((l) => ({ id: l.cardId ?? l.trackedMetricId ?? label(l), title: label(l), muted: !l.onCanvas }))}
+              icon={<Target className="h-3.5 w-3.5 text-muted-foreground" />}
+            />
+
+            {/* guards */}
+            <TraceRow
+              label="guards"
+              emptyText="No guardrail metrics linked."
+              refs={trace.guardrails.map((g) => ({ id: g.cardId ?? g.trackedMetricId ?? label(g), title: label(g), muted: !g.onCanvas }))}
+              icon={<Target className="h-3.5 w-3.5 text-muted-foreground" />}
+            />
+
+            {/* Gaps summary */}
+            {(trace.missing.noKpiPath || trace.missing.noDashboard) && trace.target && (
+              <div className="space-y-1 rounded-lg border border-dashed p-3 text-xs text-muted-foreground">
+                {trace.missing.noKpiPath && (
+                  <p>· No path to a KPI yet — connect this metric upward on the canvas.</p>
+                )}
+                {trace.missing.noDashboard && (
+                  <p>· Not shown on a dashboard — add a widget bound to this metric.</p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:justify-start">
+          {projectId && (
+            <>
+              <Button variant="outline" size="sm" onClick={() => navigate(`/canvas/${projectId}`)}>
+                <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                Open canvas
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => navigate(`/canvas/${projectId}/dashboard`)}>
+                <LayoutGrid className="mr-1.5 h-3.5 w-3.5" />
+                Open dashboard
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TraceNode({
+  icon,
+  title,
+  emphasis,
+  muted,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  emphasis?: boolean;
+  muted?: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs',
+        emphasis ? 'bg-background font-medium' : 'bg-background',
+        muted && 'border-dashed text-muted-foreground'
+      )}
+    >
+      {icon}
+      <span className="max-w-[140px] truncate">{title}</span>
+      {muted && <span className="text-[10px]">(off-canvas)</span>}
+    </span>
+  );
+}
+
+function Gap({ text }: { text: string }) {
+  return (
+    <span className="inline-flex items-center rounded-md border border-dashed px-2 py-1 text-xs italic text-muted-foreground">
+      {text}
+    </span>
+  );
+}
+
+function Connector({ label }: { label: string }) {
+  return (
+    <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+      <ArrowRight className="h-3 w-3" />
+      <span className="font-mono">{label}</span>
+      <ArrowRight className="h-3 w-3" />
+    </span>
+  );
+}
+
+function TraceRow({
+  label,
+  refs,
+  emptyText,
+  icon,
+}: {
+  label: string;
+  refs: Array<{ id: string; title: string; muted?: boolean }>;
+  emptyText: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-xs">
+      <span className="w-20 shrink-0 font-mono text-[10px] text-muted-foreground">{label}</span>
+      {refs.length === 0 ? (
+        <span className="italic text-muted-foreground">{emptyText}</span>
+      ) : (
+        refs.map((r) => <TraceNode key={r.id} icon={icon} title={r.title} muted={r.muted} />)
+      )}
+    </div>
+  );
+}

--- a/src/features/strategy/components/StrategyImpactSheet.tsx
+++ b/src/features/strategy/components/StrategyImpactSheet.tsx
@@ -75,6 +75,7 @@ interface StrategyImpactSheetProps {
   canEdit: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onOpenTrace?: (nodeId: string) => void;
 }
 
 function optionKey(o: Pick<MetricOption, 'source' | 'id'>): string {
@@ -99,6 +100,7 @@ export function StrategyImpactSheet({
   canEdit,
   open,
   onOpenChange,
+  onOpenTrace,
 }: StrategyImpactSheetProps) {
   const client = useClerkSupabase();
 
@@ -324,9 +326,19 @@ export function StrategyImpactSheet({
           <div className="mt-4 space-y-5 px-1 pb-6">
             {/* Trace preview */}
             <div className="rounded-md border bg-muted/40 p-3">
-              <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-                <TrendingUp className="h-3.5 w-3.5" />
-                Impact path
+              <div className="mb-1 flex items-center justify-between gap-1.5 text-xs font-medium text-muted-foreground">
+                <span className="flex items-center gap-1.5">
+                  <TrendingUp className="h-3.5 w-3.5" />
+                  Impact path
+                </span>
+                {onOpenTrace && cardId && (
+                  <button
+                    onClick={() => onOpenTrace(cardId)}
+                    className="text-primary hover:underline"
+                  >
+                    View trace
+                  </button>
+                )}
               </div>
               {!target ? (
                 <p className="text-sm text-muted-foreground">

--- a/src/features/strategy/components/StrategyTree.tsx
+++ b/src/features/strategy/components/StrategyTree.tsx
@@ -31,6 +31,7 @@ interface StrategyTreeProps {
   relationships: Relationship[];
   impactByNode: Record<string, { contract: ImpactContract; links: MetricLink[] }>;
   onOpenImpact: (cardId: string) => void;
+  onOpenTrace?: (cardId: string) => void;
 }
 
 const UNGROUPED = '__ungrouped__';
@@ -41,6 +42,7 @@ export function StrategyTree({
   relationships,
   impactByNode,
   onOpenImpact,
+  onOpenTrace,
 }: StrategyTreeProps) {
   const [filter, setFilter] = useState<ImpactFilter>('all');
   const currentPeriod = useMemo(() => new Date().toISOString().slice(0, 7), []);
@@ -152,6 +154,7 @@ export function StrategyTree({
                   cards={cards}
                   relationships={relationships}
                   onOpenImpact={onOpenImpact}
+                  onOpenTrace={onOpenTrace}
                 />
               ))}
             </div>
@@ -168,6 +171,7 @@ interface StrategyTreeItemProps {
   cards: MetricCard[];
   relationships: Relationship[];
   onOpenImpact: (cardId: string) => void;
+  onOpenTrace?: (cardId: string) => void;
 }
 
 function StrategyTreeItem({
@@ -176,6 +180,7 @@ function StrategyTreeItem({
   cards,
   relationships,
   onOpenImpact,
+  onOpenTrace,
 }: StrategyTreeItemProps) {
   const isHypothesis = card.category === 'Ideas/Hypothesis';
   const KindIcon = isHypothesis ? FlaskConical : Hammer;
@@ -210,7 +215,17 @@ function StrategyTreeItem({
           />
           {card.title || 'Untitled'}
         </button>
-        {summary && <ImpactChip summary={summary} />}
+        <div className="flex shrink-0 items-center gap-2">
+          {summary && <ImpactChip summary={summary} />}
+          {onOpenTrace && trace.target && (
+            <button
+              onClick={() => onOpenTrace(card.id)}
+              className="text-[11px] text-primary hover:underline"
+            >
+              Trace
+            </button>
+          )}
+        </div>
       </div>
 
       {!trace.target ? (

--- a/src/features/strategy/pages/StrategyPage.tsx
+++ b/src/features/strategy/pages/StrategyPage.tsx
@@ -31,6 +31,7 @@ import { StrategyTable } from '@/features/strategy/components/StrategyTable';
 import { StrategyTree } from '@/features/strategy/components/StrategyTree';
 import { CardCommentSheet } from '@/features/strategy/components/CardCommentSheet';
 import { StrategyImpactSheet } from '@/features/strategy/components/StrategyImpactSheet';
+import { ImpactTraceDialog } from '@/features/strategy/components/ImpactTraceDialog';
 import { listContractsWithLinksForProject } from '@/shared/lib/supabase/services/strategyImpact';
 import {
   summarizeImpact,
@@ -91,6 +92,7 @@ export default function StrategyPage() {
   const [settingsCardId, setSettingsCardId] = useState<string | null>(null);
   const [commentCardId, setCommentCardId] = useState<string | null>(null);
   const [impactCardId, setImpactCardId] = useState<string | null>(null);
+  const [traceCardId, setTraceCardId] = useState<string | null>(null);
   const [impactEntries, setImpactEntries] = useState<
     Array<{ contract: ImpactContract; links: MetricLink[] }>
   >([]);
@@ -495,6 +497,7 @@ export default function StrategyPage() {
           relationships={edges}
           impactByNode={impactByNode}
           onOpenImpact={setImpactCardId}
+          onOpenTrace={setTraceCardId}
         />
       ) : (
         <StrategyTable
@@ -551,6 +554,13 @@ export default function StrategyPage() {
             setImpactReload((n) => n + 1);
           }
         }}
+        onOpenTrace={setTraceCardId}
+      />
+      <ImpactTraceDialog
+        nodeId={traceCardId}
+        projectId={canvasId}
+        open={Boolean(traceCardId)}
+        onOpenChange={(open) => !open && setTraceCardId(null)}
       />
     </div>
   );


### PR DESCRIPTION
Closes **CVS-173** — completes Milestone 3. **Stacked on [#81](https://github.com/nadeemramli/metrimap/pull/81)** (CVS-172).

## What
A self-contained **Impact Trace** dialog that makes the straight line visible for any Action/Hypothesis.

- **`ImpactTraceDialog`** loads its own canvas data and renders via the CVS-168 resolver:
  `item --targets--> target --rolls_up_to--> … --> KPI`, with **shown_on** dashboard widgets and **leads_to** / **guards** rows — all labelled with the relationship type.
- **Actionable gaps**: no target metric, no KPI path yet, not on a dashboard.
- **Jump-outs**: Open canvas / Open dashboard.
- **Three entry points**: "View trace" in the Strategy Impact panel, per-item "Trace" in the Strategy Tree, and "Trace" in the dashboard widget overlay (`WidgetImpactBadge`).

## Verification
- `type-check` ✅ · lint ✅ · **full vitest 202/202** ✅ — adds a full-path trace render test (target + KPI + dashboard) via mocked services.

Structure + links only; measured deltas are CVS-174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)