### PR TITLE
feat(cvs-248): public share + embed for evidence items

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import WorkspaceSettingsPage from './features/settings/pages/WorkspaceSettingsPa
 import AccountSettingsPage from './features/settings/pages/AccountSettingsPage';
 import ConnectAgentPage from './features/settings/pages/ConnectAgentPage';
 import EmbedCanvasPage from './features/canvas/pages/EmbedCanvasPage';
+import EmbedEvidencePage from './features/evidence/pages/EmbedEvidencePage';
 import HomePage from './features/projects/pages/HomePage';
 
 // Auth Pages
@@ -84,6 +85,10 @@ export default function App() {
 
                 {/* Public read-only embed (no auth — RLS gates by is_public) */}
                 <Route path="/embed/:canvasId" element={<EmbedCanvasPage />} />
+                <Route
+                  path="/embed/evidence/:evidenceId"
+                  element={<EmbedEvidencePage />}
+                />
 
                 {/* Protected routes */}
                 <Route

--- a/src/features/evidence/pages/EmbedEvidencePage.tsx
+++ b/src/features/evidence/pages/EmbedEvidencePage.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Loader2, ShieldOff } from 'lucide-react';
+import { getEvidenceItemById } from '@/shared/lib/supabase/services/evidence';
+import EvidenceContentRenderer from '@/features/evidence/components/EvidenceContentRenderer';
+import type { EvidenceItem } from '@/shared/types';
+
+// Read-only, public embed of a single evidence item (for Notion/Confluence/
+// iframe). No auth — the anon Supabase client + RLS only return the item when
+// it is is_public (see setEvidencePublic + the evidence_public_share migration).
+export default function EmbedEvidencePage() {
+  const { evidenceId } = useParams();
+  const [status, setStatus] = useState<'loading' | 'ok' | 'missing'>('loading');
+  const [evidence, setEvidence] = useState<EvidenceItem | null>(null);
+
+  useEffect(() => {
+    if (!evidenceId) return;
+    let cancelled = false;
+    // No client passed → anon client; RLS returns it only when is_public.
+    getEvidenceItemById(evidenceId)
+      .then((item) => {
+        if (cancelled) return;
+        if (!item) {
+          setStatus('missing');
+          return;
+        }
+        setEvidence(item);
+        setStatus('ok');
+      })
+      .catch(() => !cancelled && setStatus('missing'));
+    return () => {
+      cancelled = true;
+    };
+  }, [evidenceId]);
+
+  if (status === 'loading') {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-white">
+        <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  if (status === 'missing' || !evidence) {
+    return (
+      <div className="flex h-screen w-screen flex-col items-center justify-center gap-3 bg-white px-6 text-center">
+        <ShieldOff className="h-8 w-8 text-gray-300" />
+        <p className="text-sm text-gray-500">
+          This evidence isn't shared publicly.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen w-screen overflow-y-auto bg-white">
+      <div className="mx-auto max-w-3xl px-6 py-8">
+        <header className="mb-6 border-b pb-4">
+          <div className="mb-1 flex flex-wrap items-center gap-2 text-xs text-gray-500">
+            <span className="rounded bg-gray-100 px-1.5 py-0.5 font-medium">
+              {evidence.type}
+            </span>
+            {evidence.date && <span>{evidence.date}</span>}
+            {evidence.owner && <span>· {evidence.owner}</span>}
+          </div>
+          <h1 className="text-xl font-semibold text-gray-900">
+            {evidence.title || 'Untitled evidence'}
+          </h1>
+          {evidence.hypothesis && (
+            <p className="mt-1 text-sm text-gray-600">{evidence.hypothesis}</p>
+          )}
+        </header>
+
+        <EvidenceContentRenderer evidence={evidence} />
+
+        {evidence.link && (
+          <a
+            href={evidence.link}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-6 inline-block text-sm text-primary hover:underline"
+          >
+            View source ↗
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/evidence/pages/EvidenceRepositoryPage.tsx
+++ b/src/features/evidence/pages/EvidenceRepositoryPage.tsx
@@ -47,6 +47,7 @@ import {
   Filter,
   FlaskConical,
   Globe,
+  Lock,
   MoreVertical,
   Plus,
   Search,
@@ -59,8 +60,12 @@ import { Link, useParams } from 'react-router-dom';
 import EvidenceEditor from '../components/EvidenceEditor';
 import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
 import { useAppStore } from '@/shared/stores/useAppStore';
-import { createProjectEvidence } from '@/shared/lib/supabase/services/evidence';
+import {
+  createProjectEvidence,
+  setEvidencePublic,
+} from '@/shared/lib/supabase/services/evidence';
 import { updateEvidenceItem } from '@/shared/lib/supabase/services/relationships';
+import { toast } from 'sonner';
 
 const evidenceTypeOptions = [
   { value: 'Experiment', icon: FlaskConical, variant: 'blue' },
@@ -251,6 +256,29 @@ export default function EvidenceRepositoryPage() {
     }
   };
 
+  // Publish an evidence item read-only and copy its public/embed link.
+  const handleShareEvidence = async (evidence: EvidenceItem) => {
+    if (!client) return;
+    try {
+      await setEvidencePublic(evidence.id, true, client);
+      const url = `${window.location.origin}/embed/evidence/${evidence.id}`;
+      await navigator.clipboard.writeText(url);
+      toast.success('Public link copied — anyone with it can view this evidence');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to share evidence');
+    }
+  };
+
+  const handleUnshareEvidence = async (evidence: EvidenceItem) => {
+    if (!client) return;
+    try {
+      await setEvidencePublic(evidence.id, false, client);
+      toast.success('Evidence is now private');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update sharing');
+    }
+  };
+
   const handleViewInCanvas = (e: EvidenceItem) => {
     // Prefer nested canvas route if available
     const canvasId = canvas?.id;
@@ -434,6 +462,18 @@ export default function EvidenceRepositoryPage() {
                             <ExternalLink className="mr-2 h-4 w-4" />
                             Open Full Page
                           </Link>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => handleShareEvidence(evidence)}
+                        >
+                          <Globe className="mr-2 h-4 w-4" />
+                          Share &amp; copy link
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => handleUnshareEvidence(evidence)}
+                        >
+                          <Lock className="mr-2 h-4 w-4" />
+                          Make private
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onClick={() => handleDuplicateEvidence(evidence)}

--- a/src/shared/lib/supabase/services/evidence.ts
+++ b/src/shared/lib/supabase/services/evidence.ts
@@ -21,8 +21,27 @@ function rowToEvidence(row: Tables<'evidence_items'>): EvidenceItem {
     hypothesis: row.hypothesis || undefined,
     summary: row.summary,
     impactOnConfidence: row.impact_on_confidence || undefined,
+    isPublic: row.is_public ?? false,
     content: (row.content as EvidenceItem['content']) ?? undefined,
   };
+}
+
+/**
+ * Toggle an evidence item's public read-only share. When on, anyone with the
+ * link can view it at /embed/evidence/:id (RLS: is_public disjunct). Writes stay
+ * project-access gated, so only editors can flip this.
+ */
+export async function setEvidencePublic(
+  id: string,
+  isPublic: boolean,
+  client?: Client
+): Promise<void> {
+  const c = resolveClient(client);
+  const { error } = await c
+    .from('evidence_items')
+    .update({ is_public: isPublic })
+    .eq('id', id);
+  if (error) throw new Error(error.message);
 }
 
 /** Evidence attached to a metric card, newest first. */

--- a/src/shared/lib/supabase/types.ts
+++ b/src/shared/lib/supabase/types.ts
@@ -1005,6 +1005,7 @@ export type Database = {
           hypothesis: string | null
           id: string
           impact_on_confidence: string | null
+          is_public: boolean
           link: string | null
           owner_id: string | null
           project_id: string | null
@@ -1023,6 +1024,7 @@ export type Database = {
           hypothesis?: string | null
           id?: string
           impact_on_confidence?: string | null
+          is_public?: boolean
           link?: string | null
           owner_id?: string | null
           project_id?: string | null
@@ -1041,6 +1043,7 @@ export type Database = {
           hypothesis?: string | null
           id?: string
           impact_on_confidence?: string | null
+          is_public?: boolean
           link?: string | null
           owner_id?: string | null
           project_id?: string | null

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -192,6 +192,8 @@ export interface EvidenceItem {
   hypothesis?: string;
   summary: string;
   impactOnConfidence?: string;
+  /** Public read-only share (see setEvidencePublic + /embed/evidence/:id). */
+  isPublic?: boolean;
   createdAt?: string;
   createdBy?: string;
   updatedAt?: string;

--- a/supabase/migrations/20260713120000_evidence_public_share.sql
+++ b/supabase/migrations/20260713120000_evidence_public_share.sql
@@ -1,0 +1,27 @@
+-- =====================================================================
+-- EVIDENCE PUBLIC SHARE — let a single evidence item be shared publicly (read-
+-- only) independent of its parent project's visibility, for /embed/evidence/:id
+-- (Notion/Confluence/iframe). Mirrors projects.is_public. Relationship+evidence
+-- lane, priority 6. Adds an `is_public = true` disjunct to the SELECT policy so
+-- the anon role can read a shared item; writes remain project-access gated.
+-- =====================================================================
+BEGIN;
+
+ALTER TABLE public.evidence_items
+  ADD COLUMN IF NOT EXISTS is_public boolean NOT NULL DEFAULT false;
+
+DROP POLICY IF EXISTS evidence_items_select ON public.evidence_items;
+CREATE POLICY evidence_items_select ON public.evidence_items
+  FOR SELECT TO anon, authenticated
+  USING (
+    is_public = true
+    OR public.can_view_project(
+      COALESCE(
+        project_id,
+        (SELECT r.project_id FROM public.relationships r
+          WHERE r.id = evidence_items.relationship_id)
+      )
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
Closes **CVS-248** (relationship + evidence lane, **priority 6**). Mirrors the canvas `is_public` + `/embed/:canvasId` pattern for a single evidence item.

## What
- **DB:** `evidence_items.is_public` + an `is_public = true` disjunct on `evidence_items_select` (anon can read a shared item); writes stay project-access gated.
- **Service:** `setEvidencePublic(id, isPublic)`; `rowToEvidence` maps `isPublic`.
- **Public viewer:** `/embed/evidence/:evidenceId` → **`EmbedEvidencePage`** — full-screen, **anon** load, read-only `EvidenceContentRenderer` (renders the EditorJS notebook), "This evidence isn't shared publicly" fallback. Route sits outside the auth shell, sibling to `/embed/:canvasId`.
- **Share UI:** evidence repository card menu → **"Share & copy link"** (publishes + copies `/embed/evidence/:id`) and **"Make private"**.

## Verification
- `type-check` ✅ · `lint` ✅ (0 new) · **full vitest 255/255** ✅.
- ⚠️ **Migration not applied to prod** — owner applies `20260713120000_evidence_public_share.sql` (per the manual test), which the public route needs.

Independent of the other lane PRs (#99 edges, #101 history) — different files. Read-only public snapshot only (no tokens/expiry; not the editable view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)