### PR TITLE
feat(cvs-177): Strategy impact demo dataset + end-to-end pipeline test

### DIFF
--- a/src/features/strategy/impact/demoStrategyImpact.test.ts
+++ b/src/features/strategy/impact/demoStrategyImpact.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { buildDemoStrategyImpact } from './demoStrategyImpact';
+import { resolveImpactTrace } from './impactTrace';
+import { buildSeriesByKey, evaluateImpact, measuredByNode } from './measurement';
+import { linkedStrategyForWidget } from './widgetLinks';
+
+// End-to-end proof (CVS-177): over the canonical demo dataset, the pure pipeline
+// engines together yield the straight line Action → target → KPI → dashboard →
+// measured result — and degrade correctly for the failure states.
+
+describe('demo Strategy impact — full pipeline', () => {
+  const demo = buildDemoStrategyImpact();
+  const { contract, links } = demo.entries[0];
+
+  it('resolves the trace: Action → target → KPI, shown on the dashboard widget', () => {
+    const trace = resolveImpactTrace({
+      strategyNodeId: demo.ids.action,
+      links,
+      cards: demo.cards,
+      relationships: demo.relationships,
+      widgets: demo.widgets,
+    });
+    expect(trace.target?.card?.id).toBe(demo.ids.checkoutCvr);
+    expect(trace.kpiPath.map((c) => c.id)).toEqual([demo.ids.checkoutCvr, demo.ids.revenue, demo.ids.kpi]);
+    expect(trace.kpi?.id).toBe(demo.ids.kpi);
+    expect(trace.target?.widgets.map((w) => w.id)).toEqual([demo.ids.widget]);
+    expect(trace.leading.map((l) => l.card?.id)).toEqual([demo.ids.addToCart]);
+    expect(trace.guardrails.map((g) => g.card?.id).sort()).toEqual([demo.ids.aov, demo.ids.refundRate].sort());
+    expect(trace.missing).toEqual({ noTarget: false, targetNotOnCanvas: false, noKpiPath: false, noDashboard: false });
+  });
+
+  it('links the bet to the dashboard widget', () => {
+    const linked = linkedStrategyForWidget(demo.widgets[0], demo.entries, demo.cards);
+    expect(linked.map((l) => l.node?.id)).toEqual([demo.ids.action]);
+    expect(linked[0].roles).toContain('target');
+  });
+
+  it('measures a win: target +7% beats +5%, guardrails pass → won', () => {
+    const ev = evaluateImpact(contract, links, buildSeriesByKey(links, demo.cards, demo.trackedValues));
+    expect(ev.target?.pctDelta).toBeCloseTo(7);
+    expect(ev.met).toBe('met');
+    expect(ev.guardrailStatus).toBe('pass');
+    expect(ev.suggestedResult).toBe('won');
+
+    const measured = measuredByNode(demo.entries, demo.cards, demo.trackedValues);
+    expect(measured[demo.ids.action].deltaText).toBe('+7.0%');
+    expect(measured[demo.ids.action].met).toBe('met');
+  });
+
+  it('groups the work under its pillar in the tree model', () => {
+    // The pillar group contains the action + hypothesis (Strategy Tree buckets by group).
+    expect(demo.groups[0].nodeIds).toContain(demo.ids.action);
+    expect(demo.groups[0].nodeIds).toContain(demo.ids.hypothesis);
+  });
+});
+
+describe('demo Strategy impact — failure & missing states', () => {
+  const demo = buildDemoStrategyImpact();
+  const { contract, links } = demo.entries[0];
+
+  it('no target metric → noTarget + inconclusive', () => {
+    const noTargetLinks = links.filter((l) => l.role !== 'target');
+    const trace = resolveImpactTrace({ strategyNodeId: demo.ids.action, links: noTargetLinks, cards: demo.cards, relationships: demo.relationships, widgets: demo.widgets });
+    expect(trace.missing.noTarget).toBe(true);
+    const ev = evaluateImpact(contract, noTargetLinks, buildSeriesByKey(noTargetLinks, demo.cards, demo.trackedValues));
+    expect(ev.suggestedResult).toBe('inconclusive');
+  });
+
+  it('no KPI path → noKpiPath when the metric is not wired upward', () => {
+    const noRollup = demo.relationships.filter((r) => !(r.sourceId === demo.ids.revenue && r.targetId === demo.ids.kpi) && !(r.sourceId === demo.ids.checkoutCvr && r.targetId === demo.ids.revenue));
+    const trace = resolveImpactTrace({ strategyNodeId: demo.ids.action, links, cards: demo.cards, relationships: noRollup, widgets: demo.widgets });
+    expect(trace.missing.noKpiPath).toBe(true);
+  });
+
+  it('no dashboard widget → noDashboard', () => {
+    const trace = resolveImpactTrace({ strategyNodeId: demo.ids.action, links, cards: demo.cards, relationships: demo.relationships, widgets: [] });
+    expect(trace.missing.noDashboard).toBe(true);
+  });
+
+  it('guardrail breach blocks the win (inconclusive)', () => {
+    // AOV jumps +20% in the window → guardrail fail.
+    const breached = {
+      ...demo.trackedValues,
+      [demo.ids.trackedCheckoutCvr]: demo.trackedValues[demo.ids.trackedCheckoutCvr],
+      tm_aov: [
+        { period: '2026-05', value: 80, change_percent: 0, trend: 'neutral' as const },
+        { period: '2026-07', value: 96, change_percent: 20, trend: 'up' as const },
+      ],
+    };
+    const ev = evaluateImpact(contract, links, buildSeriesByKey(links, demo.cards, breached));
+    expect(ev.met).toBe('met'); // target still hit
+    expect(ev.guardrailStatus).toBe('fail');
+    expect(ev.suggestedResult).toBe('inconclusive'); // blocked
+  });
+
+  it('stale / no data in the window → unknown, not zero', () => {
+    const stale = { ...demo.trackedValues, [demo.ids.trackedCheckoutCvr]: [{ period: '2026-05', value: 3.0, change_percent: 0, trend: 'neutral' as const }] };
+    const ev = evaluateImpact(contract, links, buildSeriesByKey(links, demo.cards, stale));
+    expect(ev.target?.hasData).toBe(false);
+    expect(ev.met).toBe('unknown');
+    expect(ev.suggestedResult).toBe('inconclusive');
+  });
+});

