### PR TITLE
CVS-156 (slice 1): app-shell rail wrapping workspace routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import AccountSettingsPage from './features/settings/pages/AccountSettingsPage';
 import ConnectAgentPage from './features/settings/pages/ConnectAgentPage';
 import EmbedCanvasPage from './features/canvas/pages/EmbedCanvasPage';
 import HomePage from './features/projects/pages/HomePage';
+import AppShell from './shared/components/layout/AppShell';
 
 // Auth Pages
 import SignInPage from './features/auth/pages/SignInPage';
@@ -85,16 +86,6 @@ export default function App() {
                 {/* Public read-only embed (no auth — RLS gates by is_public) */}
                 <Route path="/embed/:canvasId" element={<EmbedCanvasPage />} />
 
-                {/* Protected routes */}
-                <Route
-                  path="/"
-                  element={
-                    <ProtectedRoute>
-                      <HomePage />
-                    </ProtectedRoute>
-                  }
-                />
-
                 {/* Debug route - always accessible */}
                 <Route
                   path="/debug"
@@ -115,63 +106,35 @@ export default function App() {
                   }
                 />
 
-                {/* Evidence Repository */}
+                {/* Workspace routes — wrapped in the app-shell rail (CVS-156) */}
                 <Route
-                  path="/evidence"
                   element={
                     <ProtectedRoute>
-                      <EvidenceRepositoryPage />
+                      <AppShell />
                     </ProtectedRoute>
                   }
-                />
-                <Route
-                  path="/evidence/:evidenceId"
-                  element={
-                    <ProtectedRoute>
-                      <EvidencePage />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="/catalog"
-                  element={
-                    <ProtectedRoute>
-                      <CatalogPage />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="/feed"
-                  element={
-                    <ProtectedRoute>
-                      <FeedPage />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="/settings"
-                  element={
-                    <ProtectedRoute>
-                      <AccountSettingsPage />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="/settings/workspace"
-                  element={
-                    <ProtectedRoute>
-                      <WorkspaceSettingsPage />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="/settings/connect"
-                  element={
-                    <ProtectedRoute>
-                      <ConnectAgentPage />
-                    </ProtectedRoute>
-                  }
-                />
+                >
+                  <Route path="/" element={<HomePage />} />
+                  <Route
+                    path="/evidence"
+                    element={<EvidenceRepositoryPage />}
+                  />
+                  <Route
+                    path="/evidence/:evidenceId"
+                    element={<EvidencePage />}
+                  />
+                  <Route path="/catalog" element={<CatalogPage />} />
+                  <Route path="/feed" element={<FeedPage />} />
+                  <Route path="/settings" element={<AccountSettingsPage />} />
+                  <Route
+                    path="/settings/workspace"
+                    element={<WorkspaceSettingsPage />}
+                  />
+                  <Route
+                    path="/settings/connect"
+                    element={<ConnectAgentPage />}
+                  />
+                </Route>
 
                 {/* Canvas routes - With sidebar layout */}
                 <Route

--- a/src/features/projects/components/ProjectCard.tsx
+++ b/src/features/projects/components/ProjectCard.tsx
@@ -90,62 +90,62 @@ export function ProjectCard({
             >
               <DropdownMenuItem
                 onClick={() => onOpenCanvas(project.id)}
-                className="flex items-center px-3 py-2.5 rounded-md hover:bg-gray-50 transition-colors cursor-pointer text-sm font-medium"
+                className="flex items-center px-3 py-2.5 rounded-md hover:bg-muted transition-colors cursor-pointer text-sm font-medium"
               >
                 <span>Open Canvas</span>
               </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={() => onDuplicateProject(project.id)}
-                className="flex items-center px-3 py-2.5 rounded-md hover:bg-gray-50 transition-colors cursor-pointer text-sm font-medium"
+                className="flex items-center px-3 py-2.5 rounded-md hover:bg-muted transition-colors cursor-pointer text-sm font-medium"
               >
                 <span>Duplicate</span>
               </DropdownMenuItem>
               {onSaveAsTemplate && (
                 <DropdownMenuItem
                   onClick={() => onSaveAsTemplate(project.id)}
-                  className="flex items-center px-3 py-2.5 rounded-md hover:bg-gray-50 transition-colors cursor-pointer text-sm font-medium"
+                  className="flex items-center px-3 py-2.5 rounded-md hover:bg-muted transition-colors cursor-pointer text-sm font-medium"
                 >
                   <span>Save as Template</span>
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem
                 onClick={() => onToggleStar(project.id)}
-                className="flex items-center px-3 py-2.5 rounded-md hover:bg-gray-50 transition-colors cursor-pointer text-sm font-medium"
+                className="flex items-center px-3 py-2.5 rounded-md hover:bg-muted transition-colors cursor-pointer text-sm font-medium"
               >
                 <span>{project.isStarred ? 'Remove Star' : 'Add Star'}</span>
               </DropdownMenuItem>
-              <DropdownMenuSeparator className="my-1 bg-gray-200" />
+              <DropdownMenuSeparator className="my-1 bg-border" />
               <DropdownMenuItem
                 onClick={() => onProjectSettings(project.id)}
-                className="flex items-center px-3 py-2.5 rounded-md hover:bg-gray-50 transition-colors cursor-pointer text-sm font-medium"
+                className="flex items-center px-3 py-2.5 rounded-md hover:bg-muted transition-colors cursor-pointer text-sm font-medium"
               >
                 <span>Project Settings</span>
               </DropdownMenuItem>
               {isArchived ? (
                 <DropdownMenuItem
                   onClick={() => onRestore(project.id)}
-                  className="flex items-center px-3 py-2.5 rounded-md hover:bg-gray-50 transition-colors cursor-pointer text-sm font-medium"
+                  className="flex items-center px-3 py-2.5 rounded-md hover:bg-muted transition-colors cursor-pointer text-sm font-medium"
                 >
                   <span>Restore from Archive</span>
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuItem
                   onClick={() => onArchive(project.id)}
-                  className="flex items-center px-3 py-2.5 rounded-md hover:bg-gray-50 transition-colors cursor-pointer text-sm font-medium"
+                  className="flex items-center px-3 py-2.5 rounded-md hover:bg-muted transition-colors cursor-pointer text-sm font-medium"
                 >
                   <span>Archive</span>
                 </DropdownMenuItem>
               )}
               {onMoveToSpace && (
                 <>
-                  <DropdownMenuSeparator className="my-1 bg-gray-200" />
+                  <DropdownMenuSeparator className="my-1 bg-border" />
                   <DropdownMenuLabel className="px-3 text-xs text-muted-foreground">
                     Move to Space
                   </DropdownMenuLabel>
                   {project.spaceId && (
                     <DropdownMenuItem
                       onClick={() => onMoveToSpace(project.id, null)}
-                      className="flex items-center px-3 py-2 rounded-md hover:bg-gray-50 cursor-pointer text-sm"
+                      className="flex items-center px-3 py-2 rounded-md hover:bg-muted cursor-pointer text-sm"
                     >
                       <span>Uncategorized</span>
                     </DropdownMenuItem>
@@ -156,17 +156,17 @@ export function ProjectCard({
                       <DropdownMenuItem
                         key={s.id}
                         onClick={() => onMoveToSpace(project.id, s.id)}
-                        className="flex items-center px-3 py-2 rounded-md hover:bg-gray-50 cursor-pointer text-sm"
+                        className="flex items-center px-3 py-2 rounded-md hover:bg-muted cursor-pointer text-sm"
                       >
                         <span>{s.name}</span>
                       </DropdownMenuItem>
                     ))}
-                  <DropdownMenuSeparator className="my-1 bg-gray-200" />
+                  <DropdownMenuSeparator className="my-1 bg-border" />
                 </>
               )}
               <DropdownMenuItem
                 onClick={() => onDeleteProject(project.id)}
-                className="flex items-center px-3 py-2.5 rounded-md hover:bg-red-50 transition-colors cursor-pointer text-sm font-medium text-red-600 hover:text-red-700"
+                className="flex items-center px-3 py-2.5 rounded-md hover:bg-destructive/10 transition-colors cursor-pointer text-sm font-medium text-destructive hover:text-destructive"
               >
                 <span>{isArchived ? 'Delete Permanently' : 'Delete Project'}</span>
               </DropdownMenuItem>
@@ -200,15 +200,15 @@ export function ProjectCard({
           {/* Project Stats */}
           <div className="flex items-center gap-4 text-sm text-muted-foreground">
             <div className="flex items-center gap-1">
-              <BarChart3 className="h-3 w-3 text-blue-500" />
+              <BarChart3 className="h-3 w-3 text-chart-1" />
               {project.nodeCount ?? project.nodes.length} metrics
             </div>
             <div className="flex items-center gap-1">
-              <Network className="h-3 w-3 text-green-500" />
+              <Network className="h-3 w-3 text-chart-2" />
               {project.edgeCount ?? project.edges.length} relationships
             </div>
             <div className="flex items-center gap-1">
-              <Folder className="h-3 w-3 text-purple-500" />
+              <Folder className="h-3 w-3 text-chart-3" />
               {project.groupCount ?? project.groups?.length ?? 0} groups
             </div>
           </div>

--- a/src/features/projects/pages/HomePage.tsx
+++ b/src/features/projects/pages/HomePage.tsx
@@ -12,8 +12,17 @@ import {
   createShortcut,
   useKeyboardShortcuts,
 } from '@/shared/hooks/useKeyboardShortcuts';
+import { LayoutTemplate, Plus } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { Button } from '@/shared/components/ui/button';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/shared/components/ui/tabs';
 
 // Custom hooks and components
 import { useProjectActions } from '@/shared/hooks/useProjectActions';
@@ -32,6 +41,18 @@ type ViewMode = 'grid' | 'list';
 
 export default function HomePage() {
   const navigate = useNavigate();
+
+  // Explore / Operate home modes (CVS-156). The rail deep-links here via ?view;
+  // Operate (the user's own canvases) is the default, Explore holds examples.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view = searchParams.get('view') === 'explore' ? 'explore' : 'operate';
+  const setView = (v: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (v === 'operate') next.delete('view');
+    else next.set('view', v);
+    setSearchParams(next, { replace: true });
+  };
+
   const {
     projects,
     initializeProjects,
@@ -144,50 +165,67 @@ export default function HomePage() {
     <div className="bg-background">
       {/* Main Content */}
       <div className="px-8 py-8 max-w-19/20 mx-auto">
-        {/* Examples — demoted to a slim entry; collapsed by default once the
-            user has their own canvases so their work stays above the fold. */}
-        <ShowcaseSection
-          onOpenCanvas={handleOpenCanvas}
-          defaultCollapsed={safeProjects.length > 0}
-        />
+        <Tabs value={view} onValueChange={setView} className="w-full">
+          <TabsList className="mb-6">
+            <TabsTrigger value="operate">Operate</TabsTrigger>
+            <TabsTrigger value="explore">Explore</TabsTrigger>
+          </TabsList>
 
-        {/* One consolidated control bar: space · filter · search · sort · view · New */}
-        <HomeControlBar
-          spaces={spaces}
-          spaceFilter={spaceFilter}
-          onSpaceFilter={setSpaceFilter}
-          onSpaceCreate={createSpace}
-          onSpaceUpdate={updateSpace}
-          onSpaceDelete={deleteSpace}
-          viewFilter={viewFilter}
-          onViewFilter={setViewFilter}
-          counts={counts}
-          searchQuery={searchQuery}
-          onSearchQueryChange={setSearchQuery}
-          sortBy={sortBy}
-          onSortByChange={setSortBy}
-          sortOrder={sortOrder}
-          onSortOrderChange={setSortOrder}
-          viewMode={viewMode}
-          onViewModeChange={setViewMode}
-          selectedTags={selectedTags}
-          allTags={allTags}
-          onToggleTag={toggleTag}
-          onClearTags={() => setSelectedTags([])}
-          isCreatingCanvas={isCreatingCanvas}
-          onCreateCanvas={handleCreateCanvas}
-          onNewFromTemplate={() => setTemplatePickerOpen(true)}
-        />
+          {/* Operate — the user's own canvases (their durable work). */}
+          <TabsContent value="operate" className="mt-0">
+            {/* One consolidated control bar: space · filter · search · sort · view · New */}
+            <HomeControlBar
+              spaces={spaces}
+              spaceFilter={spaceFilter}
+              onSpaceFilter={setSpaceFilter}
+              onSpaceCreate={createSpace}
+              onSpaceUpdate={updateSpace}
+              onSpaceDelete={deleteSpace}
+              viewFilter={viewFilter}
+              onViewFilter={setViewFilter}
+              counts={counts}
+              searchQuery={searchQuery}
+              onSearchQueryChange={setSearchQuery}
+              sortBy={sortBy}
+              onSortByChange={setSortBy}
+              sortOrder={sortOrder}
+              onSortOrderChange={setSortOrder}
+              viewMode={viewMode}
+              onViewModeChange={setViewMode}
+              selectedTags={selectedTags}
+              allTags={allTags}
+              onToggleTag={toggleTag}
+              onClearTags={() => setSelectedTags([])}
+              isCreatingCanvas={isCreatingCanvas}
+              onCreateCanvas={handleCreateCanvas}
+              onNewFromTemplate={() => setTemplatePickerOpen(true)}
+            />
 
-        {/* Single project list (driven by the control bar) */}
-        <div className="mt-0">
-          {filteredProjects.length > 0 ? (
-            viewMode === 'grid' ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {filteredProjects.map((project) => (
-                  <ProjectCard
-                    key={project.id}
-                    project={project}
+            {/* Single project list (driven by the control bar) */}
+            <div className="mt-0">
+              {filteredProjects.length > 0 ? (
+                viewMode === 'grid' ? (
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {filteredProjects.map((project) => (
+                      <ProjectCard
+                        key={project.id}
+                        project={project}
+                        onOpenCanvas={handleOpenCanvas}
+                        onDuplicateProject={handleDuplicateProject}
+                        onToggleStar={toggleStar}
+                        onDeleteProject={handleDeleteProject}
+                        onProjectSettings={handleProjectSettings}
+                        onArchive={archiveProject}
+                        onRestore={restoreProject}
+                        spaces={spaces}
+                        onMoveToSpace={moveProjectToSpace}
+                        onSaveAsTemplate={handleSaveAsTemplate}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <ProjectTable
+                    projects={filteredProjects}
                     onOpenCanvas={handleOpenCanvas}
                     onDuplicateProject={handleDuplicateProject}
                     onToggleStar={toggleStar}
@@ -199,39 +237,49 @@ export default function HomePage() {
                     onMoveToSpace={moveProjectToSpace}
                     onSaveAsTemplate={handleSaveAsTemplate}
                   />
-                ))}
-              </div>
-            ) : (
-              <ProjectTable
-                projects={filteredProjects}
-                onOpenCanvas={handleOpenCanvas}
-                onDuplicateProject={handleDuplicateProject}
-                onToggleStar={toggleStar}
-                onDeleteProject={handleDeleteProject}
-                onProjectSettings={handleProjectSettings}
-                onArchive={archiveProject}
-                onRestore={restoreProject}
-                spaces={spaces}
-                onMoveToSpace={moveProjectToSpace}
-                onSaveAsTemplate={handleSaveAsTemplate}
-              />
-            )
-          ) : (
-            <EmptyState
-              type={
-                safeProjects.length === 0
-                  ? 'no-projects'
-                  : viewFilter === 'starred'
-                    ? 'no-starred'
-                    : viewFilter === 'recent'
-                      ? 'no-recent'
-                      : 'no-results'
-              }
-              onCreateCanvas={handleCreateCanvas}
-              isCreatingCanvas={isCreatingCanvas}
+                )
+              ) : (
+                <EmptyState
+                  type={
+                    safeProjects.length === 0
+                      ? 'no-projects'
+                      : viewFilter === 'starred'
+                        ? 'no-starred'
+                        : viewFilter === 'recent'
+                          ? 'no-recent'
+                          : 'no-results'
+                  }
+                  onCreateCanvas={handleCreateCanvas}
+                  isCreatingCanvas={isCreatingCanvas}
+                />
+              )}
+            </div>
+          </TabsContent>
+
+          {/* Explore — examples + starting points for learning the pattern. */}
+          <TabsContent value="explore" className="mt-0 space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                onClick={() => handleCreateCanvas()}
+                disabled={isCreatingCanvas}
+              >
+                <Plus className="h-4 w-4" />
+                New canvas
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => setTemplatePickerOpen(true)}
+              >
+                <LayoutTemplate className="h-4 w-4" />
+                Start from a template
+              </Button>
+            </div>
+            <ShowcaseSection
+              onOpenCanvas={handleOpenCanvas}
+              defaultCollapsed={false}
             />
-          )}
-        </div>
+          </TabsContent>
+        </Tabs>
       </div>
 
       {/* Quick Search */}

--- a/src/features/projects/pages/HomePage.tsx
+++ b/src/features/projects/pages/HomePage.tsx
@@ -3,16 +3,11 @@ import QuickSearchCommand, {
   useQuickSearch,
 } from '@/features/canvas/components/search/QuickSearchCommand';
 import { useAppStore, useProjectsStore } from '@/lib/stores';
-import FeedbackButton from '@/shared/components/common/feedback/FeedbackButton';
-import { OrganizationSwitcher, useOrganization } from '@clerk/react-router';
+import { useOrganization } from '@clerk/react-router';
 import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
 import { useProjectsRealtime } from '../hooks/useProjectsRealtime';
-import { NotificationInbox } from '@/features/notifications/components/NotificationInbox';
 import { TemplatePicker } from '../components/TemplatePicker';
 import { toast } from 'sonner';
-import { Activity, Database } from 'lucide-react';
-import { UserMenu } from '@/shared/components/layout/UserMenu';
-import { Logo } from '@/shared/components/layout/Logo';
 import {
   createShortcut,
   useKeyboardShortcuts,
@@ -37,7 +32,6 @@ type ViewMode = 'grid' | 'list';
 
 export default function HomePage() {
   const navigate = useNavigate();
-  const isDevelopment = import.meta.env.DEV;
   const {
     projects,
     initializeProjects,
@@ -147,45 +141,7 @@ export default function HomePage() {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Header */}
-      <div className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-10 w-full">
-        <div className="px-6 py-3">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Logo className="h-8 w-8 shrink-0 rounded-md overflow-hidden transition-all duration-300 hover:scale-105 cursor-pointer" />
-              {/* Workspace switcher (Clerk org = workspace). Orgs-only model:
-                  personal account hidden; ProtectedRoute keeps an org active. */}
-              <OrganizationSwitcher
-                hidePersonal
-                afterCreateOrganizationUrl="/"
-                afterSelectOrganizationUrl="/"
-                afterLeaveOrganizationUrl="/"
-              />
-            </div>
-            <div className="flex items-center gap-3">
-              <button
-                onClick={() => navigate('/catalog')}
-                className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-              >
-                <Database className="h-4 w-4" />
-                Metric Catalog
-              </button>
-              <button
-                onClick={() => navigate('/feed')}
-                className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                <Activity className="h-4 w-4" />
-                Activity
-              </button>
-              <NotificationInbox />
-              {isDevelopment && <FeedbackButton variant="outline" size="sm" />}
-              <UserMenu />
-            </div>
-          </div>
-        </div>
-      </div>
-
+    <div className="bg-background">
       {/* Main Content */}
       <div className="px-8 py-8 max-w-19/20 mx-auto">
         {/* Examples — demoted to a slim entry; collapsed by default once the

--- a/src/shared/components/layout/AppShell.tsx
+++ b/src/shared/components/layout/AppShell.tsx
@@ -1,0 +1,176 @@
+import { OrganizationSwitcher } from '@clerk/react-router';
+import {
+  Activity,
+  Compass,
+  Database,
+  Gauge,
+  Home,
+  Search,
+  Sparkles,
+  Star,
+} from 'lucide-react';
+import { useState } from 'react';
+import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom';
+
+import AdvancedSearchModal from '@/features/canvas/components/search/AdvancedSearchModal';
+import { NotificationInbox } from '@/features/notifications/components/NotificationInbox';
+import { useProjectsStore } from '@/lib/stores';
+import { Logo } from '@/shared/components/layout/Logo';
+import { UserMenu } from '@/shared/components/layout/UserMenu';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarSeparator,
+  SidebarTrigger,
+} from '@/shared/components/ui/sidebar';
+
+// Primary workspace navigation. Explore/Operate deep-link into the home tabs
+// (the tab reader lands in the CVS-156 follow-up); the rest are real routes.
+const NAV = [
+  { label: 'Home', icon: Home, to: '/', match: (p: string) => p === '/' },
+  { label: 'Explore', icon: Compass, to: '/?view=explore' },
+  { label: 'Operate', icon: Gauge, to: '/?view=operate' },
+  { label: 'Data', icon: Database, to: '/catalog' },
+  { label: 'Activity', icon: Activity, to: '/feed' },
+  { label: 'Agent', icon: Sparkles, to: '/settings/connect' },
+] as const;
+
+/**
+ * Workspace app shell (CVS-156): a sticky left rail — workspace switcher, search,
+ * primary nav, pinned boards, user utilities — wrapping every top-level workspace
+ * route via <Outlet/>. Canvas routes keep their own CanvasLayout.
+ */
+export default function AppShell() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  const projects = useProjectsStore((s) => s.projects);
+  const pinned = (Array.isArray(projects) ? projects : [])
+    .filter((p) => p.tags?.includes('starred'))
+    .slice(0, 6);
+
+  const isActive = (item: (typeof NAV)[number]) =>
+    'match' in item && item.match
+      ? item.match(location.pathname)
+      : location.pathname + location.search === item.to;
+
+  return (
+    <SidebarProvider>
+      <Sidebar collapsible="offcanvas">
+        <SidebarHeader className="gap-2">
+          <div className="flex items-center gap-2 px-1 py-1">
+            <Link to="/" aria-label="Home" className="shrink-0">
+              <Logo className="h-7 w-7 rounded-md" />
+            </Link>
+            <div className="min-w-0 flex-1">
+              <OrganizationSwitcher
+                hidePersonal
+                afterCreateOrganizationUrl="/"
+                afterSelectOrganizationUrl="/"
+                afterLeaveOrganizationUrl="/"
+              />
+            </div>
+          </div>
+        </SidebarHeader>
+
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  onClick={() => setSearchOpen(true)}
+                  tooltip="Search (Shift+F)"
+                >
+                  <Search />
+                  <span>Search</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              {NAV.map((item) => (
+                <SidebarMenuItem key={item.label}>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={isActive(item)}
+                    tooltip={item.label}
+                  >
+                    <Link to={item.to}>
+                      <item.icon />
+                      <span>{item.label}</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroup>
+
+          {pinned.length > 0 && (
+            <SidebarGroup>
+              <SidebarGroupLabel>Pinned</SidebarGroupLabel>
+              <SidebarMenu>
+                {pinned.map((p) => (
+                  <SidebarMenuItem key={p.id}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={location.pathname === `/canvas/${p.id}`}
+                      tooltip={p.name}
+                    >
+                      <Link to={`/canvas/${p.id}`}>
+                        <Star />
+                        <span>{p.name}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroup>
+          )}
+        </SidebarContent>
+
+        <SidebarFooter>
+          <SidebarSeparator />
+          <div className="flex items-center justify-between gap-2 px-1">
+            <UserMenu />
+            <NotificationInbox />
+          </div>
+        </SidebarFooter>
+      </Sidebar>
+
+      <SidebarInset>
+        <header className="sticky top-0 z-10 flex h-12 items-center gap-2 border-b border-border bg-background/80 px-4 backdrop-blur-sm">
+          <SidebarTrigger className="-ml-1" />
+        </header>
+        <div className="flex-1 overflow-auto">
+          <Outlet />
+        </div>
+      </SidebarInset>
+
+      <AdvancedSearchModal
+        isOpen={searchOpen}
+        onClose={() => setSearchOpen(false)}
+        onResultSelect={(result) => {
+          const canvasId = (result.data as { canvasId?: string })?.canvasId;
+          if (result.type === 'evidence') {
+            navigate('/evidence', { state: { focusEvidence: result.id } });
+          } else if (canvasId) {
+            navigate(`/canvas/${canvasId}`, {
+              state:
+                result.type === 'relationship'
+                  ? { openRelationship: result.id }
+                  : { focusNode: result.id },
+            });
+          }
+          setSearchOpen(false);
+        }}
+      />
+    </SidebarProvider>
+  );
+}


### PR DESCRIPTION
Slice 1 of CVS-156 (Variant A — labeled rail, owner-chosen). **Build-for-review — structural, whole-workspace visual change; needs a browser.**

Adopts the previously-unused shadcn `Sidebar` primitive as a sticky left rail:
- **New** `AppShell.tsx` — workspace switcher + Logo (header) · Search + Home/Explore/Operate/Data/Activity/Agent + Pinned boards (content) · user menu + notifications (footer). `SidebarInset` hosts a slim top bar (mobile trigger) + `<Outlet/>`. Offcanvas collapsible → mobile sheet + `Cmd+B`.
- `App.tsx` — workspace routes (`/`, `/evidence`, `/catalog`, `/feed`, `/settings*`) nested under one `AppShell` parent route. Canvas routes untouched (own `CanvasLayout`).
- `HomePage` — bespoke header removed (now in the rail), imports pruned.

Explore/Operate currently deep-link to `/` (the tab reader + ProjectCard token cleanup are **slice 2**). type-check · 0 lint errors · 254 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)