### PR TITLE
feat(visibility): access tags + audience policy (CVS-120)

### DIFF
--- a/src/features/assets/pages/AssetsPage.tsx
+++ b/src/features/assets/pages/AssetsPage.tsx
@@ -1,3 +1,4 @@
+import { AccessTagControls } from '@/features/settings/components/AccessTagControls';
 import { AssetsChartsTab } from '@/features/assets/components/AssetsChartsTab';
 import { AssetsDataTab } from '@/features/assets/components/AssetsDataTab';
 import { AssetsEmptyState } from '@/features/assets/components/emptystate/AssetsEmptyState';
@@ -1714,16 +1715,11 @@ export default function AssetsPage() {
                   )}
                 </div>
                 <div className="flex items-center gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      // TODO: Implement tag editing
-                      console.log('Edit tag:', tag);
-                    }}
-                  >
-                    Edit
-                  </Button>
+                  <AccessTagControls
+                    tagId={tag.id}
+                    isAccess={tag.is_access}
+                    redactionMode={tag.redaction_mode}
+                  />
                   <Button
                     variant="destructive"
                     size="sm"

--- a/src/features/settings/components/AccessTagControls.tsx
+++ b/src/features/settings/components/AccessTagControls.tsx
@@ -1,0 +1,176 @@
+import { Badge } from '@/shared/components/ui/badge';
+import { Button } from '@/shared/components/ui/button';
+import { Checkbox } from '@/shared/components/ui/checkbox';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/shared/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/components/ui/select';
+import { Switch } from '@/shared/components/ui/switch';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import {
+  getTagAudience,
+  setTagAccess,
+  setTagAudience,
+  type RedactionMode,
+} from '@/shared/lib/supabase/services/accessTags';
+import {
+  listGroups,
+  type WorkspaceGroupWithCount,
+} from '@/shared/lib/supabase/services/groups';
+import { Users } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Per-tag access controls for the project tag manager (CVS-120): mark a tag as
+ * an access tag, choose its redaction mode, and pick the workspace groups
+ * (audience) that may see nodes carrying it. No access tag = visible to all.
+ */
+export function AccessTagControls({
+  tagId,
+  isAccess: initialAccess,
+  redactionMode: initialMode,
+}: {
+  tagId: string;
+  isAccess?: boolean;
+  redactionMode?: string;
+}) {
+  const client = useClerkSupabase();
+  const [access, setAccess] = useState(!!initialAccess);
+  const [mode, setMode] = useState<RedactionMode>(
+    initialMode === 'hide_node' ? 'hide_node' : 'hide_value'
+  );
+  const [groups, setGroups] = useState<WorkspaceGroupWithCount[] | null>(null);
+  const [audience, setAudience] = useState<Set<string>>(new Set());
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!client || !access) return;
+    getTagAudience(tagId, client)
+      .then((ids) => setAudience(new Set(ids)))
+      .catch(() => {});
+  }, [client, access, tagId]);
+
+  const ensureGroups = async () => {
+    if (groups || !client) return;
+    try {
+      setGroups(await listGroups(client));
+    } catch {
+      setGroups([]);
+    }
+  };
+
+  const toggleAccess = async (next: boolean) => {
+    if (!client) return;
+    setAccess(next);
+    setSaving(true);
+    try {
+      await setTagAccess(tagId, { isAccess: next, redactionMode: mode }, client);
+      if (next) await ensureGroups();
+      toast.success(next ? 'Marked as access tag' : 'Access removed');
+    } catch {
+      setAccess(!next);
+      toast.error('Failed to update access');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const changeMode = async (m: RedactionMode) => {
+    if (!client) return;
+    setMode(m);
+    try {
+      await setTagAccess(tagId, { isAccess: true, redactionMode: m }, client);
+    } catch {
+      toast.error('Failed to set redaction mode');
+    }
+  };
+
+  const toggleGroup = async (groupId: string, checked: boolean) => {
+    if (!client) return;
+    const next = new Set(audience);
+    if (checked) next.add(groupId);
+    else next.delete(groupId);
+    setAudience(next);
+    try {
+      await setTagAudience(tagId, [...next], client);
+    } catch {
+      // revert
+      const revert = new Set(audience);
+      setAudience(revert);
+      toast.error('Failed to update audience');
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      {access && (
+        <>
+          <Select value={mode} onValueChange={(v) => changeMode(v as RedactionMode)}>
+            <SelectTrigger className="h-7 w-[130px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="hide_value">Hide value</SelectItem>
+              <SelectItem value="hide_node">Hide node</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <Popover onOpenChange={(o) => o && ensureGroups()}>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm" className="h-7 gap-1 text-xs">
+                <Users className="h-3 w-3" />
+                Audience
+                {audience.size > 0 && (
+                  <Badge variant="secondary" className="ml-1 px-1">
+                    {audience.size}
+                  </Badge>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-56">
+              {groups === null ? (
+                <p className="text-xs text-muted-foreground">Loading groups…</p>
+              ) : groups.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  No groups yet. Create them in Workspace Settings → Groups.
+                </p>
+              ) : (
+                <div className="space-y-1.5">
+                  <p className="mb-1 text-xs font-medium text-muted-foreground">
+                    Groups that can see nodes with this tag
+                  </p>
+                  {groups.map((g) => (
+                    <label
+                      key={g.id}
+                      className="flex cursor-pointer items-center gap-2 text-sm"
+                    >
+                      <Checkbox
+                        checked={audience.has(g.id)}
+                        onCheckedChange={(v) => toggleGroup(g.id, v === true)}
+                      />
+                      <span>{g.name}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </PopoverContent>
+          </Popover>
+        </>
+      )}
+
+      <div className="flex items-center gap-1.5" title="Restrict who can see nodes with this tag">
+        <Switch checked={access} onCheckedChange={toggleAccess} disabled={saving} />
+        <span className="text-xs text-muted-foreground">Access</span>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/lib/supabase/services/accessTags.ts
+++ b/src/shared/lib/supabase/services/accessTags.ts
@@ -1,0 +1,118 @@
+import { supabase } from '@/shared/lib/supabase/client';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '../types';
+
+/**
+ * Access-tag + audience policy (CVS-120). A tag can be marked an "access tag"
+ * carrying an audience of workspace groups (CVS-119); nodes with it are visible
+ * only to those groups (resolved by node_visible_to_me, enforced by RLS in
+ * CVS-121). A per-node allowlist (node_access_grants) is the escape hatch.
+ *
+ * Access columns are written directly (not via updateTag) because the generated
+ * tags zod schema is `.strict()` and doesn't know is_access/redaction_mode.
+ */
+
+export type RedactionMode = 'hide_value' | 'hide_node';
+
+function db(client?: SupabaseClient<Database>) {
+  return client || supabase();
+}
+
+/** Flag/unflag a tag as an access tag and set its redaction mode. */
+export async function setTagAccess(
+  tagId: string,
+  opts: { isAccess: boolean; redactionMode?: RedactionMode },
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<void> {
+  const client = db(authenticatedClient);
+  const patch: { is_access: boolean; redaction_mode?: string } = {
+    is_access: opts.isAccess,
+  };
+  if (opts.redactionMode) patch.redaction_mode = opts.redactionMode;
+  const { error } = await client
+    .from('tags')
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq('id', tagId);
+  if (error) throw error;
+}
+
+/** Group ids that may see nodes carrying this access tag. */
+export async function getTagAudience(
+  tagId: string,
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<string[]> {
+  const client = db(authenticatedClient);
+  const { data, error } = await client
+    .from('tag_audiences')
+    .select('group_id')
+    .eq('tag_id', tagId);
+  if (error) throw error;
+  return (data ?? []).map((r) => r.group_id);
+}
+
+/** Replace a tag's audience with exactly `groupIds`. */
+export async function setTagAudience(
+  tagId: string,
+  groupIds: string[],
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<void> {
+  const client = db(authenticatedClient);
+  const { error: delErr } = await client
+    .from('tag_audiences')
+    .delete()
+    .eq('tag_id', tagId);
+  if (delErr) throw delErr;
+  if (groupIds.length === 0) return;
+  const { error } = await client
+    .from('tag_audiences')
+    .insert(groupIds.map((group_id) => ({ tag_id: tagId, group_id })));
+  if (error) throw error;
+}
+
+/** Per-node allowlist grants (escape hatch). */
+export async function getNodeAccessGrants(
+  metricCardId: string,
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<string[]> {
+  const client = db(authenticatedClient);
+  const { data, error } = await client
+    .from('node_access_grants')
+    .select('group_id')
+    .eq('metric_card_id', metricCardId);
+  if (error) throw error;
+  return (data ?? []).map((r) => r.group_id);
+}
+
+export async function setNodeAccessGrants(
+  metricCardId: string,
+  groupIds: string[],
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<void> {
+  const client = db(authenticatedClient);
+  const { error: delErr } = await client
+    .from('node_access_grants')
+    .delete()
+    .eq('metric_card_id', metricCardId);
+  if (delErr) throw delErr;
+  if (groupIds.length === 0) return;
+  const { error } = await client
+    .from('node_access_grants')
+    .insert(groupIds.map((group_id) => ({ metric_card_id: metricCardId, group_id })));
+  if (error) throw error;
+}
+
+/**
+ * Authoritative visibility of a node for the current user (mirrors the RLS
+ * predicate). Used by the redaction UX (CVS-122) to preview / mask.
+ */
+export async function nodeVisibleToMe(
+  metricCardId: string,
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<boolean> {
+  const client = db(authenticatedClient);
+  const { data, error } = await client.rpc('node_visible_to_me', {
+    card_id: metricCardId,
+  });
+  if (error) throw error;
+  return data ?? false;
+}

--- a/src/shared/lib/supabase/types.ts
+++ b/src/shared/lib/supabase/types.ts
@@ -1498,6 +1498,66 @@ export type Database = {
           }
         ]
       }
+      tag_audiences: {
+        Row: {
+          group_id: string
+          tag_id: string
+        }
+        Insert: {
+          group_id: string
+          tag_id: string
+        }
+        Update: {
+          group_id?: string
+          tag_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tag_audiences_group_id_fkey"
+            columns: ["group_id"]
+            isOneToOne: false
+            referencedRelation: "workspace_groups"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tag_audiences_tag_id_fkey"
+            columns: ["tag_id"]
+            isOneToOne: false
+            referencedRelation: "tags"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      node_access_grants: {
+        Row: {
+          group_id: string
+          metric_card_id: string
+        }
+        Insert: {
+          group_id: string
+          metric_card_id: string
+        }
+        Update: {
+          group_id?: string
+          metric_card_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "node_access_grants_group_id_fkey"
+            columns: ["group_id"]
+            isOneToOne: false
+            referencedRelation: "workspace_groups"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "node_access_grants_metric_card_id_fkey"
+            columns: ["metric_card_id"]
+            isOneToOne: false
+            referencedRelation: "metric_cards"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       tags: {
         Row: {
           id: string
@@ -1508,6 +1568,8 @@ export type Database = {
           created_by: string
           created_at: string | null
           updated_at: string | null
+          is_access: boolean
+          redaction_mode: string
         }
         Insert: {
           id?: string
@@ -1518,6 +1580,8 @@ export type Database = {
           created_by: string
           created_at?: string | null
           updated_at?: string | null
+          is_access?: boolean
+          redaction_mode?: string
         }
         Update: {
           id?: string
@@ -1528,6 +1592,8 @@ export type Database = {
           created_by?: string
           created_at?: string | null
           updated_at?: string | null
+          is_access?: boolean
+          redaction_mode?: string
         }
         Relationships: [
           {
@@ -1581,6 +1647,10 @@ export type Database = {
       my_groups: {
         Args: Record<PropertyKey, never>
         Returns: string[]
+      }
+      node_visible_to_me: {
+        Args: { card_id: string }
+        Returns: boolean
       }
     }
     Enums: {

--- a/supabase/migrations/20260711120000_access_tags.sql
+++ b/supabase/migrations/20260711120000_access_tags.sql
@@ -1,0 +1,145 @@
+-- =====================================================================
+-- ACCESS TAGS + AUDIENCE POLICY (CVS-120) — extends the existing tag system
+-- so a tag can be an "access tag" carrying an audience (which workspace groups
+-- may see nodes with it). Builds on workspace_groups/my_groups() (CVS-119).
+--
+-- Model (locked in CVS-118):
+--   * tags.is_access        — mark a tag as an access tag
+--   * tags.redaction_mode   — hide_value (default) | hide_node
+--   * tag_audiences         — access tag -> allowed groups
+--   * node_access_grants    — per-node allowlist escape hatch
+--   * node_visible_to_me()  — deterministic visibility resolver (fail closed)
+--
+-- This migration adds the MODEL + resolver only. RLS enforcement that USES the
+-- resolver on metric_cards / edges / metric_values lands in CVS-121. Existing
+-- untagged nodes stay visible to everyone (is_access defaults false).
+-- =====================================================================
+BEGIN;
+
+ALTER TABLE public.tags
+  ADD COLUMN IF NOT EXISTS is_access boolean NOT NULL DEFAULT false;
+ALTER TABLE public.tags
+  ADD COLUMN IF NOT EXISTS redaction_mode text NOT NULL DEFAULT 'hide_value';
+
+DO $$ BEGIN
+  ALTER TABLE public.tags
+    ADD CONSTRAINT tags_redaction_mode_check
+    CHECK (redaction_mode IN ('hide_value', 'hide_node'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS public.tag_audiences (
+  tag_id   uuid NOT NULL REFERENCES public.tags(id) ON DELETE CASCADE,
+  group_id uuid NOT NULL REFERENCES public.workspace_groups(id) ON DELETE CASCADE,
+  PRIMARY KEY (tag_id, group_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.node_access_grants (
+  metric_card_id uuid NOT NULL REFERENCES public.metric_cards(id) ON DELETE CASCADE,
+  group_id       uuid NOT NULL REFERENCES public.workspace_groups(id) ON DELETE CASCADE,
+  PRIMARY KEY (metric_card_id, group_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tag_audiences_group      ON public.tag_audiences(group_id);
+CREATE INDEX IF NOT EXISTS idx_node_access_grants_group ON public.node_access_grants(group_id);
+
+-- ---------------------------------------------------------------------
+-- node_visible_to_me(card_id): the deterministic resolver the RLS layer
+-- (CVS-121) and the client (redaction UX, CVS-122) both call.
+--
+-- SECURITY DEFINER (runs as owner, bypassing RLS) so it can read the tag /
+-- audience tables AND so calling it from the metric_cards RLS policy in
+-- CVS-121 does not recurse. Fail-closed: unknown card / no match => false.
+--
+-- Visible when ANY of:
+--   * requester owns/admins/edits the project (has_project_access), OR
+--   * the node carries NO access tag, OR
+--   * the requester is in some access tag's audience, OR
+--   * the requester's group has a per-node allowlist grant.
+-- Multiple access tags union (any granting tag lets the viewer in).
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.node_visible_to_me(card_id uuid)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT EXISTS (SELECT 1 FROM public.metric_cards mc WHERE mc.id = card_id)
+    AND (
+      public.has_project_access(
+        (SELECT mc.project_id FROM public.metric_cards mc WHERE mc.id = card_id), true
+      )
+      OR NOT EXISTS (
+        SELECT 1 FROM public.metric_card_tags mct
+        JOIN public.tags t ON t.id = mct.tag_id
+        WHERE mct.metric_card_id = card_id AND t.is_access
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.metric_card_tags mct
+        JOIN public.tags t ON t.id = mct.tag_id AND t.is_access
+        JOIN public.tag_audiences ta ON ta.tag_id = t.id
+        WHERE mct.metric_card_id = card_id
+          AND ta.group_id IN (SELECT public.my_groups())
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.node_access_grants g
+        WHERE g.metric_card_id = card_id
+          AND g.group_id IN (SELECT public.my_groups())
+      )
+    );
+$$;
+GRANT EXECUTE ON FUNCTION public.node_visible_to_me(uuid) TO authenticated, anon;
+
+-- ---------------------------------------------------------------------
+-- RLS — audience/allowlist rows scoped to the requester's workspace via the
+-- group they reference (workspace_groups.workspace_id = requesting_org_id()).
+-- ---------------------------------------------------------------------
+ALTER TABLE public.tag_audiences      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.node_access_grants ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tag_audiences_select ON public.tag_audiences;
+CREATE POLICY tag_audiences_select ON public.tag_audiences
+  FOR SELECT USING (EXISTS (
+    SELECT 1 FROM public.workspace_groups g
+    WHERE g.id = tag_audiences.group_id
+      AND g.workspace_id = public.requesting_org_id()
+  ));
+
+DROP POLICY IF EXISTS tag_audiences_insert ON public.tag_audiences;
+CREATE POLICY tag_audiences_insert ON public.tag_audiences
+  FOR INSERT WITH CHECK (EXISTS (
+    SELECT 1 FROM public.workspace_groups g
+    WHERE g.id = tag_audiences.group_id
+      AND g.workspace_id = public.requesting_org_id()
+  ) AND public.requesting_user_id() IS NOT NULL);
+
+DROP POLICY IF EXISTS tag_audiences_delete ON public.tag_audiences;
+CREATE POLICY tag_audiences_delete ON public.tag_audiences
+  FOR DELETE USING (EXISTS (
+    SELECT 1 FROM public.workspace_groups g
+    WHERE g.id = tag_audiences.group_id
+      AND g.workspace_id = public.requesting_org_id()
+  ));
+
+DROP POLICY IF EXISTS node_access_grants_select ON public.node_access_grants;
+CREATE POLICY node_access_grants_select ON public.node_access_grants
+  FOR SELECT USING (EXISTS (
+    SELECT 1 FROM public.workspace_groups g
+    WHERE g.id = node_access_grants.group_id
+      AND g.workspace_id = public.requesting_org_id()
+  ));
+
+DROP POLICY IF EXISTS node_access_grants_insert ON public.node_access_grants;
+CREATE POLICY node_access_grants_insert ON public.node_access_grants
+  FOR INSERT WITH CHECK (EXISTS (
+    SELECT 1 FROM public.workspace_groups g
+    WHERE g.id = node_access_grants.group_id
+      AND g.workspace_id = public.requesting_org_id()
+  ) AND public.requesting_user_id() IS NOT NULL);
+
+DROP POLICY IF EXISTS node_access_grants_delete ON public.node_access_grants;
+CREATE POLICY node_access_grants_delete ON public.node_access_grants
+  FOR DELETE USING (EXISTS (
+    SELECT 1 FROM public.workspace_groups g
+    WHERE g.id = node_access_grants.group_id
+      AND g.workspace_id = public.requesting_org_id()
+  ));
+
+COMMIT;


### PR DESCRIPTION
Second build issue of the **Access & Visibility** lane. Model + resolver for tag-based node visibility. Decisions locked in CVS-118; builds on groups (CVS-119).

## What
- **Migration `20260711120000_access_tags.sql`**: `tags.is_access` + `tags.redaction_mode` (`hide_value` default / `hide_node`); `tag_audiences` (access tag → groups); `node_access_grants` (per-node allowlist escape hatch); and `node_visible_to_me(card_id)` — a `SECURITY DEFINER`, fail-closed resolver (union over a node's access tags' audiences + owner/admin + allowlist). RLS scopes the new tables to the workspace.
- **`services/accessTags.ts`**: mark access / set redaction mode, get+set audience, get+set node grants, `nodeVisibleToMe` RPC. Writes access columns directly to bypass the strict generated `tags` zod schema.
- **`settings/components/AccessTagControls.tsx`**: per-tag **Access** switch + redaction-mode select + audience group picker — replaces the dead "Edit" stub in the AssetsPage project tag manager.
- **`types.ts`**: hand-added the columns, tables, and function.

## Acceptance criteria (CVS-120)
- [x] A tag can be flagged "access" with an audience of groups
- [x] Assign access tags on node create/edit (tags are assigned as before; access is a tag property)
- [x] Deterministic visibility resolution (`node_visible_to_me`)
- [x] Backfills cleanly — existing untagged nodes stay visible to all (`is_access` defaults false)

## Notes
- **Model + resolver only. The RLS wall that USES `node_visible_to_me` on `metric_cards`/edges/`metric_values` is CVS-121** — restricting a node has no enforced effect until that lands (the resolver + UI are in place to configure it).
- Migration **applied to prod** (`iqrclwolhookzzmiedun`). `type-check` + full `lint` + `vitest` pass via Husky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)