### PR TITLE
fix(canvas): stop React #185 loop from portal-container context churn (CVS-65)

### DIFF
--- a/src/shared/contexts/PortalContainerContext.tsx
+++ b/src/shared/contexts/PortalContainerContext.tsx
@@ -10,8 +10,15 @@ export function PortalContainerProvider({
   container,
   children,
 }: React.PropsWithChildren<{ container?: HTMLElement | null }>) {
+  // Memoize the context value so it's a STABLE reference when `container` is
+  // unchanged. Without this, every render handed consumers a new `{ container }`
+  // object, so open dropdown/dialog/popover content (which portals INTO the
+  // ReactFlow container) re-rendered on every canvas render — inside ReactFlow
+  // that churned node dimensions → controlled-nodes update → re-render → React
+  // #185 "Maximum update depth exceeded" (CVS-23/65).
+  const value = React.useMemo(() => ({ container }), [container]);
   return (
-    <PortalContainerContext.Provider value={{ container }}>
+    <PortalContainerContext.Provider value={value}>
       {children}
     </PortalContainerContext.Provider>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
     host: "0.0.0.0"
   },
   build: {
+    // 'hidden' sourcemaps: emit .map files (so React #185 / error_reports stacks
+    // can be decoded to real component + line) WITHOUT a sourceMappingURL comment,
+    // so browsers don't auto-load them and source isn't exposed to users. See the
+    // recurring canvas #185 crash (CVS-23/65) — minified stacks were undecodable.
+    sourcemap: "hidden",
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
**Root cause found (decoded, not guessed).** Pulled a fresh #185 stack + fetched the deployed bundle to decode the minified frames: the throwing component is a **Radix `DropdownMenuContent`** portaled into the ReactFlow container via `PortalContainerContext`.

`PortalContainerProvider` created a **new `value={{ container }}` object on every render**, so every `usePortalContainer` consumer — the open dropdown/dialog/popover **portaled into the ReactFlow container** — re-rendered on every canvas render. Re-rendering that content inside ReactFlow churns node dimensions → controlled-nodes update → re-render → **"Maximum update depth exceeded" (#185)**. Repro: *edit evidence → back to canvas* (store change re-renders the canvas with a dropdown mounted).

## Fix
- **Memoize the context value** on `container` (stable once ReactFlow mounts) — consumers now re-render only on a real container change. Also protects dialog + popover (same context).
- **Enable `build.sourcemap: 'hidden'`** — future `error_reports` stacks decode to real component + line (undecodable before; this is how I found it).

This supersedes the interim churn hardening (PR #89) as the actual root fix.

## Verification
type-check ✓, lint ✓, full build ✓ (+ 9 sourcemaps emitted). Runtime confirmation is the manual test — this is the #185 the user is hitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)