### PR TITLE
feat(visibility): redaction UX — badge, value masking, admin matrix (CVS-122)

### DIFF
--- a/src/features/canvas/components/nodes/metric-node/MetricCard.tsx
+++ b/src/features/canvas/components/nodes/metric-node/MetricCard.tsx
@@ -41,6 +41,8 @@ import {
   getMetricCardTags,
   removeTagsFromMetricCard,
 } from '@/shared/lib/supabase/services/tags';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import { useVisibilityStore } from '@/shared/stores/useVisibilityStore';
 import type {
   CardCategory,
   MetricCard as MetricCardType,
@@ -58,6 +60,7 @@ import {
   GripVertical,
   Layers,
   Link,
+  Lock,
   MessageSquare,
   Minimize2,
   Minus,
@@ -265,23 +268,37 @@ export default function MetricCard({ data, selected }: NodeProps) {
     data as unknown as MetricCardNodeData;
   const [isExpanded] = useState(true);
 
+  // Node-level visibility (CVS-122): show a lock + mask the value on nodes
+  // restricted for this viewer. Client pairing for hide_value; hide_node rows
+  // are already filtered by RLS (CVS-121), so this never leaks vs the wall.
+  const visClient = useClerkSupabase();
+  const ensureVisibility = useVisibilityStore((s) => s.ensureLoaded);
+  const restrictedSet = useVisibilityStore(
+    (s) => s.restrictedByProject[card.projectId]
+  );
+  const isRestricted = !!restrictedSet?.has(card.id);
+  useEffect(() => {
+    if (visClient && card.projectId) ensureVisibility(card.projectId, visClient);
+  }, [visClient, card.projectId, ensureVisibility]);
+
   // Last-edited-by attribution (server-stamped updated_by).
   const editedByName = useUserName(card.updatedBy);
 
   // Alert state (monitored / breached) — evaluated against the LIVE latest
   // value, independent of any time-travel view.
   const alertRules = useAlertRulesStore((s) => s.rulesByCard[card.id]);
-  const latestValue = Array.isArray(card.data)
-    ? card.data[card.data.length - 1]
-    : undefined;
+  const latestValue =
+    isRestricted || !Array.isArray(card.data)
+      ? undefined
+      : card.data[card.data.length - 1];
   const alertState = alertStateFor(alertRules, latestValue);
 
   // Time-travel: what the card DISPLAYS reflects the canvas "as of" period.
   const asOfPeriod = useTimeTravelStore((s) => s.asOfPeriod);
   const comparePeriod = useTimeTravelStore((s) => s.comparePeriod);
-  const viewedData = seriesAsOf(card.data, asOfPeriod);
+  const viewedData = isRestricted ? [] : seriesAsOf(card.data, asOfPeriod);
   const timeTravelDelta =
-    card.category === 'Data/Metric' && comparePeriod
+    !isRestricted && card.category === 'Data/Metric' && comparePeriod
       ? deltaBetween(card.data, asOfPeriod, comparePeriod)
       : null;
 
@@ -884,7 +901,13 @@ export default function MetricCard({ data, selected }: NodeProps) {
                 }}
               />
             ) : (
-              <h3 className="nodrag font-semibold text-card-foreground text-sm leading-tight flex-1">
+              <h3 className="nodrag font-semibold text-card-foreground text-sm leading-tight flex-1 flex items-center gap-1">
+                {isRestricted && (
+                  <Lock
+                    className="h-3 w-3 shrink-0 text-amber-600"
+                    aria-label="Restricted"
+                  />
+                )}
                 {card.title}
               </h3>
             )}
