### PR TITLE
feat(cvs-175): Impact Review mode (won/lost/inconclusive + Evidence)

### DIFF
--- a/src/features/strategy/components/ImpactReviewSection.test.tsx
+++ b/src/features/strategy/components/ImpactReviewSection.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ImpactContract, MetricLink } from '@/features/strategy/impact/types';
+import type { MetricCard } from '@/shared/types';
+
+vi.mock('@/shared/hooks/useClerkSupabase', () => {
+  const client = {};
+  return { useClerkSupabase: () => client };
+});
+vi.mock('@/lib/stores', () => ({
+  useAppStore: (sel: (s: { user: { id: string } }) => unknown) => sel({ user: { id: 'u1' } }),
+}));
+vi.mock('@/shared/lib/supabase/services/trackedMetrics', () => ({
+  getMetricValuesByMetricIds: async () => ({
+    tm_cvr: [
+      { period: '2026-05', value: 100, change_percent: 0, trend: 'neutral' },
+      { period: '2026-07', value: 107, change_percent: 7, trend: 'up' },
+    ],
+    tm_aov: [
+      { period: '2026-05', value: 50, change_percent: 0, trend: 'neutral' },
+      { period: '2026-07', value: 51, change_percent: 2, trend: 'up' },
+    ],
+  }),
+}));
+vi.mock('@/shared/lib/supabase/services/evidence', () => ({ createCardEvidence: vi.fn(async () => ({})) }));
+
+import { ImpactReviewSection } from './ImpactReviewSection';
+
+const contract: ImpactContract = {
+  id: 'c', workspaceId: null, projectId: 'p', strategyNodeId: 'act',
+  expectedDirection: 'increase', expectedDeltaValue: 5, expectedDeltaUnit: 'percent',
+  baselineStart: '2026-05', baselineEnd: '2026-05', measureStart: '2026-07', measureEnd: '2026-07',
+  baselineIsManual: false, confidence: null, impactStatus: 'measuring',
+  ownerLabel: null, resultNote: null, createdBy: 'u', createdAt: '', updatedAt: '',
+};
+const links: MetricLink[] = [
+  { id: 't', contractId: 'c', role: 'target', refSource: 'tracked', trackedMetricId: 'tm_cvr', cardId: null },
+  { id: 'g', contractId: 'c', role: 'guardrail', refSource: 'tracked', trackedMetricId: 'tm_aov', cardId: null },
+];
+const cards: MetricCard[] = [
+  { id: 'cvr', title: 'Checkout CVR', description: '', category: 'Data/Metric', tags: [], causalFactors: [], dimensions: [], position: { x: 0, y: 0 }, assignees: [], createdAt: '', updatedAt: '', trackedMetricId: 'tm_cvr' },
+];
+
+describe('ImpactReviewSection', () => {
+  it('shows the measured outcome and marks a result', async () => {
+    const onMark = vi.fn();
+    render(
+      <ImpactReviewSection
+        contract={contract}
+        links={links}
+        cards={cards}
+        cardId="act"
+        cardTitle="Ship checkout"
+        projectId="p"
+        canEdit
+        resultNote="Rollout went smoothly"
+        onMarkResult={onMark}
+      />
+    );
+    // measured target delta + suggestion appear after series load
+    expect(await screen.findByText(/\+7\.0%/)).toBeInTheDocument();
+    expect(screen.getByText('won')).toBeInTheDocument(); // suggests won
+    // mark the outcome
+    fireEvent.click(screen.getByRole('button', { name: 'Won' }));
+    expect(onMark).toHaveBeenCalledWith('won');
+  });
+});

