### PR TITLE
feat(cvs-176): surface measured impact deltas in Strategy + Dashboard

### DIFF
--- a/src/features/dashboard/components/WidgetCard.tsx
+++ b/src/features/dashboard/components/WidgetCard.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/features/dashboard/utils/widgetData';
 import { WidgetImpactBadge } from '@/features/dashboard/components/WidgetImpactBadge';
 import type { WidgetStrategyLink } from '@/features/strategy/impact/widgetLinks';
+import type { MeasuredImpact } from '@/features/strategy/impact/measurement';
 import {
   GripVertical,
   Settings2,
@@ -30,6 +31,7 @@ interface WidgetCardProps {
   onConfigure: (widget: DashboardWidget) => void;
   onRemove: (id: string) => void;
   strategyLinks?: WidgetStrategyLink[];
+  measuredMap?: Record<string, MeasuredImpact>;
   currentPeriod?: string;
   onOpenStrategy?: (nodeId: string) => void;
   onOpenTrace?: (nodeId: string) => void;
@@ -44,6 +46,7 @@ export function WidgetCard({
   onConfigure,
   onRemove,
   strategyLinks,
+  measuredMap,
   currentPeriod,
   onOpenStrategy,
   onOpenTrace,
@@ -63,6 +66,7 @@ export function WidgetCard({
           {strategyLinks && strategyLinks.length > 0 && onOpenStrategy && (
             <WidgetImpactBadge
               links={strategyLinks}
+              measuredMap={measuredMap}
               currentPeriod={currentPeriod ?? new Date().toISOString().slice(0, 7)}
               onOpenStrategy={onOpenStrategy}
               onOpenTrace={onOpenTrace}

--- a/src/features/dashboard/components/WidgetImpactBadge.tsx
+++ b/src/features/dashboard/components/WidgetImpactBadge.tsx
@@ -17,6 +17,7 @@ import {
   type EffectiveStatus,
   type WidgetStrategyLink,
 } from '@/features/strategy/impact/widgetLinks';
+import type { MeasuredImpact } from '@/features/strategy/impact/measurement';
 
 const STATUS_STYLES: Record<EffectiveStatus, string> = {
   draft: 'bg-muted text-muted-foreground',
@@ -43,6 +44,7 @@ interface WidgetImpactBadgeProps {
   currentPeriod: string;
   onOpenStrategy: (nodeId: string) => void;
   onOpenTrace?: (nodeId: string) => void;
+  measuredMap?: Record<string, MeasuredImpact>;
 }
 
 export function WidgetImpactBadge({
@@ -50,6 +52,7 @@ export function WidgetImpactBadge({
   currentPeriod,
   onOpenStrategy,
   onOpenTrace,
+  measuredMap,
 }: WidgetImpactBadgeProps) {
   const [open, setOpen] = useState(false);
   if (links.length === 0) return null;
@@ -111,6 +114,20 @@ export function WidgetImpactBadge({
                     </span>
                   ))}
                   {delta && <span>expect {delta}</span>}
+                  {measuredMap?.[contract.strategyNodeId]?.hasData && (
+                    <span
+                      className={cn(
+                        'font-medium',
+                        measuredMap[contract.strategyNodeId].met === 'met'
+                          ? 'text-emerald-600'
+                          : measuredMap[contract.strategyNodeId].met === 'missed'
+                            ? 'text-red-600'
+                            : 'text-muted-foreground'
+                      )}
+                    >
+                      actual {measuredMap[contract.strategyNodeId].deltaText}
+                    </span>
+                  )}
                   {contract.confidence && <span>{contract.confidence} conf.</span>}
                   {window && <span>{window}</span>}
                   {contract.ownerLabel && <span>· {contract.ownerLabel}</span>}

--- a/src/features/dashboard/pages/DashboardPage.tsx
+++ b/src/features/dashboard/pages/DashboardPage.tsx
@@ -21,6 +21,7 @@ import {
   linkedStrategyForWidget,
   type WidgetStrategyLink,
 } from '@/features/strategy/impact/widgetLinks';
+import { measuredByNode } from '@/features/strategy/impact/measurement';
 import { ImpactTraceDialog } from '@/features/strategy/components/ImpactTraceDialog';
 import type {
   ImpactContract,
@@ -171,8 +172,12 @@ export default function DashboardPage() {
         (w.config.trackedMetricIds ?? []).forEach((id) => ids.add(id));
       }
     });
+    // Also the metrics referenced by impact contracts, so measured deltas resolve.
+    for (const { links } of impactEntries) {
+      for (const l of links) if (l.refSource === 'tracked' && l.trackedMetricId) ids.add(l.trackedMetricId);
+    }
     return Array.from(ids);
-  }, [widgets]);
+  }, [widgets, impactEntries]);
 
   useEffect(() => {
     if (!client || referencedTrackedIds.length === 0) {
@@ -198,6 +203,12 @@ export default function DashboardPage() {
     }
     return map;
   }, [widgets, impactEntries, cards]);
+
+  // Measured deltas per strategy node (CVS-176), for the badge overlay.
+  const measuredMap = useMemo(
+    () => measuredByNode(impactEntries, cards, trackedValues),
+    [impactEntries, cards, trackedValues]
+  );
 
   const openStrategyItem = useMemo(
     () => () => {
@@ -538,6 +549,7 @@ export default function DashboardPage() {
                 onConfigure={openConfigure}
                 onRemove={handleRemove}
                 strategyLinks={strategyLinksByWidget[w.id]}
+                measuredMap={measuredMap}
                 currentPeriod={currentPeriod}
                 onOpenStrategy={openStrategyItem}
                 onOpenTrace={setTraceNodeId}

--- a/src/features/strategy/components/ImpactChip.tsx
+++ b/src/features/strategy/components/ImpactChip.tsx
@@ -1,10 +1,12 @@
 // Compact impact summary for board tiles + table cells (CVS-170): status pill +
-// target metric + expected delta. Reads a pre-computed ImpactSummary.
+// target metric + expected delta. Reads a pre-computed ImpactSummary. Optionally
+// shows the MEASURED target delta + guardrail health (CVS-176).
 
-import { Target } from 'lucide-react';
+import { AlertTriangle, Target } from 'lucide-react';
 import { cn } from '@/shared/utils';
 import type { ImpactStatus } from '@/features/strategy/impact/types';
 import type { ImpactSummary } from '@/features/strategy/impact/impactContract';
+import type { MeasuredImpact } from '@/features/strategy/impact/measurement';
 
 const IMPACT_STATUS_STYLES: Record<ImpactStatus, string> = {
   draft: 'bg-muted text-muted-foreground',
@@ -17,10 +19,11 @@ const IMPACT_STATUS_STYLES: Record<ImpactStatus, string> = {
 
 interface ImpactChipProps {
   summary: ImpactSummary;
+  measured?: MeasuredImpact;
   className?: string;
 }
 
-export function ImpactChip({ summary, className }: ImpactChipProps) {
+export function ImpactChip({ summary, measured, className }: ImpactChipProps) {
   return (
     <span className={cn('flex flex-wrap items-center gap-1.5', className)}>
       <span
@@ -39,10 +42,29 @@ export function ImpactChip({ summary, className }: ImpactChipProps) {
           <span className="italic">no target</span>
         )}
       </span>
-      {summary.deltaText && (
-        <span className="text-[10px] font-medium text-muted-foreground">
-          {summary.deltaText}
+      {measured?.hasData ? (
+        <span
+          className={cn(
+            'flex items-center gap-1 text-[10px] font-medium',
+            measured.met === 'met'
+              ? 'text-emerald-600'
+              : measured.met === 'missed'
+                ? 'text-red-600'
+                : 'text-muted-foreground'
+          )}
+          title={`measured ${measured.deltaText ?? ''} · ${measured.met}`}
+        >
+          {measured.deltaText}
+          {measured.guardrailStatus === 'fail' && (
+            <AlertTriangle className="h-3 w-3 text-red-600" />
+          )}
         </span>
+      ) : (
+        summary.deltaText && (
+          <span className="text-[10px] font-medium text-muted-foreground">
+            {summary.deltaText}
+          </span>
+        )
       )}
     </span>
   );

--- a/src/features/strategy/components/StrategyBoard.tsx
+++ b/src/features/strategy/components/StrategyBoard.tsx
@@ -1,6 +1,7 @@
 import type { StrategyBoardData } from '@/features/strategy/utils/groupStrategy';
 import { StrategyCardTile } from '@/features/strategy/components/StrategyCardTile';
 import type { ImpactSummary } from '@/features/strategy/impact/impactContract';
+import type { MeasuredImpact } from '@/features/strategy/impact/measurement';
 import type { WorkflowStatus } from '@/shared/types';
 import { cn } from '@/shared/utils';
 import { useState } from 'react';
@@ -13,6 +14,7 @@ interface StrategyBoardProps {
   onStatusChange: (cardId: string, status: WorkflowStatus) => void;
   onCardClick?: (cardId: string) => void;
   impactSummaries?: Record<string, ImpactSummary>;
+  measuredMap?: Record<string, MeasuredImpact>;
 }
 
 export function StrategyBoard({
@@ -20,6 +22,7 @@ export function StrategyBoard({
   onStatusChange,
   onCardClick,
   impactSummaries,
+  measuredMap,
 }: StrategyBoardProps) {
   const [dragOver, setDragOver] = useState<WorkflowStatus | null>(null);
 
@@ -60,6 +63,7 @@ export function StrategyBoard({
                 card={card}
                 onClick={onCardClick}
                 impact={impactSummaries?.[card.id]}
+                measured={measuredMap?.[card.id]}
               />
             ))}
           </div>

--- a/src/features/strategy/components/StrategyCardTile.tsx
+++ b/src/features/strategy/components/StrategyCardTile.tsx
@@ -2,6 +2,7 @@ import { PRIORITY_STYLES } from '@/features/canvas/utils/workflow';
 import { Badge } from '@/shared/components/ui/badge';
 import { ImpactChip } from '@/features/strategy/components/ImpactChip';
 import type { ImpactSummary } from '@/features/strategy/impact/impactContract';
+import type { MeasuredImpact } from '@/features/strategy/impact/measurement';
 import type { MetricCard } from '@/shared/types';
 import { cn } from '@/shared/utils';
 import { CalendarDays, FlaskConical, Hammer } from 'lucide-react';
@@ -13,9 +14,10 @@ interface StrategyCardTileProps {
   card: MetricCard;
   onClick?: (cardId: string) => void;
   impact?: ImpactSummary;
+  measured?: MeasuredImpact;
 }
 
-export function StrategyCardTile({ card, onClick, impact }: StrategyCardTileProps) {
+export function StrategyCardTile({ card, onClick, impact, measured }: StrategyCardTileProps) {
   const isHypothesis = card.category === 'Ideas/Hypothesis';
   const workflow = card.workflow ?? {};
   const KindIcon = isHypothesis ? FlaskConical : Hammer;
@@ -84,7 +86,7 @@ export function StrategyCardTile({ card, onClick, impact }: StrategyCardTileProp
 
       {impact && (
         <div className="border-t pt-2">
-          <ImpactChip summary={impact} />
+          <ImpactChip summary={impact} measured={measured} />
         </div>
       )}
     </div>

--- a/src/features/strategy/components/StrategyTable.tsx
+++ b/src/features/strategy/components/StrategyTable.tsx
@@ -59,6 +59,7 @@ import {
   type ImpactFilter,
   type ImpactSummary,
 } from '@/features/strategy/impact/impactContract';
+import type { MeasuredImpact } from '@/features/strategy/impact/measurement';
 
 const STATUS_OPTIONS: PillOption<WorkflowStatus>[] = WORKFLOW_STATUSES.map(
   (s) => ({ value: s.value, label: s.label, className: WORKFLOW_STATUS_STYLES[s.value] })
@@ -88,6 +89,7 @@ interface StrategyTableProps extends StrategyTableHandlers {
   members: ProjectMember[];
   commentCounts: Record<string, number>;
   impactSummaries: Record<string, ImpactSummary>;
+  measuredMap?: Record<string, MeasuredImpact>;
   canEdit: boolean;
 }
 
@@ -114,6 +116,7 @@ export function StrategyTable({
   members,
   commentCounts,
   impactSummaries,
+  measuredMap,
   canEdit,
   onStatusChange,
   onPriorityChange,
@@ -316,7 +319,7 @@ export function StrategyTable({
                                 className="text-left"
                                 title="Edit impact"
                               >
-                                <ImpactChip summary={impactSummaries[card.id]} />
+                                <ImpactChip summary={impactSummaries[card.id]} measured={measuredMap?.[card.id]} />
                               </button>
                             ) : (
                               <button

--- a/src/features/strategy/impact/measurement.test.ts
+++ b/src/features/strategy/impact/measurement.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { evaluateImpact } from './measurement';
+import { buildSeriesByKey, evaluateImpact, measuredByNode } from './measurement';
 import type { ImpactContract, MetricLink } from './types';
-import type { MetricValue } from '@/shared/types';
+import type { MetricCard, MetricValue } from '@/shared/types';
 
 const mv = (period: string, value: number): MetricValue => ({
   period,
@@ -94,5 +94,33 @@ describe('evaluateImpact', () => {
     const series = { 'tracked:tm_cvr': [mv('2026-05', 100), mv('2026-07', 101)] }; // +1%
     const e = evaluateImpact(contract({ expectedDirection: 'stabilize', expectedDeltaValue: 2 }), [tLink], series);
     expect(e.met).toBe('met');
+  });
+});
+
+const card = (id: string, over: Partial<MetricCard> = {}): MetricCard => ({
+  id, title: id, description: '', category: 'Data/Metric', tags: [], causalFactors: [],
+  dimensions: [], position: { x: 0, y: 0 }, assignees: [], createdAt: '', updatedAt: '', ...over,
+});
+
+describe('buildSeriesByKey / measuredByNode', () => {
+  it('resolves tracked series from the values map and card series from card.data', () => {
+    const cards: MetricCard[] = [card('card_x', { data: [mv('2026-05', 4), mv('2026-07', 6)] })];
+    const links: MetricLink[] = [
+      tLink,
+      { id: 'c', contractId: 'c', role: 'leading', refSource: 'card', trackedMetricId: null, cardId: 'card_x' },
+    ];
+    const map = buildSeriesByKey(links, cards, { tm_cvr: [mv('2026-05', 100)] });
+    expect(map['tracked:tm_cvr']).toHaveLength(1);
+    expect(map['card:card_x']).toHaveLength(2);
+  });
+
+  it('measuredByNode returns a compact measured summary per node', () => {
+    const entries = [
+      { contract: contract(), links: [tLink] },
+    ];
+    const measured = measuredByNode(entries, [], { tm_cvr: [mv('2026-05', 100), mv('2026-07', 107)] });
+    expect(measured['act'].deltaText).toBe('+7.0%');
+    expect(measured['act'].met).toBe('met');
+    expect(measured['act'].hasData).toBe(true);
   });
 });

--- a/src/features/strategy/impact/measurement.ts
+++ b/src/features/strategy/impact/measurement.ts
@@ -6,7 +6,7 @@
 //
 // NOT causal attribution or significance — just baseline/current comparison.
 
-import type { MetricValue } from '@/shared/types';
+import type { MetricCard, MetricValue } from '@/shared/types';
 import { metricRefKey } from './impactContract';
 import type { ImpactContract, MetricLink, MetricLinkRole } from './types';
 
@@ -159,4 +159,61 @@ export function evaluateImpact(
   else suggestedResult = 'lost';
 
   return { target, leading, guardrails, expected, met, guardrailStatus, suggestedResult };
+}
+
+/**
+ * Build the series-by-refKey map for a contract's links from the loaded
+ * tracked-metric snapshots + canvas card data. Pure — callers do the I/O.
+ */
+export function buildSeriesByKey(
+  links: MetricLink[],
+  cards: MetricCard[],
+  trackedValues: Record<string, MetricValue[]>
+): Record<string, MetricValue[]> {
+  const map: Record<string, MetricValue[]> = {};
+  for (const l of links) {
+    const key = metricRefKey(l);
+    if (!key) continue;
+    if (l.refSource === 'tracked' && l.trackedMetricId) {
+      map[key] = trackedValues[l.trackedMetricId] ?? [];
+    } else if (l.refSource === 'card' && l.cardId) {
+      map[key] = cards.find((c) => c.id === l.cardId)?.data ?? [];
+    }
+  }
+  return map;
+}
+
+/** Compact measured outcome for chips/badges/trace (CVS-176). */
+export interface MeasuredImpact {
+  deltaText: string | null;
+  pctDelta: number | null;
+  met: MetTarget;
+  guardrailStatus: GuardrailStatus;
+  hasData: boolean;
+}
+
+export function toMeasured(ev: ImpactEvaluation): MeasuredImpact {
+  const t = ev.target;
+  const hasData = !!t?.hasData;
+  let deltaText: string | null = null;
+  if (t && hasData) {
+    const pct = t.pctDelta != null ? `${t.pctDelta > 0 ? '+' : ''}${t.pctDelta.toFixed(1)}%` : null;
+    const abs = t.absDelta != null ? `${t.absDelta > 0 ? '+' : ''}${t.absDelta}` : null;
+    deltaText = pct ?? abs;
+  }
+  return { deltaText, pctDelta: t?.pctDelta ?? null, met: ev.met, guardrailStatus: ev.guardrailStatus, hasData };
+}
+
+/** Evaluate many contracts at once → measured summary keyed by strategy node id. */
+export function measuredByNode(
+  entries: Array<{ contract: ImpactContract; links: MetricLink[] }>,
+  cards: MetricCard[],
+  trackedValues: Record<string, MetricValue[]>
+): Record<string, MeasuredImpact> {
+  const out: Record<string, MeasuredImpact> = {};
+  for (const { contract, links } of entries) {
+    const ev = evaluateImpact(contract, links, buildSeriesByKey(links, cards, trackedValues));
+    if (ev.target) out[contract.strategyNodeId] = toMeasured(ev);
+  }
+  return out;
 }

--- a/src/features/strategy/pages/StrategyPage.tsx
+++ b/src/features/strategy/pages/StrategyPage.tsx
@@ -33,14 +33,17 @@ import { CardCommentSheet } from '@/features/strategy/components/CardCommentShee
 import { StrategyImpactSheet } from '@/features/strategy/components/StrategyImpactSheet';
 import { ImpactTraceDialog } from '@/features/strategy/components/ImpactTraceDialog';
 import { listContractsWithLinksForProject } from '@/shared/lib/supabase/services/strategyImpact';
+import { getMetricValuesByMetricIds } from '@/shared/lib/supabase/services/trackedMetrics';
 import {
   summarizeImpact,
   type ImpactSummary,
 } from '@/features/strategy/impact/impactContract';
+import { measuredByNode } from '@/features/strategy/impact/measurement';
 import type {
   ImpactContract,
   MetricLink,
 } from '@/features/strategy/impact/types';
+import type { MetricValue } from '@/shared/types';
 import { ValueJourneyStrip } from '@/features/strategy/components/ValueJourneyStrip';
 import { TaskPanel } from '@/features/canvas/components/panels/task-panel/TaskPanel';
 import {
@@ -195,6 +198,35 @@ export default function StrategyPage() {
     for (const e of impactEntries) map[e.contract.strategyNodeId] = e;
     return map;
   }, [impactEntries]);
+
+  // Measured deltas (CVS-176): load tracked-metric snapshots referenced by any
+  // contract, then evaluate each bet for a compact measured summary.
+  const [impactTrackedValues, setImpactTrackedValues] = useState<
+    Record<string, MetricValue[]>
+  >({});
+  const impactTrackedIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const { links } of impactEntries) {
+      for (const l of links) if (l.refSource === 'tracked' && l.trackedMetricId) ids.add(l.trackedMetricId);
+    }
+    return Array.from(ids).sort();
+  }, [impactEntries]);
+  const impactTrackedKey = impactTrackedIds.join(',');
+  useEffect(() => {
+    if (!client || impactTrackedIds.length === 0) {
+      setImpactTrackedValues({});
+      return;
+    }
+    getMetricValuesByMetricIds(impactTrackedIds, client)
+      .then(setImpactTrackedValues)
+      .catch(() => setImpactTrackedValues({}));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, impactTrackedKey]);
+
+  const measuredMap = useMemo(
+    () => measuredByNode(impactEntries, cards, impactTrackedValues),
+    [impactEntries, cards, impactTrackedValues]
+  );
 
   // Members carry avatars too — merge so a just-assigned person resolves before
   // the batched user fetch returns.
@@ -489,6 +521,7 @@ export default function StrategyPage() {
           onStatusChange={handleStatusChange}
           onCardClick={setSettingsCardId}
           impactSummaries={impactSummaries}
+          measuredMap={measuredMap}
         />
       ) : viewMode === 'tree' ? (
         <StrategyTree
@@ -507,6 +540,7 @@ export default function StrategyPage() {
           members={members}
           commentCounts={commentCounts}
           impactSummaries={impactSummaries}
+          measuredMap={measuredMap}
           canEdit={canEdit}
           onStatusChange={handleStatusChange}
           onPriorityChange={handlePriorityChange}


### PR DESCRIPTION
Closes **CVS-176** — completes Milestone 4. **Stacked on [#88](https://github.com/nadeemramli/metrimap/pull/88) → #85.**

## What
Propagates the CVS-174 measured outcome to the scannable surfaces.

- **`measurement.ts`**: `buildSeriesByKey()` + `measuredByNode()` + `toMeasured()` → a compact `MeasuredImpact` ({deltaText, met, guardrailStatus, hasData}) per node.
- **Strategy overlay**: `StrategyPage` loads the contracts' tracked-metric snapshots and passes a `measuredMap` to the board tiles + table; **`ImpactChip`** shows the measured delta coloured **met/missed** with a **guardrail-breach ⚠** (falls back to the expected delta when there's no measured data).
- **Dashboard overlay**: `DashboardPage` extends its tracked-value load to contract metrics; the widget impact-badge overlay shows **"actual +7%"** per linked bet, coloured by met.

## Verification
- `type-check` ✅ · lint ✅ · **full vitest 212/212** ✅ — `buildSeriesByKey` + `measuredByNode` unit tests.

Per the issue this targets the Strategy + Dashboard overlays; the trace view remains structure/links (its measured summary already lives in the review panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)