### PR TITLE
feat(evidence): notebook blocks /chart + /snapshot (CVS-34 slice 4.3/4.4)

### DIFF
--- a/src/features/evidence/blocks/ChartBlock.ts
+++ b/src/features/evidence/blocks/ChartBlock.ts
@@ -1,0 +1,156 @@
+// Custom EditorJS block: /chart — a live sparkline of a metric card's value
+// history (CVS-34 slice 4.3). Stores cardId + a snapshot of the series; resolves
+// the live series from the canvas store (card.data: MetricValue[]) when present.
+// Plain-DOM SVG (no React / charting lib) — safe inside EditorJS.
+import { useCanvasStore } from '@/lib/stores';
+import { sparklineSvg } from './sparkline';
+
+interface ChartData {
+  cardId: string;
+  title?: string;
+  series?: number[];
+}
+
+interface BlockToolArgs {
+  data: Partial<ChartData>;
+  readOnly?: boolean;
+}
+
+function nodes(): any[] {
+  return useCanvasStore.getState().canvas?.nodes ?? [];
+}
+function seriesOf(card: any): number[] {
+  return ((card?.data ?? []) as any[])
+    .map((d) => Number(d?.value))
+    .filter((n) => !isNaN(n));
+}
+
+export default class ChartBlock {
+  static get toolbox() {
+    return {
+      title: 'Chart',
+      icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>',
+    };
+  }
+  static get isReadOnlySupported() {
+    return true;
+  }
+  static get sanitize() {
+    return { cardId: false, title: false, series: false };
+  }
+
+  private data: ChartData;
+  private readOnly: boolean;
+  private wrapper: HTMLElement | null = null;
+
+  constructor({ data, readOnly }: BlockToolArgs) {
+    this.data = { cardId: data?.cardId ?? '', ...data };
+    this.readOnly = Boolean(readOnly);
+  }
+
+  private rebuild() {
+    if (!this.wrapper) return;
+    this.wrapper.innerHTML = '';
+    this.wrapper.appendChild(
+      !this.readOnly && !this.data.cardId
+        ? this.renderPicker()
+        : this.renderChart()
+    );
+  }
+
+  private renderPicker(): HTMLElement {
+    const list = nodes();
+    const box = document.createElement('div');
+    box.style.cssText =
+      'padding:8px;border:1px dashed #cbd5e1;border-radius:8px;background:#f8fafc;';
+    if (list.length === 0) {
+      box.textContent = 'No metric cards on this canvas to chart.';
+      box.style.cssText += 'color:#94a3b8;font-size:13px;';
+      return box;
+    }
+    const select = document.createElement('select');
+    select.style.cssText =
+      'width:100%;padding:6px 8px;border:1px solid #e2e8f0;border-radius:6px;font-size:14px;background:#fff;';
+    const ph = document.createElement('option');
+    ph.value = '';
+    ph.textContent = 'Chart a metric…';
+    select.appendChild(ph);
+    list.forEach((c: any) => {
+      const o = document.createElement('option');
+      o.value = c.id;
+      o.textContent = c.title || 'Untitled';
+      select.appendChild(o);
+    });
+    select.onchange = () => {
+      const c = list.find((x: any) => x.id === select.value);
+      if (c) {
+        this.data = { cardId: c.id, title: c.title, series: seriesOf(c) };
+        this.rebuild();
+      }
+    };
+    box.appendChild(select);
+    return box;
+  }
+
+  private renderChart(): HTMLElement {
+    const live = nodes().find((c: any) => c.id === this.data.cardId) as any;
+    const title = live?.title || this.data.title || 'Metric';
+    const series = live ? seriesOf(live) : this.data.series || [];
+
+    const card = document.createElement('div');
+    card.style.cssText =
+      'border:1px solid #e2e8f0;border-radius:10px;padding:10px 12px;background:#fff;max-width:280px;';
+
+    const head = document.createElement('div');
+    head.style.cssText =
+      'display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;';
+    const name = document.createElement('span');
+    name.textContent = title;
+    name.style.cssText = 'font-weight:600;font-size:14px;color:#0f172a;';
+    head.appendChild(name);
+    if (!this.readOnly) {
+      const change = document.createElement('button');
+      change.type = 'button';
+      change.textContent = 'change';
+      change.style.cssText =
+        'font-size:11px;color:#94a3b8;background:none;border:none;cursor:pointer;';
+      change.onclick = (e) => {
+        e.preventDefault();
+        this.data = { cardId: '' };
+        this.rebuild();
+      };
+      head.appendChild(change);
+    }
+    card.appendChild(head);
+
+    if (series.length === 0) {
+      const empty = document.createElement('div');
+      empty.textContent = 'No values yet';
+      empty.style.cssText = 'font-size:12px;color:#94a3b8;';
+      card.appendChild(empty);
+    } else {
+      const svg = document.createElement('div');
+      svg.innerHTML = sparklineSvg(series);
+      card.appendChild(svg);
+      const last = series[series.length - 1];
+      const val = document.createElement('div');
+      val.textContent = last.toLocaleString();
+      val.style.cssText =
+        'font-size:16px;font-weight:700;color:#0f172a;margin-top:2px;';
+      card.appendChild(val);
+    }
+    return card;
+  }
+
+  render(): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.style.margin = '6px 0';
+    this.wrapper = wrapper;
+    this.rebuild();
+    return wrapper;
+  }
+
+  save(): ChartData {
+    return this.data;
+  }
+}