--- a/src/features/strategy/components/ImpactReviewSection.tsx
+++ b/src/features/strategy/components/ImpactReviewSection.tsx
@@ -1,0 +1,249 @@
+// Impact Review (CVS-175). Turns the CVS-174 measurement into an explicit
+// outcome: shows target/leading/guardrail deltas + a suggested result, lets the
+// user mark won/lost/inconclusive/keep-measuring, and creates an Evidence note
+// capturing the review. Self-contained: loads its own tracked-metric series.
+
+import { useEffect, useMemo, useState } from 'react';
+import { Loader2, NotebookPen } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/shared/utils';
+import { Button } from '@/shared/components/ui/button';
+import { useAppStore } from '@/lib/stores';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import { getMetricValuesByMetricIds } from '@/shared/lib/supabase/services/trackedMetrics';
+import { createCardEvidence } from '@/shared/lib/supabase/services/evidence';
+import { metricRefKey } from '@/features/strategy/impact/impactContract';
+import {
+  evaluateImpact,
+  type GuardrailStatus,
+  type ImpactEvaluation,
+  type MetricEval,
+} from '@/features/strategy/impact/measurement';
+import type {
+  ImpactContract,
+  ImpactStatus,
+  MetricLink,
+} from '@/features/strategy/impact/types';
+import type { EvidenceItem, MetricCard, MetricValue } from '@/shared/types';
+
+interface ImpactReviewSectionProps {
+  contract: ImpactContract;
+  links: MetricLink[];
+  cards: MetricCard[];
+  cardId: string;
+  cardTitle: string;
+  projectId?: string;
+  canEdit: boolean;
+  resultNote: string;
+  onMarkResult: (status: ImpactStatus) => Promise<void> | void;
+}
+
+const RESULT_OPTIONS: { status: ImpactStatus; label: string; style: string }[] = [
+  { status: 'won', label: 'Won', style: 'bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20' },
+  { status: 'lost', label: 'Lost', style: 'bg-red-500/10 text-red-600 hover:bg-red-500/20' },
+  { status: 'inconclusive', label: 'Inconclusive', style: 'bg-zinc-500/10 text-zinc-600 hover:bg-zinc-500/20' },
+  { status: 'measuring', label: 'Keep measuring', style: 'bg-amber-500/10 text-amber-600 hover:bg-amber-500/20' },
+];
+
+const GUARDRAIL_STYLE: Record<GuardrailStatus, string> = {
+  pass: 'text-emerald-600',
+  fail: 'text-red-600',
+  unknown: 'text-muted-foreground',
+};
+
+function fmtDelta(e: MetricEval): string {
+  if (!e.hasData) return 'no data';
+  const pct = e.pctDelta != null ? `${e.pctDelta > 0 ? '+' : ''}${e.pctDelta.toFixed(1)}%` : null;
+  const abs = e.absDelta != null ? `${e.absDelta > 0 ? '+' : ''}${e.absDelta}` : null;
+  return pct ? `${pct} (${abs})` : (abs ?? '—');
+}
+
+function buildEvidenceSummary(
+  title: string,
+  metricLabel: (e: MetricEval) => string,
+  ev: ImpactEvaluation,
+  resultNote: string
+): string {
+  const lines: string[] = [`Impact review — ${title}`, ''];
+  if (ev.target) {
+    lines.push(
+      `Target ${metricLabel(ev.target)}: baseline ${ev.target.baseline ?? '—'} → window ${ev.target.windowValue ?? '—'} = ${fmtDelta(ev.target)}`
+    );
+  }
+  if (ev.expected) {
+    lines.push(`Expected: ${ev.expected.direction} ${ev.expected.value ?? ''}${ev.expected.unit === 'percent' ? '%' : ''} → ${ev.met}`);
+  }
+  for (const l of ev.leading) lines.push(`Leading ${metricLabel(l)}: ${fmtDelta(l)}`);
+  for (const g of ev.guardrails) lines.push(`Guardrail ${metricLabel(g)}: ${g.status} (${fmtDelta(g)})`);
+  lines.push('', `Suggested result: ${ev.suggestedResult}`);
+  if (resultNote) lines.push('', `Note: ${resultNote}`);
+  return lines.join('\n');
+}
+
+export function ImpactReviewSection({
+  contract,
+  links,
+  cards,
+  cardId,
+  cardTitle,
+  projectId,
+  canEdit,
+  resultNote,
+  onMarkResult,
+}: ImpactReviewSectionProps) {
+  const client = useClerkSupabase();
+  const userId = useAppStore((s) => s.user?.id);
+  const [trackedValues, setTrackedValues] = useState<Record<string, MetricValue[]>>({});
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  const trackedIds = useMemo(
+    () =>
+      links
+        .filter((l) => l.refSource === 'tracked' && l.trackedMetricId)
+        .map((l) => l.trackedMetricId as string),
+    [links]
+  );
+  const trackedKey = trackedIds.slice().sort().join(',');
+
+  useEffect(() => {
+    if (!client || trackedIds.length === 0) {
+      setTrackedValues({});
+      return;
+    }
+    setLoading(true);
+    getMetricValuesByMetricIds(trackedIds, client)
+      .then(setTrackedValues)
+      .catch(() => setTrackedValues({}))
+      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, trackedKey]);
+
+  const seriesByKey = useMemo(() => {
+    const map: Record<string, MetricValue[]> = {};
+    for (const l of links) {
+      const key = metricRefKey(l);
+      if (!key) continue;
+      if (l.refSource === 'tracked' && l.trackedMetricId) {
+        map[key] = trackedValues[l.trackedMetricId] ?? [];
+      } else if (l.refSource === 'card' && l.cardId) {
+        map[key] = cards.find((c) => c.id === l.cardId)?.data ?? [];
+      }
+    }
+    return map;
+  }, [links, trackedValues, cards]);
+
+  const ev = useMemo(
+    () => evaluateImpact(contract, links, seriesByKey),
+    [contract, links, seriesByKey]
+  );
+
+  const labelFor = (e: MetricEval): string => {
+    const link = links.find((l) => metricRefKey(l) === e.refKey);
+    if (link?.refSource === 'card') return cards.find((c) => c.id === link.cardId)?.title ?? 'Metric';
+    return cards.find((c) => c.trackedMetricId === link?.trackedMetricId)?.title ?? 'Tracked metric';
+  };
+
+  const handleCreateEvidence = async () => {
+    if (!client || !userId || !projectId) return;
+    setCreating(true);
+    try {
+      const evidence: EvidenceItem = {
+        id: '',
+        title: `Impact review: ${cardTitle}`,
+        type: 'Analysis',
+        date: new Date().toISOString().slice(0, 10),
+        owner: userId,
+        summary: buildEvidenceSummary(cardTitle, labelFor, ev, resultNote),
+        hypothesis: undefined,
+        createdAt: '',
+        updatedAt: '',
+      };
+      await createCardEvidence(evidence, cardId, projectId, userId, client);
+      toast.success('Evidence note created');
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to create evidence');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  if (!ev.target) return null;
+
+  return (
+    <div className="space-y-3 rounded-md border p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold text-muted-foreground">Review</span>
+        <span className="text-[11px] text-muted-foreground">
+          suggests <span className="font-medium capitalize">{ev.suggestedResult}</span>
+        </span>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-3">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <div className="space-y-1 text-xs">
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Target {labelFor(ev.target)}</span>
+            <span className="font-medium">
+              {fmtDelta(ev.target)}{' '}
+              <span className={cn('capitalize', ev.met === 'met' ? 'text-emerald-600' : ev.met === 'missed' ? 'text-red-600' : 'text-muted-foreground')}>
+                · {ev.met}
+              </span>
+            </span>
+          </div>
+          {ev.leading.map((l) => (
+            <div key={l.refKey} className="flex items-center justify-between text-muted-foreground">
+              <span>Leading {labelFor(l)}</span>
+              <span>{fmtDelta(l)}</span>
+            </div>
+          ))}
+          {ev.guardrails.map((g) => (
+            <div key={g.refKey} className="flex items-center justify-between">
+              <span className="text-muted-foreground">Guardrail {labelFor(g)}</span>
+              <span className={cn('font-medium capitalize', GUARDRAIL_STYLE[g.status])}>
+                {g.status} · {fmtDelta(g)}
+              </span>
+            </div>
+          ))}
+          {ev.guardrailStatus === 'fail' && (
+            <p className="pt-1 text-[11px] text-red-600">
+              A guardrail breached — can't auto-win; review before marking Won.
+            </p>
+          )}
+        </div>
+      )}
+
+      {canEdit && (
+        <>
+          <div className="flex flex-wrap gap-1.5">
+            {RESULT_OPTIONS.map((r) => (
+              <button
+                key={r.status}
+                onClick={() => onMarkResult(r.status)}
+                className={cn('rounded px-2 py-1 text-[11px] font-medium', r.style)}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+          {!resultNote && (
+            <p className="text-[11px] text-amber-600">Add a result note above before marking an outcome.</p>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 w-full gap-1.5"
+            onClick={handleCreateEvidence}
+            disabled={creating || !projectId}
+          >
+            {creating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <NotebookPen className="h-3.5 w-3.5" />}
+            Create evidence note
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/strategy/components/StrategyImpactSheet.tsx
+++ b/src/features/strategy/components/StrategyImpactSheet.tsx
@@ -44,6 +44,7 @@ import type { MetricCard, Relationship } from '@/shared/types';
 import type {
   Confidence,
   ExpectedDirection,
+  ImpactContract,
   ImpactStatus,
   MetricLink,
   MetricLinkInput,
@@ -55,6 +56,7 @@ import {
   IMPACT_STATUSES,
 } from '@/features/strategy/impact/types';
 import { resolveImpactTrace } from '@/features/strategy/impact/impactTrace';
+import { ImpactReviewSection } from '@/features/strategy/components/ImpactReviewSection';
 
 /** A selectable metric — a catalogued tracked metric or a canvas metric card. */
 interface MetricOption {
@@ -229,13 +231,14 @@ export function StrategyImpactSheet({
   }, [open, cardId, client]);
 
   // Live trace preview from the current (possibly unsaved) selections.
-  const trace = useMemo(() => {
-    if (!cardId) return null;
+  // Live links + a draft contract from the current form — shared by the trace
+  // preview and the review section so both reflect unsaved edits.
+  const formLinks = useMemo(() => {
     const links: MetricLink[] = [];
     const push = (o: MetricOption, role: MetricLinkRole, i: number) =>
       links.push({
-        id: `preview-${role}-${i}`,
-        contractId: 'preview',
+        id: `form-${role}-${i}`,
+        contractId: 'form',
         role,
         refSource: o.source,
         trackedMetricId: o.source === 'tracked' ? o.id : null,
@@ -244,17 +247,48 @@ export function StrategyImpactSheet({
     if (target) push(target, 'target', 0);
     leading.forEach((o, i) => push(o, 'leading', i));
     guardrails.forEach((o, i) => push(o, 'guardrail', i));
+    return links;
+  }, [target, leading, guardrails]);
+
+  const formContract: ImpactContract = useMemo(
+    () => ({
+      id: contractId ?? 'draft',
+      workspaceId: null,
+      projectId: projectId ?? null,
+      strategyNodeId: cardId ?? '',
+      expectedDirection: direction || null,
+      expectedDeltaValue: deltaValue.trim() === '' ? null : Number(deltaValue),
+      expectedDeltaUnit: direction === 'stabilize' ? null : deltaUnit,
+      baselineStart: baselineStart.trim() || null,
+      baselineEnd: baselineEnd.trim() || null,
+      measureStart: measureStart.trim() || null,
+      measureEnd: measureEnd.trim() || null,
+      baselineIsManual: false,
+      confidence: confidence || null,
+      impactStatus: status,
+      ownerLabel: null,
+      resultNote: resultNote.trim() || null,
+      createdBy: '',
+      createdAt: '',
+      updatedAt: '',
+    }),
+    [contractId, projectId, cardId, direction, deltaValue, deltaUnit, baselineStart, baselineEnd, measureStart, measureEnd, confidence, status, resultNote]
+  );
+
+  const trace = useMemo(() => {
+    if (!cardId) return null;
     return resolveImpactTrace({
       strategyNodeId: cardId,
-      links,
+      links: formLinks,
       cards,
       relationships,
       widgets: [],
     });
-  }, [cardId, target, leading, guardrails, cards, relationships]);
+  }, [cardId, formLinks, cards, relationships]);
 
-  const handleSave = async () => {
+  const handleSave = async (statusOverride?: ImpactStatus) => {
     if (!cardId || !client) return;
+    const nextStatus = statusOverride ?? status;
     setSaving(true);
     try {
       const contract = await upsertContract(
@@ -269,7 +303,7 @@ export function StrategyImpactSheet({
           measureStart: measureStart.trim() || null,
           measureEnd: measureEnd.trim() || null,
           confidence: confidence || null,
-          impactStatus: status,
+          impactStatus: nextStatus,
           resultNote: resultNote.trim() || null,
         },
         client
@@ -287,6 +321,12 @@ export function StrategyImpactSheet({
     } finally {
       setSaving(false);
     }
+  };
+
+  // Review: mark an outcome — persists the status + all current fields/links.
+  const markResult = async (next: ImpactStatus) => {
+    setStatus(next);
+    await handleSave(next);
   };
 
   const handleRemove = async () => {
@@ -513,6 +553,20 @@ export function StrategyImpactSheet({
               />
             </div>
 
+            {cardId && target && (
+              <ImpactReviewSection
+                contract={formContract}
+                links={formLinks}
+                cards={cards}
+                cardId={cardId}
+                cardTitle={cardTitle || 'Strategy item'}
+                projectId={projectId}
+                canEdit={canEdit}
+                resultNote={resultNote}
+                onMarkResult={markResult}
+              />
+            )}
+
             {canEdit && (
               <div className="flex items-center justify-between pt-1">
                 {contractId ? (
@@ -522,7 +576,7 @@ export function StrategyImpactSheet({
                 ) : (
                   <span />
                 )}
-                <Button onClick={handleSave} disabled={saving}>
+                <Button onClick={() => handleSave()} disabled={saving}>
                   {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
                   Save impact
                 </Button>


### PR DESCRIPTION
Closes **CVS-175** (Strategy impact — Milestone 4). **Stacked on [#85](https://github.com/nadeemramli/metrimap/pull/85)** (CVS-174).

## What
A review ritual for closing bets, inside the Impact panel.

- **`ImpactReviewSection`** loads the contract's tracked-metric series, runs the CVS-174 `evaluateImpact`, and shows **target / leading / guardrail** deltas with met + pass/fail and a **suggested result**.
- **Mark result**: Won / Lost / Inconclusive / Keep measuring → persists the outcome (via `markResult`). A **failed guardrail** is flagged and blocks a clean auto-win; a **result note** is strongly prompted.
- **Create evidence note**: writes a card-linked Evidence item capturing baseline, window, deltas, guardrail status, and the decision.
- Result = `impactStatus`, so it **immediately surfaces** in the panel chip, board/table, dashboard badge, and trace.

## Verification
- `type-check` ✅ · lint ✅ · **full vitest 210/210** ✅ — review-section component test (winning fixture → suggests won → marks result).

Ready-for-review discoverability reuses the existing "review ready" filters (board/table/tree/dashboard). No causal attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)