### PR TITLE
feat(cvs-244): relationship strength history + audit trail + trend sparkline

### DIFF
--- a/src/features/canvas/components/panels/relationship-panel/RelationshipSheet.tsx
+++ b/src/features/canvas/components/panels/relationship-panel/RelationshipSheet.tsx
@@ -64,6 +64,7 @@ import {
 } from '@/shared/components/ui/tooltip';
 import { InfoHint } from '@/shared/components/common/InfoHint';
 import { useRelationshipEvidence, useRelationshipTags } from './hooks';
+import { StrengthTrendCard } from './StrengthTrendCard';
 
 interface RelationshipSheetProps {
   isOpen: boolean;
@@ -123,6 +124,7 @@ export default function RelationshipSheet({
     changelog,
     isLoadingChangelog,
     refetchChangelog,
+    strengthHistory,
   } = useRelationshipEvidence(
     relationshipId,
     canvasId,
@@ -938,6 +940,8 @@ export default function RelationshipSheet({
                     relationship
                   </p>
                 </div>
+
+                <StrengthTrendCard points={strengthHistory} />
 
                 {isLoadingChangelog ? (
                   <div className="text-center py-8 text-gray-500">

--- a/src/features/canvas/components/panels/relationship-panel/StrengthTrendCard.tsx
+++ b/src/features/canvas/components/panels/relationship-panel/StrengthTrendCard.tsx
@@ -1,0 +1,71 @@
+// Strength-trend sparkline for the relationship History tab (relationship
+// intelligence lane, priority 5). Renders the recorded weight-over-time series
+// from relationship_history, coloured by the current sign.
+
+import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
+import { Sparkline } from '@/features/dashboard/components/Sparkline';
+import {
+  summarizeStrengthTrend,
+  toStrengthTrend,
+  type RelationshipHistoryPoint,
+} from '@/shared/lib/supabase/services/relationshipHistory';
+
+export function StrengthTrendCard({
+  points,
+}: {
+  points: RelationshipHistoryPoint[];
+}) {
+  const series = toStrengthTrend(points);
+  const summary = summarizeStrengthTrend(points);
+
+  if (summary.points === 0) {
+    return (
+      <div className="rounded-lg border p-3 text-sm text-gray-500">
+        No strength history yet — change this relationship's strength to start
+        tracking its trend.
+      </div>
+    );
+  }
+
+  const current = summary.current ?? 0;
+  const color = current < 0 ? '#dc2626' : current > 0 ? '#16a34a' : '#6b7280';
+  const Icon =
+    summary.direction === 'up'
+      ? TrendingUp
+      : summary.direction === 'down'
+        ? TrendingDown
+        : Minus;
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-sm font-medium">Strength trend</span>
+        <span className="flex items-center gap-1 text-xs text-gray-600">
+          <Icon className="h-3.5 w-3.5" />
+          {current}
+          {summary.delta != null && summary.points > 1 && (
+            <span className="text-gray-400">
+              ({summary.delta > 0 ? '+' : ''}
+              {summary.delta})
+            </span>
+          )}
+        </span>
+      </div>
+      {series.length >= 2 ? (
+        <Sparkline
+          values={series}
+          color={color}
+          idKey={`rel-strength-${points[0]?.relationshipId ?? 'x'}`}
+          height={40}
+        />
+      ) : (
+        <p className="text-xs text-gray-500">
+          One data point so far — more edits will draw the trend.
+        </p>
+      )}
+      <p className="mt-1 text-[11px] text-gray-500">
+        {summary.points} recorded change{summary.points === 1 ? '' : 's'}
+      </p>
+    </div>
+  );
+}

--- a/src/features/canvas/components/panels/relationship-panel/hooks.ts
+++ b/src/features/canvas/components/panels/relationship-panel/hooks.ts
@@ -13,6 +13,10 @@ import {
   type ChangelogEntry,
 } from '@/shared/lib/supabase/services/changelog';
 import {
+  getRelationshipHistory,
+  type RelationshipHistoryPoint,
+} from '@/shared/lib/supabase/services/relationshipHistory';
+import {
   addTagsToRelationship,
   getRelationshipTags,
   removeTagsFromRelationship,
@@ -115,6 +119,9 @@ export function useRelationshipEvidence(
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [changelog, setChangelog] = useState<ChangelogEntry[]>([]);
   const [isLoadingChangelog, setIsLoadingChangelog] = useState(false);
+  const [strengthHistory, setStrengthHistory] = useState<
+    RelationshipHistoryPoint[]
+  >([]);
 
   const currentProject = projectId ? getProjectById(projectId) : null;
   const relationship = relationshipId
@@ -142,9 +149,24 @@ export function useRelationshipEvidence(
     }
   }, [relationshipId]);
 
+  // Load the strength/confidence trend (audit + sparkline).
+  const loadStrengthHistory = useCallback(async () => {
+    if (!relationshipId) {
+      setStrengthHistory([]);
+      return;
+    }
+    try {
+      setStrengthHistory(await getRelationshipHistory(relationshipId));
+    } catch (error) {
+      console.error('Failed to load relationship strength history:', error);
+      setStrengthHistory([]);
+    }
+  }, [relationshipId]);
+
   useEffect(() => {
     loadChangelog();
-  }, [loadChangelog]);
+    loadStrengthHistory();
+  }, [loadChangelog, loadStrengthHistory]);
 
   const openDialog = useCallback((evidence?: EvidenceItem) => {
     setSelectedEvidence(evidence || null);
@@ -282,5 +304,9 @@ export function useRelationshipEvidence(
     changelog,
     isLoadingChangelog,
     refetchChangelog: loadChangelog,
+
+    // Strength/confidence trend (audit + sparkline)
+    strengthHistory,
+    refetchStrengthHistory: loadStrengthHistory,
   };
 }

--- a/src/shared/lib/supabase/services/relationshipHistory.test.ts
+++ b/src/shared/lib/supabase/services/relationshipHistory.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  summarizeStrengthTrend,
+  toStrengthTrend,
+  type RelationshipHistoryPoint,
+} from './relationshipHistory';
+
+const pt = (weight: number | null, createdAt = ''): RelationshipHistoryPoint => ({
+  id: Math.random().toString(36).slice(2),
+  relationshipId: 'r',
+  projectId: 'p',
+  type: 'Probabilistic',
+  confidence: 'Medium',
+  weight,
+  changedBy: 'u',
+  createdAt,
+});
+
+describe('toStrengthTrend', () => {
+  it('extracts the weight series, dropping null-weight snapshots', () => {
+    expect(toStrengthTrend([pt(10), pt(null), pt(30), pt(25)])).toEqual([10, 30, 25]);
+  });
+  it('is empty when no snapshot recorded a strength', () => {
+    expect(toStrengthTrend([pt(null), pt(null)])).toEqual([]);
+  });
+});
+
+describe('summarizeStrengthTrend', () => {
+  it('reports first/current/delta and an upward direction', () => {
+    const s = summarizeStrengthTrend([pt(10), pt(20), pt(35)]);
+    expect(s).toMatchObject({ points: 3, first: 10, current: 35, delta: 25, direction: 'up' });
+  });
+  it('detects a downward move', () => {
+    expect(summarizeStrengthTrend([pt(50), pt(20)]).direction).toBe('down');
+  });
+  it('flat when unchanged or single point', () => {
+    expect(summarizeStrengthTrend([pt(40)]).direction).toBe('flat');
+    expect(summarizeStrengthTrend([pt(40), pt(40)]).direction).toBe('flat');
+  });
+  it('none when there is no strength history', () => {
+    expect(summarizeStrengthTrend([pt(null)])).toMatchObject({ points: 0, direction: 'none', current: null });
+  });
+});

--- a/src/shared/lib/supabase/services/relationshipHistory.ts
+++ b/src/shared/lib/supabase/services/relationshipHistory.ts
@@ -1,0 +1,105 @@
+// Relationship history — strength/confidence/type snapshots over time for the
+// audit trail + strength-trend sparkline. One row per relationship edit; the
+// weight snapshots power the trend. See migration 20260712120000.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
+import type { Database } from '../types';
+
+type Client = SupabaseClient<Database>;
+type Row = Database['public']['Tables']['relationship_history']['Row'];
+
+const COLS =
+  'id, relationship_id, project_id, type, confidence, weight, changed_by, created_at';
+
+export interface RelationshipHistoryPoint {
+  id: string;
+  relationshipId: string;
+  projectId: string | null;
+  type: string | null;
+  confidence: string | null;
+  weight: number | null;
+  changedBy: string;
+  createdAt: string;
+}
+
+function rowToPoint(r: Row): RelationshipHistoryPoint {
+  return {
+    id: r.id,
+    relationshipId: r.relationship_id,
+    projectId: r.project_id,
+    type: r.type,
+    confidence: r.confidence,
+    weight: r.weight,
+    changedBy: r.changed_by,
+    createdAt: r.created_at,
+  };
+}
+
+/** Record a snapshot of a relationship's strength/confidence/type at edit time. */
+export async function appendRelationshipHistory(
+  input: {
+    relationshipId: string;
+    projectId?: string | null;
+    type?: string | null;
+    confidence?: string | null;
+    weight?: number | null;
+  },
+  client?: Client
+): Promise<void> {
+  const c = resolveClient(client);
+  const { error } = await c.from('relationship_history').insert({
+    relationship_id: input.relationshipId,
+    project_id: input.projectId ?? null,
+    type: input.type ?? null,
+    confidence: input.confidence ?? null,
+    weight: input.weight ?? null,
+  });
+  if (error) throw new Error(error.message);
+}
+
+/** All snapshots for a relationship, oldest → newest. */
+export async function getRelationshipHistory(
+  relationshipId: string,
+  client?: Client
+): Promise<RelationshipHistoryPoint[]> {
+  const c = resolveClient(client);
+  const { data, error } = await c
+    .from('relationship_history')
+    .select(COLS)
+    .eq('relationship_id', relationshipId)
+    .order('created_at', { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((r) => rowToPoint(r as Row));
+}
+
+/** The weight series (points that recorded a strength), oldest → newest. */
+export function toStrengthTrend(points: RelationshipHistoryPoint[]): number[] {
+  return points
+    .filter((p) => typeof p.weight === 'number')
+    .map((p) => p.weight as number);
+}
+
+export interface StrengthTrendSummary {
+  points: number;
+  first: number | null;
+  current: number | null;
+  delta: number | null;
+  direction: 'up' | 'down' | 'flat' | 'none';
+}
+
+/** Compact summary of how a relationship's strength has moved over its history. */
+export function summarizeStrengthTrend(
+  points: RelationshipHistoryPoint[]
+): StrengthTrendSummary {
+  const series = toStrengthTrend(points);
+  if (series.length === 0) {
+    return { points: 0, first: null, current: null, delta: null, direction: 'none' };
+  }
+  const first = series[0];
+  const current = series[series.length - 1];
+  const delta = Number((current - first).toFixed(2));
+  const direction =
+    series.length < 2 || delta === 0 ? 'flat' : delta > 0 ? 'up' : 'down';
+  return { points: series.length, first, current, delta, direction };
+}

--- a/src/shared/lib/supabase/services/relationships.ts
+++ b/src/shared/lib/supabase/services/relationships.ts
@@ -10,6 +10,7 @@ import {
 } from '@/shared/lib/validation/zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { resolveClient } from '@/shared/utils/authenticatedClient';
+import { appendRelationshipHistory } from './relationshipHistory';
 import type { EvidenceItem, Relationship } from '../../types';
 import type {
   Database,
@@ -138,6 +139,23 @@ export async function updateRelationship(
   if (error) {
     console.error('Error updating relationship:', error);
     throw error;
+  }
+
+  // Record a strength/confidence/type snapshot for the audit trail + trend.
+  // Best-effort: never fail the update if history can't be written.
+  try {
+    await appendRelationshipHistory(
+      {
+        relationshipId: id,
+        projectId: data.project_id,
+        type: data.type,
+        confidence: data.confidence,
+        weight: data.weight,
+      },
+      client
+    );
+  } catch (historyError) {
+    console.error('Failed to record relationship history:', historyError);
   }
 
   return transformRelationship(data);

--- a/src/shared/lib/supabase/types.ts
+++ b/src/shared/lib/supabase/types.ts
@@ -1414,6 +1414,54 @@ export type Database = {
           },
         ]
       }
+      relationship_history: {
+        Row: {
+          changed_by: string
+          confidence: string | null
+          created_at: string
+          id: string
+          project_id: string | null
+          relationship_id: string
+          type: string | null
+          weight: number | null
+        }
+        Insert: {
+          changed_by?: string
+          confidence?: string | null
+          created_at?: string
+          id?: string
+          project_id?: string | null
+          relationship_id: string
+          type?: string | null
+          weight?: number | null
+        }
+        Update: {
+          changed_by?: string
+          confidence?: string | null
+          created_at?: string
+          id?: string
+          project_id?: string | null
+          relationship_id?: string
+          type?: string | null
+          weight?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "relationship_history_relationship_id_fkey"
+            columns: ["relationship_id"]
+            isOneToOne: false
+            referencedRelation: "relationships"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "relationship_history_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       relationships: {
         Row: {
           id: string

--- a/supabase/migrations/20260712120000_relationship_history.sql
+++ b/supabase/migrations/20260712120000_relationship_history.sql
@@ -1,0 +1,38 @@
+-- =====================================================================
+-- RELATIONSHIP HISTORY — strength/confidence/type snapshots over time, for the
+-- relationship audit trail + strength-trend sparkline (relationship intelligence
+-- lane, priority 5). One row per relationship edit; weight snapshots power the
+-- trend. Project-scoped RLS (mirrors relationships via has_project_access), with
+-- a creator fallback so history on legacy null-project relationships still works.
+-- =====================================================================
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.relationship_history (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  relationship_id uuid NOT NULL REFERENCES public.relationships(id) ON DELETE CASCADE,
+  project_id      uuid REFERENCES public.projects(id) ON DELETE CASCADE,
+  type            text,
+  confidence      text,
+  weight          double precision,
+  changed_by      text NOT NULL DEFAULT public.requesting_user_id(),
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.relationship_history ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS relationship_history_select ON public.relationship_history;
+CREATE POLICY relationship_history_select ON public.relationship_history
+  FOR SELECT USING (
+    public.has_project_access(project_id, false)
+    OR changed_by = public.requesting_user_id()
+  );
+
+-- Append-only: you may only record your own edits; reads are gated above.
+DROP POLICY IF EXISTS relationship_history_insert ON public.relationship_history;
+CREATE POLICY relationship_history_insert ON public.relationship_history
+  FOR INSERT WITH CHECK (changed_by = public.requesting_user_id());
+
+CREATE INDEX IF NOT EXISTS idx_relationship_history_rel
+  ON public.relationship_history(relationship_id, created_at);
+
+COMMIT;


### PR DESCRIPTION
Closes **CVS-244** (relationship intelligence lane, **priority 5** — audit trail + strength trend). A focused slice of CVS-161's history scope that avoids the full sheet redesign.

## What
Relationship strength/confidence changes are now **durable and inspectable over time**.

- **`relationship_history`** table (project-scoped RLS via `has_project_access` + creator fallback), append-only.
- **`services/relationshipHistory.ts`** — `appendRelationshipHistory` / `getRelationshipHistory` + pure `toStrengthTrend` / `summarizeStrengthTrend`.
- **`updateRelationship`** records a snapshot on every save (best-effort — never fails the edit).
- Relationship sheet **History/Audit tab** gains a **strength-trend sparkline** (weight over time, coloured by sign) + summary (current, delta, direction, # changes), above the existing changelog audit.

## Verification
- `type-check` ✅ · `lint` ✅ · **full vitest 260/260** ✅ — 6 unit tests for the trend helpers.
- ⚠️ **Migration not applied to prod** — owner applies `20260712120000_relationship_history.sql` (per the manual test).

Independent of the CVS-165 edge PR (#99) — different files, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)