--- a/src/features/evidence/blocks/SnapshotBlock.ts
+++ b/src/features/evidence/blocks/SnapshotBlock.ts
@@ -1,0 +1,178 @@
+// Custom EditorJS block: /snapshot — freeze a metric card's values at capture
+// time with a timestamp (CVS-34 slice 4.4). Unlike /chart (live), the series is
+// captured once and never updates — an audit record of what the metric looked
+// like when the evidence was written. Plain-DOM SVG. (Screenshot-of-a-region
+// capture is a future upgrade; this freezes the data instead.)
+import { useCanvasStore } from '@/lib/stores';
+import { sparklineSvg } from './sparkline';
+
+interface SnapshotData {
+  cardId: string;
+  title?: string;
+  series?: number[];
+  value?: number;
+  capturedAt?: string; // ISO
+}
+
+interface BlockToolArgs {
+  data: Partial<SnapshotData>;
+  readOnly?: boolean;
+}
+
+function nodes(): any[] {
+  return useCanvasStore.getState().canvas?.nodes ?? [];
+}
+function seriesOf(card: any): number[] {
+  return ((card?.data ?? []) as any[])
+    .map((d) => Number(d?.value))
+    .filter((n) => !isNaN(n));
+}
+
+export default class SnapshotBlock {
+  static get toolbox() {
+    return {
+      title: 'Snapshot',
+      icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="6" width="18" height="14" rx="2"/><circle cx="12" cy="13" r="3.5"/><path d="M8 6l1.5-2h5L16 6"/></svg>',
+    };
+  }
+  static get isReadOnlySupported() {
+    return true;
+  }
+  static get sanitize() {
+    return {
+      cardId: false,
+      title: false,
+      series: false,
+      value: false,
+      capturedAt: false,
+    };
+  }
+
+  private data: SnapshotData;
+  private readOnly: boolean;
+  private wrapper: HTMLElement | null = null;
+
+  constructor({ data, readOnly }: BlockToolArgs) {
+    this.data = { cardId: data?.cardId ?? '', ...data };
+    this.readOnly = Boolean(readOnly);
+  }
+
+  private rebuild() {
+    if (!this.wrapper) return;
+    this.wrapper.innerHTML = '';
+    this.wrapper.appendChild(
+      !this.readOnly && !this.data.capturedAt
+        ? this.renderPicker()
+        : this.renderSnapshot()
+    );
+  }
+
+  private renderPicker(): HTMLElement {
+    const list = nodes();
+    const box = document.createElement('div');
+    box.style.cssText =
+      'padding:8px;border:1px dashed #cbd5e1;border-radius:8px;background:#f8fafc;';
+    if (list.length === 0) {
+      box.textContent = 'No metric cards on this canvas to snapshot.';
+      box.style.cssText += 'color:#94a3b8;font-size:13px;';
+      return box;
+    }
+    const select = document.createElement('select');
+    select.style.cssText =
+      'width:100%;padding:6px 8px;border:1px solid #e2e8f0;border-radius:6px;font-size:14px;background:#fff;';
+    const ph = document.createElement('option');
+    ph.value = '';
+    ph.textContent = 'Snapshot a metric (freeze it)…';
+    select.appendChild(ph);
+    list.forEach((c: any) => {
+      const o = document.createElement('option');
+      o.value = c.id;
+      o.textContent = c.title || 'Untitled';
+      select.appendChild(o);
+    });
+    select.onchange = () => {
+      const c = list.find((x: any) => x.id === select.value);
+      if (c) {
+        const series = seriesOf(c);
+        this.data = {
+          cardId: c.id,
+          title: c.title,
+          series,
+          value: series[series.length - 1],
+          capturedAt: new Date().toISOString(),
+        };
+        this.rebuild();
+      }
+    };
+    box.appendChild(select);
+    return box;
+  }
+
+  private renderSnapshot(): HTMLElement {
+    const series = this.data.series || [];
+    const card = document.createElement('div');
+    card.style.cssText =
+      'border:1px solid #e2e8f0;border-radius:10px;padding:10px 12px;background:#fbfbfc;max-width:280px;';
+
+    const head = document.createElement('div');
+    head.style.cssText =
+      'display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;';
+    const name = document.createElement('span');
+    name.textContent = this.data.title || 'Metric';
+    name.style.cssText = 'font-weight:600;font-size:14px;color:#0f172a;';
+    head.appendChild(name);
+    const badge = document.createElement('span');
+    badge.textContent = 'snapshot';
+    badge.style.cssText =
+      'font-size:10px;color:#64748b;background:#f1f5f9;padding:1px 6px;border-radius:9999px;';
+    head.appendChild(badge);
+    card.appendChild(head);
+
+    if (series.length) {
+      const svg = document.createElement('div');
+      svg.innerHTML = sparklineSvg(series, { color: '#64748b' });
+      card.appendChild(svg);
+    }
+    const val = document.createElement('div');
+    val.textContent =
+      this.data.value === undefined ? '—' : this.data.value.toLocaleString();
+    val.style.cssText =
+      'font-size:16px;font-weight:700;color:#0f172a;margin-top:2px;';
+    card.appendChild(val);
+
+    const ts = document.createElement('div');
+    const when = this.data.capturedAt
+      ? new Date(this.data.capturedAt).toLocaleString()
+      : '';
+    ts.textContent = when ? `Captured ${when}` : '';
+    ts.style.cssText = 'font-size:11px;color:#94a3b8;margin-top:2px;';
+    card.appendChild(ts);
+
+    if (!this.readOnly) {
+      const recapture = document.createElement('button');
+      recapture.type = 'button';
+      recapture.textContent = 're-capture';
+      recapture.style.cssText =
+        'margin-top:6px;font-size:11px;color:#94a3b8;background:none;border:none;cursor:pointer;';
+      recapture.onclick = (e) => {
+        e.preventDefault();
+        this.data = { cardId: '' };
+        this.rebuild();
+      };
+      card.appendChild(recapture);
+    }
+    return card;
+  }
+
+  render(): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.style.margin = '6px 0';
+    this.wrapper = wrapper;
+    this.rebuild();
+    return wrapper;
+  }
+
+  save(): SnapshotData {
+    return this.data;
+  }
+}