@@ -976,7 +999,13 @@ export default function MetricCard({ data, selected }: NodeProps) {
           )}
           {viewedData.length === 0 ? (
             <div className="nodrag text-xs text-muted-foreground/70">
-              No data as of {asOfPeriod}
+              {isRestricted ? (
+                <span className="inline-flex items-center gap-1 text-amber-600">
+                  <Lock className="h-3 w-3" /> Restricted
+                </span>
+              ) : (
+                <>No data as of {asOfPeriod}</>
+              )}
             </div>
           ) : (
           <div className="nodrag space-y-2">

--- a/src/features/canvas/components/panels/metric-panel/CardSettingsSheet.tsx
+++ b/src/features/canvas/components/panels/metric-panel/CardSettingsSheet.tsx
@@ -5,6 +5,7 @@ import { DataEventsTab } from '@/features/canvas/components/panels/relationship-
 import { ResultsTab } from '@/features/canvas/components/panels/relationship-panel/tabs/results-tab';
 import { SettingsTab } from '@/features/canvas/components/panels/relationship-panel/tabs/settings-tab';
 import { WorkflowSection } from '@/features/canvas/components/panels/metric-panel/WorkflowSection';
+import { NodeVisibilityControl } from '@/features/settings/components/NodeVisibilityControl';
 import EvidenceDialog from '@/features/evidence/components/EvidenceDialog';
 import { Button } from '@/shared/components/ui/button';
 import { Input } from '@/shared/components/ui/input';
@@ -1208,6 +1209,7 @@ function CardSettingsSheetComponent({
 
               {/* Settings Tab */}
               <TabsContent value="settings" className="space-y-6 pt-2">
+                {cardId && <NodeVisibilityControl cardId={cardId} />}
                 {card && (
                   <WorkflowSection
                     card={card}

--- a/src/features/settings/components/AccessMatrixPanel.tsx
+++ b/src/features/settings/components/AccessMatrixPanel.tsx
@@ -1,0 +1,131 @@
+import { Badge } from '@/shared/components/ui/badge';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import {
+  getWorkspaceAccessTags,
+  type WorkspaceAccessTag,
+} from '@/shared/lib/supabase/services/accessTags';
+import {
+  listGroups,
+  type WorkspaceGroupWithCount,
+} from '@/shared/lib/supabase/services/groups';
+import { Check, Loader2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+/**
+ * Admin access matrix (CVS-122): access tags (rows) × groups (columns), a check
+ * where the group is in the tag's audience — "who can see what" at a glance,
+ * and a group column doubles as the "view as <group>" preview (read a column to
+ * see everything that group is admitted to). Read-only; edit audiences in the
+ * project tag manager (Assets → Manage Project Tags).
+ */
+export function AccessMatrixPanel() {
+  const client = useClerkSupabase();
+  const [tags, setTags] = useState<WorkspaceAccessTag[]>([]);
+  const [groups, setGroups] = useState<WorkspaceGroupWithCount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [viewAs, setViewAs] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!client) return;
+    setLoading(true);
+    Promise.all([getWorkspaceAccessTags(client), listGroups(client)])
+      .then(([t, g]) => {
+        setTags(t);
+        setGroups(g);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [client]);
+
+  if (loading) {
+    return <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />;
+  }
+
+  if (tags.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground/70">
+        No access tags yet. Mark a tag as an access tag in a project (Assets →
+        Manage Project Tags) to control node visibility.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <span className="text-muted-foreground">View as group:</span>
+        <button
+          onClick={() => setViewAs(null)}
+          className={`rounded-full border px-2 py-0.5 ${viewAs === null ? 'border-primary bg-primary/10' : 'border-border'}`}
+        >
+          All
+        </button>
+        {groups.map((g) => (
+          <button
+            key={g.id}
+            onClick={() => setViewAs(g.id)}
+            className={`rounded-full border px-2 py-0.5 ${viewAs === g.id ? 'border-primary bg-primary/10' : 'border-border'}`}
+          >
+            {g.name}
+          </button>
+        ))}
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="border-b border-border p-2 text-left font-medium">
+                Access tag
+              </th>
+              {groups.map((g) => (
+                <th
+                  key={g.id}
+                  className={`border-b border-border p-2 text-center font-medium ${viewAs === g.id ? 'bg-primary/5' : ''}`}
+                >
+                  {g.name}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {tags.map((t) => {
+              const audience = new Set(t.audienceGroupIds);
+              return (
+                <tr key={t.id}>
+                  <td className="border-b border-border/60 p-2">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary">{t.name}</Badge>
+                      <span className="text-xs text-muted-foreground">
+                        {t.redactionMode === 'hide_node' ? 'hide node' : 'hide value'}
+                      </span>
+                    </div>
+                  </td>
+                  {groups.map((g) => (
+                    <td
+                      key={g.id}
+                      className={`border-b border-border/60 p-2 text-center ${viewAs === g.id ? 'bg-primary/5' : ''}`}
+                    >
+                      {audience.has(g.id) ? (
+                        <Check className="mx-auto h-4 w-4 text-emerald-600" />
+                      ) : (
+                        <span className="text-muted-foreground/40">·</span>
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      {viewAs && (
+        <p className="text-xs text-muted-foreground">
+          Showing what <strong>{groups.find((g) => g.id === viewAs)?.name}</strong>{' '}
+          can see — a checked row means members of that group are in the tag's
+          audience (nodes with that tag are visible to them).
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/settings/components/NodeVisibilityControl.tsx
+++ b/src/features/settings/components/NodeVisibilityControl.tsx
@@ -1,0 +1,138 @@
+import { Badge } from '@/shared/components/ui/badge';
+import { Checkbox } from '@/shared/components/ui/checkbox';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import {
+  getCardAccessInfo,
+  getNodeAccessGrants,
+  setNodeAccessGrants,
+  type CardAccessTag,
+} from '@/shared/lib/supabase/services/accessTags';
+import {
+  listGroups,
+  type WorkspaceGroupWithCount,
+} from '@/shared/lib/supabase/services/groups';
+import { Eye, Loader2, Lock } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Per-node "Who can see this" (CVS-122): shows the access tags applied to the
+ * node + their audiences, and lets an admin grant extra groups directly
+ * (node_access_grants allowlist). Visibility is enforced by RLS (CVS-121); this
+ * is the control surface. No access tag ⇒ visible to everyone with canvas access.
+ */
+export function NodeVisibilityControl({ cardId }: { cardId: string }) {
+  const client = useClerkSupabase();
+  const [accessTags, setAccessTags] = useState<CardAccessTag[]>([]);
+  const [grants, setGrants] = useState<Set<string>>(new Set());
+  const [groups, setGroups] = useState<WorkspaceGroupWithCount[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!client || !cardId) return;
+    setLoading(true);
+    Promise.all([
+      getCardAccessInfo(cardId, client),
+      getNodeAccessGrants(cardId, client),
+      listGroups(client),
+    ])
+      .then(([tags, grantIds, gs]) => {
+        setAccessTags(tags);
+        setGrants(new Set(grantIds));
+        setGroups(gs);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [client, cardId]);
+
+  const groupName = (id: string) => groups.find((g) => g.id === id)?.name ?? '—';
+
+  const toggleGrant = async (groupId: string, checked: boolean) => {
+    if (!client) return;
+    const next = new Set(grants);
+    if (checked) next.add(groupId);
+    else next.delete(groupId);
+    setGrants(next);
+    try {
+      await setNodeAccessGrants(cardId, [...next], client);
+    } catch {
+      setGrants(grants);
+      toast.error('Failed to update node access');
+    }
+  };
+
+  const restricted = accessTags.length > 0;
+
+  if (loading) {
+    return (
+      <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+    );
+  }
+
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <div className="mb-3 flex items-center gap-2">
+        {restricted ? (
+          <Lock className="h-4 w-4 text-amber-600" />
+        ) : (
+          <Eye className="h-4 w-4 text-primary" />
+        )}
+        <h3 className="text-sm font-semibold">Who can see this</h3>
+      </div>
+
+      {!restricted ? (
+        <p className="text-sm text-muted-foreground">
+          No access tag — visible to everyone with canvas access. Mark a tag as an
+          access tag (Assets → Manage Project Tags) to restrict this node.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          <div className="space-y-2">
+            {accessTags.map((t) => (
+              <div key={t.tagId} className="rounded-md border border-border/60 p-2">
+                <div className="flex items-center gap-2 text-sm">
+                  <Badge variant="secondary">{t.name}</Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {t.redactionMode === 'hide_node' ? 'Hide node' : 'Hide value'}
+                  </span>
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  Audience:{' '}
+                  {t.audienceGroupIds.length === 0
+                    ? 'nobody yet — only owners/admins can see this'
+                    : t.audienceGroupIds.map(groupName).join(', ')}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div>
+            <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+              Also allow specific groups (per-node override)
+            </p>
+            {groups.length === 0 ? (
+              <p className="text-xs text-muted-foreground/70">
+                No groups yet — create them in Workspace Settings → Groups.
+              </p>
+            ) : (
+              <div className="space-y-1.5">
+                {groups.map((g) => (
+                  <label
+                    key={g.id}
+                    className="flex cursor-pointer items-center gap-2 text-sm"
+                  >
+                    <Checkbox
+                      checked={grants.has(g.id)}
+                      onCheckedChange={(v) => toggleGrant(g.id, v === true)}
+                    />
+                    <span>{g.name}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/features/settings/pages/WorkspaceSettingsPage.tsx
+++ b/src/features/settings/pages/WorkspaceSettingsPage.tsx
@@ -2,7 +2,8 @@ import { OrganizationProfile } from '@clerk/react-router';
 import { Button } from '@/shared/components/ui/button';
 import { ConnectionsPanel } from '@/features/data/components/ConnectionsPanel';
 import { GroupsPanel } from '@/features/settings/components/GroupsPanel';
-import { ArrowLeft, Database, ShieldCheck, User, Users } from 'lucide-react';
+import { AccessMatrixPanel } from '@/features/settings/components/AccessMatrixPanel';
+import { ArrowLeft, Database, Grid3x3, ShieldCheck, User, Users } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 function Section({
@@ -87,6 +88,15 @@ export default function WorkspaceSettingsPage() {
           description="Group members into departments (Finance, Marketing, Exec…). Groups are the audiences that access tags and node visibility are granted to."
         >
           <GroupsPanel />
+        </Section>
+
+        {/* Access matrix — audit access tags × groups (who can see what) */}
+        <Section
+          icon={Grid3x3}
+          title="Access matrix"
+          description="Audit who can see what: access tags (rows) × groups (columns). Use “view as group” to preview a department's access."
+        >
+          <AccessMatrixPanel />
         </Section>
       </div>
     </div>

--- a/src/shared/lib/supabase/services/accessTags.ts
+++ b/src/shared/lib/supabase/services/accessTags.ts
@@ -116,3 +116,115 @@ export async function nodeVisibleToMe(
   if (error) throw error;
   return data ?? false;
 }
+
+/**
+ * Card ids in a project restricted for the current viewer (CVS-122) — one call
+ * powers the "Restricted" badge + value masking across a canvas.
+ */
+export async function getMyRestrictedCards(
+  projectId: string,
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<string[]> {
+  const client = db(authenticatedClient);
+  const { data, error } = await client.rpc('my_restricted_cards', {
+    pid: projectId,
+  });
+  if (error) throw error;
+  return (data as string[] | null) ?? [];
+}
+
+/** Admin-only "view as <group>" preview: cards restricted for those groups. */
+export async function getRestrictedCardsForGroups(
+  projectId: string,
+  groupIds: string[],
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<string[]> {
+  const client = db(authenticatedClient);
+  const { data, error } = await client.rpc('cards_restricted_for_groups', {
+    pid: projectId,
+    group_ids: groupIds,
+  });
+  if (error) throw error;
+  return (data as string[] | null) ?? [];
+}
+
+export type WorkspaceAccessTag = {
+  id: string;
+  name: string;
+  redactionMode: RedactionMode;
+  projectId: string | null;
+  audienceGroupIds: string[];
+};
+
+/** Every access tag visible to the user (across their projects) + audiences —
+ *  powers the admin access matrix (access tags × groups). */
+export async function getWorkspaceAccessTags(
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<WorkspaceAccessTag[]> {
+  const client = db(authenticatedClient);
+  const { data: tags, error } = await client
+    .from('tags')
+    .select('id, name, redaction_mode, project_id')
+    .eq('is_access', true)
+    .order('name');
+  if (error) throw error;
+  const ids = (tags ?? []).map((t) => t.id);
+  const byTag = new Map<string, string[]>();
+  if (ids.length) {
+    const { data: auds, error: aErr } = await client
+      .from('tag_audiences')
+      .select('tag_id, group_id')
+      .in('tag_id', ids);
+    if (aErr) throw aErr;
+    for (const a of auds ?? []) {
+      const arr = byTag.get(a.tag_id) ?? [];
+      arr.push(a.group_id);
+      byTag.set(a.tag_id, arr);
+    }
+  }
+  return (tags ?? []).map((t) => ({
+    id: t.id,
+    name: t.name,
+    redactionMode: t.redaction_mode === 'hide_node' ? 'hide_node' : 'hide_value',
+    projectId: t.project_id,
+    audienceGroupIds: byTag.get(t.id) ?? [],
+  }));
+}
+
+export type CardAccessTag = {
+  tagId: string;
+  name: string;
+  redactionMode: RedactionMode;
+  audienceGroupIds: string[];
+};
+
+/** The access tags applied to a card + their audiences (for "Who can see this"). */
+export async function getCardAccessInfo(
+  metricCardId: string,
+  authenticatedClient?: SupabaseClient<Database>
+): Promise<CardAccessTag[]> {
+  const client = db(authenticatedClient);
+  const { data, error } = await client
+    .from('metric_card_tags')
+    .select('tag_id, tags!inner(id, name, is_access, redaction_mode)')
+    .eq('metric_card_id', metricCardId);
+  if (error) throw error;
+  const accessTags = (data ?? []).filter(
+    (r) => (r.tags as unknown as { is_access: boolean }).is_access
+  );
+  const result: CardAccessTag[] = [];
+  for (const r of accessTags) {
+    const t = r.tags as unknown as {
+      id: string;
+      name: string;
+      redaction_mode: string;
+    };
+    result.push({
+      tagId: t.id,
+      name: t.name,
+      redactionMode: t.redaction_mode === 'hide_node' ? 'hide_node' : 'hide_value',
+      audienceGroupIds: await getTagAudience(t.id, client),
+    });
+  }
+  return result;
+}

--- a/src/shared/lib/supabase/types.ts
+++ b/src/shared/lib/supabase/types.ts
@@ -1652,6 +1652,14 @@ export type Database = {
         Args: { card_id: string }
         Returns: boolean
       }
+      my_restricted_cards: {
+        Args: { pid: string }
+        Returns: string[]
+      }
+      cards_restricted_for_groups: {
+        Args: { pid: string; group_ids: string[] }
+        Returns: string[]
+      }
     }
     Enums: {
       [_ in never]: never

--- a/src/shared/stores/useVisibilityStore.ts
+++ b/src/shared/stores/useVisibilityStore.ts
@@ -1,0 +1,63 @@
+import type { Database } from '@/shared/lib/supabase/types';
+import { getMyRestrictedCards } from '@/shared/lib/supabase/services/accessTags';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { create } from 'zustand';
+
+/**
+ * Node-level visibility for the current viewer (CVS-122). One `my_restricted_cards`
+ * call per project yields the set of cards restricted for this viewer, which the
+ * node cards read to show a "Restricted" badge + mask the value (the client
+ * pairing for hide_value; hide_node rows are already RLS-filtered). Loaded lazily
+ * by the first node that mounts — no CanvasPage wiring needed.
+ */
+interface VisibilityState {
+  restrictedByProject: Record<string, Set<string>>;
+  loading: Record<string, boolean>;
+  ensureLoaded: (
+    projectId: string,
+    client: SupabaseClient<Database>
+  ) => Promise<void>;
+  reload: (
+    projectId: string,
+    client: SupabaseClient<Database>
+  ) => Promise<void>;
+  isRestricted: (projectId: string, cardId: string) => boolean;
+}
+
+export const useVisibilityStore = create<VisibilityState>((set, get) => ({
+  restrictedByProject: {},
+  loading: {},
+
+  ensureLoaded: async (projectId, client) => {
+    const { restrictedByProject, loading } = get();
+    if (restrictedByProject[projectId] || loading[projectId]) return;
+    await get().reload(projectId, client);
+  },
+
+  reload: async (projectId, client) => {
+    set((s) => ({ loading: { ...s.loading, [projectId]: true } }));
+    try {
+      const ids = await getMyRestrictedCards(projectId, client);
+      set((s) => ({
+        restrictedByProject: {
+          ...s.restrictedByProject,
+          [projectId]: new Set(ids),
+        },
+      }));
+    } catch {
+      // Fail open on the CLIENT only (RLS is the real boundary): show nothing
+      // as restricted rather than blanking a whole canvas on a transient error.
+      set((s) => ({
+        restrictedByProject: {
+          ...s.restrictedByProject,
+          [projectId]: s.restrictedByProject[projectId] ?? new Set(),
+        },
+      }));
+    } finally {
+      set((s) => ({ loading: { ...s.loading, [projectId]: false } }));
+    }
+  },
+
+  isRestricted: (projectId, cardId) =>
+    !!get().restrictedByProject[projectId]?.has(cardId),
+}));

--- a/supabase/migrations/20260713120000_visibility_client.sql
+++ b/supabase/migrations/20260713120000_visibility_client.sql
@@ -1,0 +1,85 @@
+-- =====================================================================
+-- REDACTION UX SUPPORT (CVS-122) — batch resolvers for the client so it can
+-- mask hide_value nodes and preview "view as <group>" in one round-trip.
+-- (hide_node nodes are already filtered by RLS in CVS-121; these power the
+-- client-side "Restricted" badge + value masking that pairs with it.)
+-- =====================================================================
+BEGIN;
+
+-- Hardening: is_visibility_admin (CVS-121) returned NULL when the Clerk org role
+-- claim was absent (NULL = ANY(...) is NULL), which propagates through
+-- NOT is_visibility_admin and can fail OPEN for hide_value masking. COALESCE the
+-- org-role test (and the whole result) to false so it is strictly boolean.
+CREATE OR REPLACE FUNCTION public.is_visibility_admin(pid uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT COALESCE((public.requesting_user_id() IS NOT NULL) AND (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = pid AND p.created_by = public.requesting_user_id())
+    OR EXISTS (SELECT 1 FROM public.project_collaborators pc
+      WHERE pc.project_id = pid AND pc.user_id = public.requesting_user_id()
+        AND pc.role = ANY (ARRAY['owner','admin']))
+    OR COALESCE(public.requesting_org_role() = ANY (ARRAY['admin','org:admin']), false)
+  ), false);
+$$;
+GRANT EXECUTE ON FUNCTION public.is_visibility_admin(uuid) TO authenticated, anon;
+
+-- Card ids in a project that are RESTRICTED for the current viewer: they carry
+-- an access tag whose audience the viewer isn't in (and no allowlist grant, and
+-- the viewer isn't an owner/admin). Includes both redaction modes; in practice
+-- only hide_value ids reach the client (hide_node rows are RLS-filtered).
+CREATE OR REPLACE FUNCTION public.my_restricted_cards(pid uuid)
+RETURNS SETOF uuid
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT mc.id FROM public.metric_cards mc
+  WHERE mc.project_id = pid
+    AND NOT public.is_visibility_admin(pid)
+    AND EXISTS (
+      SELECT 1 FROM public.metric_card_tags mct
+      JOIN public.tags t ON t.id = mct.tag_id
+      WHERE mct.metric_card_id = mc.id AND t.is_access
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.metric_card_tags mct
+      JOIN public.tags t ON t.id = mct.tag_id
+      JOIN public.tag_audiences ta ON ta.tag_id = t.id
+      WHERE mct.metric_card_id = mc.id AND t.is_access
+        AND ta.group_id IN (SELECT public.my_groups())
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.node_access_grants g
+      WHERE g.metric_card_id = mc.id AND g.group_id IN (SELECT public.my_groups())
+    );
+$$;
+GRANT EXECUTE ON FUNCTION public.my_restricted_cards(uuid) TO authenticated, anon;
+
+-- Admin-only "view as <group>" preview: which cards would be restricted for a
+-- viewer whose groups are exactly group_ids. Returns empty for non-admins
+-- (fail closed) so it can't be used by regular members to probe audiences.
+CREATE OR REPLACE FUNCTION public.cards_restricted_for_groups(pid uuid, group_ids uuid[])
+RETURNS SETOF uuid
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT mc.id FROM public.metric_cards mc
+  WHERE mc.project_id = pid
+    AND public.is_visibility_admin(pid)
+    AND EXISTS (
+      SELECT 1 FROM public.metric_card_tags mct
+      JOIN public.tags t ON t.id = mct.tag_id
+      WHERE mct.metric_card_id = mc.id AND t.is_access
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.metric_card_tags mct
+      JOIN public.tags t ON t.id = mct.tag_id
+      JOIN public.tag_audiences ta ON ta.tag_id = t.id
+      WHERE mct.metric_card_id = mc.id AND t.is_access
+        AND ta.group_id = ANY (group_ids)
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.node_access_grants g
+      WHERE g.metric_card_id = mc.id AND g.group_id = ANY (group_ids)
+    );
+$$;
+GRANT EXECUTE ON FUNCTION public.cards_restricted_for_groups(uuid, uuid[]) TO authenticated, anon;
+
+COMMIT;


### PR DESCRIPTION
The **visible layer** for Access & Visibility — pairs with the RLS wall (CVS-121).

## What
- **Migration `20260713120000_visibility_client.sql`**
  - `my_restricted_cards(pid)` — one call returns the cards restricted for the current viewer (masks a whole canvas efficiently).
  - `cards_restricted_for_groups(pid, group_ids[])` — admin-only "view as group" preview.
  - **Hardens `is_visibility_admin`**: it returned `NULL` when the Clerk org-role claim was absent (`NULL = ANY(...)`), which could fail *open* for `hide_value` masking. Now `COALESCE`'d to boolean — this also hardens CVS-121's `node_hidden_from_me` (which composes it).
- **`useVisibilityStore`** — lazy per-project restricted-set, loaded by the first node that mounts (no CanvasPage wiring, so no conflict with other lanes).
- **`MetricCard`** — lock badge + value masking for restricted nodes (value, series, delta, and alert input all blanked so nothing leaks; file is `@ts-nocheck`).
- **`NodeVisibilityControl`** — per-node **"Who can see this"** in card Settings: applied access tags + audiences, plus a per-node allowlist (`node_access_grants`).
- **`AccessMatrixPanel`** — admin **access matrix** (tags × groups) + "view as group" column highlight; in Workspace Settings.
- Service + types: `getMyRestrictedCards`, `getRestrictedCardsForGroups`, `getCardAccessInfo`, `getWorkspaceAccessTags`.

## Acceptance criteria (CVS-122)
- [x] Set/see a node's audience from the node UI; lock badge on restricted nodes
- [x] Unauthorized viewers see masked value (`hide_value`) or no node (`hide_node`, RLS) — matches RLS truth
- [x] Admin access matrix; "view as group" preview
- [x] UX matches RLS truth (masking uses the same predicates as the wall; hide_node is RLS-enforced, so client masking can't leak vs the wall)

## Verified on live DB (rolled back)
`hide_value` card → marketer restricted (masked), finance (audience) not, owner not; `is_visibility_admin=false` for a member with no role claim (the coalesce fix).

## Notes
- Migrations **applied to prod**. `type-check` + full `lint` + `vitest` pass via Husky.
- Follow-up (not blocking): an on-canvas "view as group" toggle that live-masks the whole canvas (this PR ships the audit-matrix preview + real-viewer masking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)