--- a/src/features/strategy/impact/demoStrategyImpact.ts
+++ b/src/features/strategy/impact/demoStrategyImpact.ts
@@ -1,0 +1,171 @@
+// Strategy impact demo dataset (CVS-177). A canonical "Grow Revenue per Visitor"
+// scenario that exercises the whole pipeline in one coherent tree:
+//
+//   KPI (Revenue per Visitor)
+//     └ Revenue
+//         └ Checkout CVR  ← target, on a dashboard widget
+//   Pillar "Conversion"
+//     Hypothesis "Fewer steps lifts conversion"  --supports-->  Action "Ship one-page checkout"
+//        Action bet: target Checkout CVR (+5%), leading Add-to-cart rate,
+//                    guardrails AOV + Refund rate, window 2026-05 → 2026-07.
+//
+// Pure data — used by the end-to-end test (demoStrategyImpact.test.ts) and as the
+// documented scenario the manual QA suite builds by hand. No I/O.
+
+import type { GroupNode, MetricCard, MetricValue, Relationship } from '@/shared/types';
+import type { ImpactContract, MetricLink } from './types';
+import type { TraceWidget } from './impactTrace';
+
+const mv = (period: string, value: number): MetricValue => ({
+  period,
+  value,
+  change_percent: 0,
+  trend: 'neutral',
+});
+
+const card = (id: string, title: string, category: MetricCard['category'], over: Partial<MetricCard> = {}): MetricCard => ({
+  id,
+  title,
+  description: '',
+  category,
+  tags: [],
+  causalFactors: [],
+  dimensions: [],
+  position: { x: 0, y: 0 },
+  assignees: [],
+  createdAt: '',
+  updatedAt: '',
+  ...over,
+});
+
+const edge = (sourceId: string, targetId: string): Relationship => ({
+  id: `${sourceId}->${targetId}`,
+  sourceId,
+  targetId,
+  type: 'Deterministic',
+  confidence: 'High',
+  evidence: [],
+  createdAt: '',
+  updatedAt: '',
+});
+
+export interface DemoStrategyImpact {
+  cards: MetricCard[];
+  relationships: Relationship[];
+  groups: GroupNode[];
+  /** tracked_metric_id → series (as the shared metric_values store would return). */
+  trackedValues: Record<string, MetricValue[]>;
+  /** Contracts + links as listContractsWithLinksForProject would return. */
+  entries: Array<{ contract: ImpactContract; links: MetricLink[] }>;
+  widgets: TraceWidget[];
+  ids: {
+    kpi: string;
+    revenue: string;
+    checkoutCvr: string;
+    addToCart: string;
+    aov: string;
+    refundRate: string;
+    action: string;
+    hypothesis: string;
+    trackedCheckoutCvr: string;
+    widget: string;
+  };
+}
+
+export function buildDemoStrategyImpact(): DemoStrategyImpact {
+  const trackedCheckoutCvr = 'tm_checkout_cvr';
+  const trackedAov = 'tm_aov';
+
+  const cards: MetricCard[] = [
+    card('kpi', 'Revenue per Visitor', 'Core/Value'),
+    card('revenue', 'Revenue', 'Data/Metric'),
+    card('checkout_cvr', 'Checkout CVR', 'Data/Metric', { trackedMetricId: trackedCheckoutCvr }),
+    card('add_to_cart', 'Add-to-cart rate', 'Data/Metric', { data: [mv('2026-05', 22), mv('2026-07', 24)] }),
+    card('aov', 'AOV', 'Data/Metric', { trackedMetricId: trackedAov }),
+    card('refund_rate', 'Refund rate', 'Data/Metric', { data: [mv('2026-05', 2.0), mv('2026-07', 2.0)] }),
+    card('act_checkout', 'Ship one-page checkout', 'Work/Action', {
+      status: 'in_progress',
+      owner: 'demo-user',
+    }),
+    card('hyp_steps', 'Fewer steps lifts conversion', 'Ideas/Hypothesis'),
+  ];
+
+  // Metric tree: checkout_cvr → revenue → KPI (the roll-up path).
+  const relationships: Relationship[] = [
+    edge('checkout_cvr', 'revenue'),
+    edge('revenue', 'kpi'),
+    // hypothesis supports the action (work-card link, not part of the metric tree)
+    edge('hyp_steps', 'act_checkout'),
+  ];
+
+  const groups: GroupNode[] = [
+    {
+      id: 'pillar_conversion',
+      name: 'Conversion',
+      color: '#6366f1',
+      // pillar contains the strategy work cards
+      nodeIds: ['act_checkout', 'hyp_steps'],
+    } as GroupNode,
+  ];
+
+  const trackedValues: Record<string, MetricValue[]> = {
+    // +7% over the window (beats the +5% expectation)
+    [trackedCheckoutCvr]: [mv('2026-05', 3.0), mv('2026-07', 3.21)],
+    // +1.25% — within the 5% guardrail tolerance (pass)
+    [trackedAov]: [mv('2026-05', 80), mv('2026-07', 81)],
+  };
+
+  const contract: ImpactContract = {
+    id: 'contract_checkout',
+    workspaceId: 'demo-workspace',
+    projectId: 'demo-canvas',
+    strategyNodeId: 'act_checkout',
+    expectedDirection: 'increase',
+    expectedDeltaValue: 5,
+    expectedDeltaUnit: 'percent',
+    baselineStart: '2026-05',
+    baselineEnd: '2026-05',
+    measureStart: '2026-07',
+    measureEnd: '2026-07',
+    baselineIsManual: false,
+    confidence: 'medium',
+    impactStatus: 'measuring',
+    ownerLabel: 'Growth',
+    resultNote: null,
+    createdBy: 'demo-user',
+    createdAt: '',
+    updatedAt: '',
+  };
+
+  const links: MetricLink[] = [
+    { id: 'l_target', contractId: contract.id, role: 'target', refSource: 'tracked', trackedMetricId: trackedCheckoutCvr, cardId: null },
+    { id: 'l_leading', contractId: contract.id, role: 'leading', refSource: 'card', trackedMetricId: null, cardId: 'add_to_cart' },
+    { id: 'l_guard_aov', contractId: contract.id, role: 'guardrail', refSource: 'tracked', trackedMetricId: trackedAov, cardId: null },
+    { id: 'l_guard_refund', contractId: contract.id, role: 'guardrail', refSource: 'card', trackedMetricId: null, cardId: 'refund_rate' },
+  ];
+
+  const widgets: TraceWidget[] = [
+    { id: 'w_checkout_cvr', title: 'Checkout CVR', config: { source: 'tracked', trackedMetricIds: [trackedCheckoutCvr] } },
+  ];
+
+  return {
+    cards,
+    relationships,
+    groups,
+    trackedValues,
+    entries: [{ contract, links }],
+    widgets,
+    ids: {
+      kpi: 'kpi',
+      revenue: 'revenue',
+      checkoutCvr: 'checkout_cvr',
+      addToCart: 'add_to_cart',
+      aov: 'aov',
+      refundRate: 'refund_rate',
+      action: 'act_checkout',
+      hypothesis: 'hyp_steps',
+      trackedCheckoutCvr,
+      widget: 'w_checkout_cvr',
+    },
+  };
+}


