### PR TITLE
feat(cvs-165): dynamic relationship edge visuals — strength/confidence/direction

### DIFF
--- a/src/features/canvas/components/edges/DynamicEdge.tsx
+++ b/src/features/canvas/components/edges/DynamicEdge.tsx
@@ -29,6 +29,7 @@ import EnhancedEdgeButton, {
   useEdgeActions,
 } from './shared/EnhancedEdgeButton';
 import {
+  getRelationshipEdgeStyle,
   getRelationshipStroke,
   getRelationshipTypeMeta,
   getRelationshipWeightLabel,
@@ -166,6 +167,12 @@ export default function DynamicEdge({
     relationship.weight
   );
   const confidenceConfig = getConfidenceConfig(relationship.confidence);
+  // CVS-165: the drawn line encodes direction/strength/confidence.
+  const edgeStyle = getRelationshipEdgeStyle(
+    relationship.type,
+    relationship.weight,
+    relationship.confidence
+  );
 
   // Debug logging for edge styling updates - REMOVED to reduce console noise
 
@@ -308,22 +315,16 @@ export default function DynamicEdge({
         markerEnd={markerEnd}
         style={{
           ...style,
-          stroke: typeConfig.stroke,
-          strokeWidth: 2,
-          strokeDasharray:
-            typeConfig.lineStyle === 'dotted' ||
-            typeConfig.lineStyle === 'dotted-smoothstep'
-              ? '5,5'
-              : 'none',
-          opacity: selected || isHovered ? 1 : 0.8,
+          stroke: edgeStyle.stroke,
+          strokeWidth: selected || isHovered ? edgeStyle.strokeWidth + 1 : edgeStyle.strokeWidth,
+          strokeDasharray: edgeStyle.strokeDasharray ?? 'none',
+          // Confidence drives baseline opacity; hover/selected always fully opaque.
+          opacity: selected || isHovered ? 1 : edgeStyle.opacity,
           transition: 'all 0.2s ease-in-out',
           cursor: 'pointer',
-          // Add animation for dotted lines
-          ...(typeConfig.lineStyle === 'dotted' ||
-          typeConfig.lineStyle === 'dotted-smoothstep'
-            ? {
-                animation: 'dash 1s linear infinite',
-              }
+          // Animate dashed lines (loose/exploratory + observed correlation).
+          ...(edgeStyle.strokeDasharray
+            ? { animation: 'dash 1s linear infinite' }
             : {}),
         }}
         onMouseEnter={() => setIsHovered(true)}

--- a/src/features/canvas/constants/relationshipTypeMeta.test.ts
+++ b/src/features/canvas/constants/relationshipTypeMeta.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getRelationshipEdgeStyle,
+  getRelationshipStroke,
+} from './relationshipTypeMeta';
+
+// CVS-165 — the drawn line encodes relationship quality (direction/strength/confidence).
+describe('getRelationshipEdgeStyle', () => {
+  it('strong positive high-confidence reads healthy green, solid, thick', () => {
+    const s = getRelationshipEdgeStyle('Causal', 80, 'High');
+    expect(s.tone).toBe('positive');
+    expect(s.stroke).toBe('#16a34a');
+    expect(s.opacity).toBe(1);
+    expect(s.strokeDasharray).toBeUndefined(); // Causal is a solid type
+    expect(s.strokeWidth).toBeGreaterThan(3); // strength → width
+    expect(s.loose).toBe(false);
+  });
+
+  it('negative/inverse warns red regardless of magnitude', () => {
+    expect(getRelationshipEdgeStyle('Causal', -70, 'High').stroke).toBe('#dc2626');
+    expect(getRelationshipEdgeStyle('Probabilistic', -5, 'High').tone).toBe('negative');
+  });
+
+  it('weak / low correlation warns amber (not green)', () => {
+    const s = getRelationshipEdgeStyle('Probabilistic', 10, 'Medium');
+    expect(s.tone).toBe('weak');
+    expect(s.stroke).toBe('#d97706');
+  });
+
+  it('unknown strength (weight 0) is neutral + loose (dashed)', () => {
+    const s = getRelationshipEdgeStyle('Probabilistic', 0, 'Medium');
+    expect(s.tone).toBe('neutral');
+    expect(s.stroke).toBe('#9ca3af');
+    expect(s.loose).toBe(true);
+    expect(s.strokeDasharray).toBeTruthy();
+  });
+
+  it('low confidence looks loose: dashed, dimmer, thinner', () => {
+    const strong = getRelationshipEdgeStyle('Causal', 80, 'High');
+    const lowConf = getRelationshipEdgeStyle('Causal', 80, 'Low');
+    expect(lowConf.loose).toBe(true);
+    expect(lowConf.strokeDasharray).toBeTruthy();
+    expect(lowConf.opacity).toBeLessThan(strong.opacity);
+    expect(lowConf.strokeWidth).toBeLessThan(strong.strokeWidth);
+    // same colour (still positive) — only firmness changes
+    expect(lowConf.stroke).toBe(strong.stroke);
+  });
+
+  it('structural types (deterministic/compositional) are definitional gray, not strength-coloured', () => {
+    const det = getRelationshipEdgeStyle('Deterministic', 90, 'High');
+    expect(det.tone).toBe('structural');
+    expect(det.stroke).toBe('#6b7280');
+    const comp = getRelationshipEdgeStyle('Compositional', -90, 'Low');
+    expect(comp.tone).toBe('structural');
+    expect(comp.stroke).toBe('#6b7280'); // ignores weight sign
+  });
+
+  it('width scales with strength magnitude', () => {
+    const weak = getRelationshipEdgeStyle('Causal', 20, 'High').strokeWidth;
+    const strong = getRelationshipEdgeStyle('Causal', 90, 'High').strokeWidth;
+    expect(strong).toBeGreaterThan(weak);
+  });
+});
+
+describe('getRelationshipStroke (delegates to edge style)', () => {
+  it('returns the tone colour', () => {
+    expect(getRelationshipStroke('Causal', 80)).toBe('#16a34a');
+    expect(getRelationshipStroke('Causal', -80)).toBe('#dc2626');
+    expect(getRelationshipStroke('Probabilistic', 5)).toBe('#d97706');
+    expect(getRelationshipStroke('Deterministic', 80)).toBe('#6b7280');
+  });
+});

--- a/src/features/canvas/constants/relationshipTypeMeta.ts
+++ b/src/features/canvas/constants/relationshipTypeMeta.ts
@@ -13,7 +13,7 @@
  */
 import { ArrowRight, Layers, Network, TrendingUp, Zap } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import type { RelationshipType } from '@/shared/types';
+import type { ConfidenceLevel, RelationshipType } from '@/shared/types';
 
 export type RelationshipLayer = 'component' | 'influence';
 
@@ -161,15 +161,125 @@ export function getRelationshipTypeMeta(
   return UNKNOWN_RELATIONSHIP_META;
 }
 
-/** Resolve the stroke color for an edge given its type + weight. */
+// ---------------------------------------------------------------------------
+// Dynamic edge visual intelligence (CVS-165)
+// The drawn line encodes relationship QUALITY: signed strength → colour +
+// direction, magnitude → width, confidence → opacity + "loose" dash. Negative
+// and weak/low-correlation links warn (red / amber) instead of reading like a
+// healthy green link; low-confidence links look loose, not validated.
+// ---------------------------------------------------------------------------
+
+/** Semantic read of a relationship's drawn line, for badges/legends too. */
+export type RelationshipTone =
+  | 'positive' // strong, healthy positive influence (green)
+  | 'negative' // inverse relationship — warns (red)
+  | 'weak' // weak / low correlation — warns (amber)
+  | 'neutral' // unknown / exploratory, no strength yet (gray)
+  | 'structural'; // deterministic / compositional — definitional (gray)
+
+export interface RelationshipEdgeStyle {
+  stroke: string;
+  strokeWidth: number;
+  /** SVG dasharray, or undefined for a solid line. */
+  strokeDasharray: string | undefined;
+  opacity: number;
+  tone: RelationshipTone;
+  /** True when the line should read as loose/exploratory (dashed + dim). */
+  loose: boolean;
+}
+
+// Semantic edge palette (hex — SVG stroke is inline, not a Tailwind class).
+const EDGE_COLORS = {
+  positiveStrong: '#16a34a', // green-600
+  positive: '#22c55e', // green-500
+  negative: '#dc2626', // red-600  — inverse relationships warn
+  weak: '#d97706', // amber-600 — weak / low correlation warns
+  neutral: '#9ca3af', // gray-400 — exploratory / unknown
+  structural: GRAY, // gray-500 — deterministic / compositional
+};
+
+/** |weight| below this reads as a weak/uncertain signal; above STRONG_MIN as strong. */
+const WEAK_MAX = 20;
+const STRONG_MIN = 50;
+
+/**
+ * The full drawn-line style for a relationship edge, derived from signed
+ * strength + confidence + type. Single source of truth for the canvas edge,
+ * the arrowhead colour, and any legend.
+ */
+export function getRelationshipEdgeStyle(
+  type: RelationshipType | string | undefined,
+  weight?: number,
+  confidence?: ConfidenceLevel | string
+): RelationshipEdgeStyle {
+  const meta = getRelationshipTypeMeta(type);
+
+  // Structural types are definitional — not coloured by statistical strength.
+  if (!meta.strokeByWeight) {
+    const dotted =
+      meta.lineStyle === 'dotted' || meta.lineStyle === 'dotted-smoothstep';
+    return {
+      stroke: EDGE_COLORS.structural,
+      strokeWidth: 2,
+      strokeDasharray: dotted ? '6,4' : undefined,
+      opacity: 0.9,
+      tone: 'structural',
+      loose: false,
+    };
+  }
+
+  const conf: ConfidenceLevel =
+    confidence === 'High' || confidence === 'Low' ? confidence : 'Medium';
+  const w = typeof weight === 'number' ? weight : 0;
+  const mag = Math.min(Math.abs(w), 100);
+
+  let tone: RelationshipTone;
+  let stroke: string;
+  if (w === 0) {
+    tone = 'neutral';
+    stroke = EDGE_COLORS.neutral;
+  } else if (w < 0) {
+    tone = 'negative';
+    stroke = EDGE_COLORS.negative;
+  } else if (mag < WEAK_MAX) {
+    tone = 'weak';
+    stroke = EDGE_COLORS.weak;
+  } else {
+    tone = 'positive';
+    stroke = mag >= STRONG_MIN ? EDGE_COLORS.positiveStrong : EDGE_COLORS.positive;
+  }
+
+  // Strength drives width (thicker = stronger); low confidence thins it.
+  const base = 1.5 + (mag / 100) * 2; // 1.5 .. 3.5
+  const strokeWidth = Number(
+    (conf === 'Low' ? Math.max(1.25, base - 0.75) : base).toFixed(2)
+  );
+
+  // Loose read: low confidence or unknown strength; observed (dotted) types
+  // like Probabilistic correlation are dashed regardless.
+  const dottedType =
+    meta.lineStyle === 'dotted' || meta.lineStyle === 'dotted-smoothstep';
+  const loose = conf === 'Low' || tone === 'neutral';
+  const dashed = loose || dottedType;
+  const opacity = conf === 'High' ? 1 : conf === 'Low' ? 0.5 : 0.8;
+
+  return {
+    stroke,
+    strokeWidth,
+    strokeDasharray: dashed ? (conf === 'Low' ? '4,4' : '6,4') : undefined,
+    opacity,
+    tone,
+    loose,
+  };
+}
+
+/** Resolve the stroke color for an edge given its type + weight (+ optional confidence). */
 export function getRelationshipStroke(
   type: RelationshipType | string | undefined,
-  weight?: number
+  weight?: number,
+  confidence?: ConfidenceLevel | string
 ): string {
-  const meta = getRelationshipTypeMeta(type);
-  if (!meta.strokeByWeight) return meta.baseStroke;
-  if (weight === undefined || weight === 0) return GRAY;
-  return weight > 0 ? '#16a34a' : '#dc2626';
+  return getRelationshipEdgeStyle(type, weight, confidence).stroke;
 }
 
 /** Resolve the mid-edge weight button label. */

--- a/src/shared/utils/canvasConverters.ts
+++ b/src/shared/utils/canvasConverters.ts
@@ -29,6 +29,7 @@ import type {
 } from '@/shared/types';
 import { MarkerType, type Edge, type Node } from '@xyflow/react';
 import type { LayoutDirection } from '@/shared/utils/autoLayout';
+import { getRelationshipStroke } from '@/features/canvas/constants/relationshipTypeMeta';
 import { normalizeOperatorData } from '@/features/canvas/utils/operatorMigration';
 
 // Convert MetricCard to ReactFlow Node
@@ -80,18 +81,14 @@ export const handlesForDirection = (
   }
 };
 
-// Arrowhead color mirrors DynamicEdge's stroke logic (gray for formulaic/zero,
-// green for positive weight, red for negative).
-const arrowColorForRelationship = (relationship: Relationship): string => {
-  if (
-    relationship.type === 'Deterministic' ||
-    relationship.type === 'Compositional'
-  )
-    return '#6b7280';
-  const w = relationship.weight;
-  if (w === undefined || w === 0) return '#6b7280';
-  return w > 0 ? '#16a34a' : '#dc2626';
-};
+// Arrowhead color mirrors DynamicEdge's stroke logic — the single edge-style
+// source of truth (green positive / red negative / amber weak / gray neutral).
+const arrowColorForRelationship = (relationship: Relationship): string =>
+  getRelationshipStroke(
+    relationship.type,
+    relationship.weight,
+    relationship.confidence
+  );
 
 // Convert Relationship to ReactFlow Edge with DynamicEdge
 export const convertToEdge = (


### PR DESCRIPTION
Addresses **CVS-165** — relationship edges should communicate quality, not read as a fixed green link. This PR delivers the **edge visual-intelligence core** (lane priorities 1–3).

## What
`getRelationshipEdgeStyle(type, weight, confidence)` is the single source of truth for the drawn line + arrowhead:
- **Direction** — positive **green**, negative/inverse **red** (always warns).
- **Strength** — weak (|w|<20) warns **amber**; magnitude drives **stroke width** (thicker = stronger).
- **Confidence** — High solid + opaque; **Low = loose** (dashed, dimmer, thinner).
- **Neutral** (no strength yet) = exploratory **loose dashed gray**.
- **Structural** (Deterministic/Compositional) stays definitional gray — not confused with statistical strength.

Applied in `DynamicEdge` (stroke/width/dash/opacity; hover/selected thickens + fully opaque; dashed animates) and `canvasConverters` arrowhead colour.

## Verification
- `type-check` ✅ · `lint` ✅ (0 new) · **full vitest 262/262** ✅ — 8 unit tests for the mapping (direction, weak→amber, low-conf loose, structural, width scaling).
- Visual QA (zoom / hover / selected / multiple types side-by-side) is in the manual test.

## Deferred (follow-ups within CVS-165)
Center-badge redesign, first-class **exploratory relationship TYPE** persistence, and **causal-validation/refutation** state — larger model/UI work, and the exploratory-type overlaps the CVS-161 sheet refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)