### PR TITLE
fix(canvas): stabilize nodes memo to cut React #185 render-loop churn (CVS-65)

### DIFF
--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -771,7 +771,14 @@ function CanvasPageInner() {
   );
 
   // UNIFIED: Use only canvasNodes from Zustand store, remove state.extraNodes
-  const temporaryExtraNodes = state.extraNodes || [];
+  // Memoize so an empty/unchanged value keeps a STABLE reference — otherwise this
+  // was a fresh `[]` every render, recomputing the whole `nodes` memo each render
+  // and feeding React Flow new node objects continuously (a driver of the
+  // controlled-nodes update loop → React #185). See CVS-23/65.
+  const temporaryExtraNodes = useMemo(
+    () => state.extraNodes || [],
+    [state.extraNodes]
+  );
 
   // Memoized data conversions
   const nodes = useMemo(() => {


### PR DESCRIPTION
Addresses the recurring **React #185 "Maximum update depth exceeded"** crash on `/canvas/:id` (CVS-23/65), which shows up after using evidence.

## Diagnosis
Pulled the real errors from the `error_reports` sink → all **#185** (infinite render loop), on the canvas. Traced to the React-Flow controlled-nodes ↔ store sync. The `nodes` `useMemo` (CanvasPage) had a dependency, `temporaryExtraNodes = state.extraNodes || []`, that was a **fresh `[]` on every render** when empty — so the memo recomputed **every render** and handed React Flow new node objects continuously, feeding the update loop (evidence-store autosaves are one of the triggers, hence the association with evidence).

## Fix
Memoize `temporaryExtraNodes` so an unchanged value keeps a stable reference. The `nodes` memo's remaining deps (store arrays/methods, `stableEvents`, primitives) are all stable, so it now recomputes only on real changes.

## Honest caveat
This removes a concrete, verified churn source and should reduce/stop the loop — but #185 in a fragile React-Flow core can have more than one contributor, and I can't 100%-confirm the root from minified prod stacks. If it still recurs, the definitive next step is a `npm run dev` repro (React prints the exact component + offending update).

## Verification
type-check ✓, lint ✓ (0 errors), full build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)