### PR TITLE
CVS-224: fix Metric/Hypothesis node toolbar crash (missing import)

### DIFF
--- a/src/features/canvas/components/nodes/HypothesisNode.tsx
+++ b/src/features/canvas/components/nodes/HypothesisNode.tsx
@@ -19,7 +19,9 @@ import {
   Target,
 } from 'lucide-react';
 import { memo, useState } from 'react';
-import { useNodeToolbarActions } from './shared/EnhancedNodeToolbar';
+import EnhancedNodeToolbar, {
+  useNodeToolbarActions,
+} from './shared/EnhancedNodeToolbar';
 
 interface HypothesisNodeData {
   node: HypothesisNodeType;

--- a/src/features/canvas/components/nodes/MetricNode.tsx
+++ b/src/features/canvas/components/nodes/MetricNode.tsx
@@ -20,7 +20,9 @@ import {
   TrendingUp,
 } from 'lucide-react';
 import { memo, useState } from 'react';
-import { useNodeToolbarActions } from './shared/EnhancedNodeToolbar';
+import EnhancedNodeToolbar, {
+  useNodeToolbarActions,
+} from './shared/EnhancedNodeToolbar';
 
 interface MetricNodeData {
   node: MetricNodeType;


### PR DESCRIPTION
Closes CVS-224. `MetricNode`/`HypothesisNode` rendered `<EnhancedNodeToolbar>` but imported only the `useNodeToolbarActions` hook, not the default component → `ReferenceError` on double-click-to-open-toolbar. User-creatable node types, so live; `@ts-nocheck` hid it. Added the default import. Strictly crash→working. type-check/lint/202 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)