--- a/src/features/evidence/blocks/sparkline.ts
+++ b/src/features/evidence/blocks/sparkline.ts
@@ -1,0 +1,40 @@
+// Tiny dependency-free SVG sparkline for the /chart + /snapshot notebook blocks
+// (CVS-34 slice 4.3/4.4). Plain SVG string — no React, no charting lib — so it's
+// safe inside EditorJS's DOM rendering and in the read-only renderer.
+
+export function sparklineSvg(
+  values: number[],
+  opts: { width?: number; height?: number; color?: string } = {}
+): string {
+  const width = opts.width ?? 220;
+  const height = opts.height ?? 48;
+  const color = opts.color ?? '#6366f1';
+  const pad = 4;
+
+  const nums = values.filter((v) => typeof v === 'number' && !isNaN(v));
+  if (nums.length === 0) {
+    return `<svg width="${width}" height="${height}"></svg>`;
+  }
+  if (nums.length === 1) nums.push(nums[0]);
+
+  const min = Math.min(...nums);
+  const max = Math.max(...nums);
+  const span = max - min || 1;
+  const stepX = (width - pad * 2) / (nums.length - 1);
+
+  const pts = nums.map((v, i) => {
+    const x = pad + i * stepX;
+    const y = pad + (height - pad * 2) * (1 - (v - min) / span);
+    return [x, y] as const;
+  });
+
+  const line = pts.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
+  const [lx, ly] = pts[pts.length - 1];
+  const area = `${pad},${height - pad} ${line} ${width - pad},${height - pad}`;
+
+  return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" style="display:block">
+    <polygon points="${area}" fill="${color}" fill-opacity="0.08" />
+    <polyline points="${line}" fill="none" stroke="${color}" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round" />
+    <circle cx="${lx.toFixed(1)}" cy="${ly.toFixed(1)}" r="2.6" fill="${color}" />
+  </svg>`;
+}

--- a/src/lib/editorjs-config.ts
+++ b/src/lib/editorjs-config.ts
@@ -35,6 +35,8 @@ import MetricRefBlock from "@/features/evidence/blocks/MetricRefBlock";
 import HypothesisBlock from "@/features/evidence/blocks/HypothesisBlock";
 import SourceBlock from "@/features/evidence/blocks/SourceBlock";
 import EvidenceLinkBlock from "@/features/evidence/blocks/EvidenceLinkBlock";
+import ChartBlock from "@/features/evidence/blocks/ChartBlock";
+import SnapshotBlock from "@/features/evidence/blocks/SnapshotBlock";
 // Note: DragDrop and Undo are problematic, we'll implement them later
 
 export interface EditorJSConfigOptions {
@@ -82,7 +84,9 @@ export const VALID_BLOCK_TYPES = [
   "metricValue",
   "hypothesisBlock",
   "sourceCite",
-  "evidenceLink"
+  "evidenceLink",
+  "chartBlock",
+  "snapshotBlock"
 ] as const;
 
 export type ValidBlockType = typeof VALID_BLOCK_TYPES[number];
@@ -307,6 +311,12 @@ export const createEditorJSTools = () => {
     },
     evidenceLink: {
       class: EvidenceLinkBlock as any,
+    },
+    chartBlock: {
+      class: ChartBlock as any,
+    },
+    snapshotBlock: {
+      class: SnapshotBlock as any,
     },
   };
 };


### PR DESCRIPTION
**Final two blocks of CVS-197** — completes the 9-block analytical notebook.

Deliberately **plain-DOM SVG, no React-in-EditorJS, no charting dependency** (so they don't add to the runtime/lifecycle issues):

- **`/chart`** — pick a metric card → a **live sparkline** of its value history (`card.data: MetricValue[]`), resolves current values on render + shows the latest value.
- **`/snapshot`** — pick a metric → **freezes** its series + value + a **timestamp**; a static sparkline that never updates (an audit record of the metric when the evidence was written). Region-screenshot capture (html-to-image) is a future upgrade; this freezes the *data* instead — usable now with no new deps or storage.

Shared `sparkline.ts` renderer.

## Verification
type-check ✓, lint ✓ (0 errors), full build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)