### PR TITLE
refactor(canvas): consolidate node sources behind one selector (CVS-230, ADR-008 step 2)

### DIFF
--- a/src/features/canvas/hooks/useCanvasNodeSources.ts
+++ b/src/features/canvas/hooks/useCanvasNodeSources.ts
@@ -1,0 +1,47 @@
+// Single source of the canvas's node inputs (ADR-008 / CVS-230, step 2 of the
+// canvas state-ownership migration). Today CanvasPage merges 4-5 node sources
+// inline in a big `nodes` memo; this hook gathers the STORE-backed sources in one
+// reference-stable place so:
+//   1. there's one selector to consume (fewer churny inputs → less React #185),
+//   2. step 3 can swap the source (→ React Flow `useNodesState`) in ONE place.
+// Behaviour-preserving: it reads exactly the same store fields the memo used.
+// (The XState transient `extraNodes` stays in the component for now — it's on the
+// way out; see ADR-008.)
+import { useMemo } from 'react';
+import { useCanvasStore, useEvidenceStore } from '@/lib/stores';
+import { useCanvasNodesStore } from '@/features/canvas/stores/useCanvasNodesStore';
+import { useNewNodeTypesStore } from '@/features/canvas/stores/useNewNodeTypesStore';
+import type { EvidenceItem, MetricCard } from '@/shared/types';
+
+const EMPTY: readonly never[] = [];
+
+export interface CanvasNodeSources {
+  /** Metric-tree cards (canvasStore.canvas.nodes). */
+  metricCards: MetricCard[];
+  /** Source / chart / operator / comment / whiteboard nodes (canvas_nodes). */
+  canvasNodes: any[];
+  /** PRD node types: value / action / hypothesis / metric. */
+  newNodes: any[];
+  /** Evidence items that carry a canvas position (rendered as nodes). */
+  positionedEvidence: EvidenceItem[];
+}
+
+export function useCanvasNodeSources(): CanvasNodeSources {
+  const metricCards = (useCanvasStore((s) => s.canvas?.nodes) ??
+    EMPTY) as MetricCard[];
+  const canvasNodes = (useCanvasNodesStore((s) => s.canvasNodes) ??
+    EMPTY) as any[];
+  const newNodes = (useNewNodeTypesStore((s) => s.newNodes) ?? EMPTY) as any[];
+  const evidence = (useEvidenceStore((s) => s.evidence) ??
+    EMPTY) as EvidenceItem[];
+
+  const positionedEvidence = useMemo(
+    () => evidence.filter((e) => e.position),
+    [evidence]
+  );
+
+  return useMemo(
+    () => ({ metricCards, canvasNodes, newNodes, positionedEvidence }),
+    [metricCards, canvasNodes, newNodes, positionedEvidence]
+  );
+}

--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -23,6 +23,7 @@ import { Eye } from 'lucide-react';
 // Extracted utilities and hooks
 import { useCanvasNodesStore } from '@/features/canvas/stores/useCanvasNodesStore';
 import { useNewNodeTypesStore } from '@/features/canvas/stores/useNewNodeTypesStore';
+import { useCanvasNodeSources } from '@/features/canvas/hooks/useCanvasNodeSources';
 import { useEvidenceStore } from '@/features/evidence/stores/useEvidenceStore';
 import { useAppStore, useCanvasStore } from '@/lib/stores';
 import { useCanvasHeader } from '@/shared/contexts/CanvasHeaderContext';
@@ -780,12 +781,18 @@ function CanvasPageInner() {
     [state.extraNodes]
   );
 
+  // Step 2 (ADR-008 / CVS-230): the store-backed node sources, gathered once in a
+  // reference-stable hook. The `nodes` memo consumes this instead of reading four
+  // stores inline — one selector, fewer churny inputs, and the single place step 3
+  // will swap to React Flow's useNodesState.
+  const nodeSources = useCanvasNodeSources();
+
   // Memoized data conversions
   const nodes = useMemo(() => {
-    const metricCardNodes = canvas?.nodes || [];
-    const evidenceNodes = evidenceList?.filter((e) => e.position) || [];
-    const persistedCanvasNodes = canvasNodes || [];
-    const newNodeTypes = newNodes || [];
+    const metricCardNodes = nodeSources.metricCards;
+    const evidenceNodes = nodeSources.positionedEvidence;
+    const persistedCanvasNodes = nodeSources.canvasNodes;
+    const newNodeTypes = nodeSources.newNodes;
 
     const convertedMetricCardNodes = metricCardNodes.map((card) =>
       convertToNode(
@@ -855,15 +862,12 @@ function CanvasPageInner() {
     return allNodes;
   }, [
     canvasId,
-    canvas?.nodes,
+    nodeSources, // consolidated store-backed node sources (ADR-008 step 2)
     canvas?.groups,
     focusedGroupId,
-    evidenceList,
     updateEvidence,
     deleteEvidence,
-    canvasNodes, // Unified canvas nodes from Zustand store
-    newNodes, // New node types from Zustand store
-    temporaryExtraNodes, // Only temporary fallback nodes
+    temporaryExtraNodes, // Only temporary fallback nodes (XState, transient)
     selectedNodeIds,
     state.isSettingsSheetOpen,
     stableEvents,


### PR DESCRIPTION
**Step 2 of the ADR-008 canvas state-ownership migration** (umbrella CVS-229).

New `useCanvasNodeSources()` gathers the four store-backed node sources — metric cards (`canvasStore`), `canvas_nodes`, new PRD node types, and positioned evidence — in **one reference-stable hook**. CanvasPage's big `nodes` memo now consumes it instead of reading four stores inline.

- **Behaviour-preserving:** identical store fields, same rendered nodes.
- **Value:** one selector (fewer churny memo deps → less #185 pressure) + the **single place step 3 swaps to React Flow `useNodesState`**.
- The XState transient `extraNodes` stays in the component for now (it's on the way out per ADR-008).

## Verification
type-check ✓, lint ✓ (0 errors), full build ✓. Behaviour identical → manual-test just confirms no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)