### PR DESCRIPTION
Closes **CVS-177** — the final issue in the Strategy impact lane (Milestone 5: QA & demo). Branches off `main`.

## What
A canonical **"Grow Revenue per Visitor"** demo scenario that exercises the whole pipeline in one coherent tree, plus an **end-to-end test** across the pure engines.

- **`demoStrategyImpact.ts`** — `buildDemoStrategyImpact()`: KPI (Revenue per Visitor) ← Revenue ← Checkout CVR (target, on a dashboard widget); pillar **Conversion** with a Hypothesis *supporting* an Action; a bet targeting Checkout CVR (**+5%**) with a leading metric, two guardrails, tracked-metric series (**+7% win**, AOV guardrail pass), and a bound widget.
- **`demoStrategyImpact.test.ts`** — proves `resolveImpactTrace` + `linkedStrategyForWidget` + `evaluateImpact`/`measuredByNode` together yield **Action → target → KPI → dashboard → measured "won"**, and degrade correctly for the **failure states**: no target, no KPI path, no dashboard, **guardrail breach → inconclusive**, stale/no-window-data → unknown.

## Verification
- `type-check` ✅ · lint ✅ · **full vitest 241/241** ✅ — 9 end-to-end assertions (happy path + 5 failure states).

Documented as a code fixture + the Linear manual-QA suite (per the docs policy — no repo feature narrative). The manual-test child issue carries the full click-through QA incl. regression.

**With this, the lane is code-complete** (CVS-166 spike + 167–177 all implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)