### PR TITLE
chore(e2e): Playwright + Clerk-testing visual verification harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ skills-lock.json
 
 # Supabase CLI local link state
 supabase/.temp/
+
+# Playwright visual verification (CVS-156 fallout — self-verify UI)
+/test-results/
+/playwright-report/
+/e2e/screenshots/

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,15 @@
+import { clerkSetup } from '@clerk/testing/playwright';
+
+// Fetches a Clerk Testing Token (using CLERK_SECRET_KEY) so headless sign-in
+// bypasses bot protection. Runs once before the suite.
+export default async function globalSetup() {
+  if (!process.env.CLERK_SECRET_KEY) {
+    console.warn(
+      '[e2e] CLERK_SECRET_KEY not set — sign-in specs will be skipped.'
+    );
+    return;
+  }
+  await clerkSetup({
+    publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+  });
+}

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -1,0 +1,37 @@
+import { clerk, setupClerkTestingToken } from '@clerk/testing/playwright';
+import { test } from '@playwright/test';
+
+const EMAIL = process.env.E2E_TEST_EMAIL;
+const PASSWORD = process.env.E2E_TEST_PASSWORD;
+
+// Authenticated workspace routes to capture. Add more as surfaces land.
+const ROUTES = [
+  { path: '/', name: 'home' },
+  { path: '/?view=explore', name: 'home-explore' },
+  { path: '/catalog', name: 'catalog' },
+  { path: '/feed', name: 'feed' },
+];
+
+test('capture workspace routes', async ({ page }) => {
+  test.skip(
+    !process.env.CLERK_SECRET_KEY || !EMAIL || !PASSWORD,
+    'Set CLERK_SECRET_KEY, E2E_TEST_EMAIL and E2E_TEST_PASSWORD in .env'
+  );
+
+  await setupClerkTestingToken({ page });
+  await page.goto('/'); // loads Clerk (redirects to sign-in when signed out)
+  await clerk.signIn({
+    page,
+    signInParams: { strategy: 'password', identifier: EMAIL!, password: PASSWORD! },
+  });
+
+  for (const r of ROUTES) {
+    await page.goto(r.path);
+    await page.waitForLoadState('networkidle').catch(() => {});
+    await page.waitForTimeout(600); // let the rail + cards settle
+    await page.screenshot({
+      path: `e2e/screenshots/${r.name}.png`,
+      fullPage: true,
+    });
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,9 @@
         "zustand": "^5.0.7"
       },
       "devDependencies": {
+        "@clerk/testing": "^2.2.2",
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.1.11",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
@@ -377,6 +379,100 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@clerk/testing": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.2.2.tgz",
+      "integrity": "sha512-QrPBMMzncjj2zxnMYyUkLqPrwGQMoZCH3tobr66b1OgCc0LKQnGrBj98aXugvXMMeZAGKc10sdbwZpiG513cfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.10.0",
+        "@clerk/shared": "^4.23.0",
+        "dotenv": "17.2.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1",
+        "cypress": "^13 || ^14 || ^15"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "cypress": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing/node_modules/@clerk/backend": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.10.0.tgz",
+      "integrity": "sha512-+No8bg+3SQ76zfu199l4lwpi3z+RqmO8N33CDXPkAnhXt6cAZu4HPT0WvZ/GDpbi7ZqpDmmP9yXpCQNGwEd0+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.23.0",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/testing/node_modules/@clerk/shared": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.23.0.tgz",
+      "integrity": "sha512-v4roxB9AwEVq56luLc9MtQ+RkVR66XZJGAfTbQXD0ArdW+fs1P/FhlKwm6OQfvDFNiCCVZA6GoP648t9dGtfrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing/node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@clerk/testing/node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@clerk/themes": {
@@ -1652,6 +1748,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -9407,6 +9519,38 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "husky",
     "test": "vitest",
     "test:rls": "tsx src/tests/run-rls-tests.ts",
+    "screenshots": "playwright test",
     "sync:errors": "node scripts/sync-error-reports.mjs",
     "sync:userback": "node scripts/sync-userback.mjs"
   },
@@ -126,7 +127,9 @@
     "zustand": "^5.0.7"
   },
   "devDependencies": {
+    "@clerk/testing": "^2.2.2",
     "@eslint/js": "^9.32.0",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.1.11",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { defineConfig, devices } from '@playwright/test';
+
+// Load .env into the Playwright (node) process — Vite loads it for the app, but
+// the runner + clerkSetup need CLERK_SECRET_KEY / E2E_* (which are NOT VITE_-
+// prefixed, so they never reach import.meta.env). Values stay server-side.
+try {
+  for (const line of readFileSync('.env', 'utf8').split('\n')) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (m && !process.env[m[1]])
+      process.env[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+} catch {
+  /* no .env in this checkout — env may be injected directly */
+}
+// @clerk/testing expects CLERK_PUBLISHABLE_KEY; the app stores it VITE_-prefixed.
+if (!process.env.CLERK_PUBLISHABLE_KEY && process.env.VITE_CLERK_PUBLISHABLE_KEY)
+  process.env.CLERK_PUBLISHABLE_KEY = process.env.VITE_CLERK_PUBLISHABLE_KEY;
+
+export default defineConfig({
+  testDir: './e2e',
+  globalSetup: './e2e/global-setup.ts',
+  timeout: 90_000,
+  fullyParallel: false,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    viewport: { width: 1440, height: 900 },
+  },
+  projects: [
+    {
+      name: 'chrome',
+      // Use the system Google Chrome (installed) instead of downloading Chromium.
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
Lets me screenshot UI routes before merging (the app-shell shipped broken because I couldn't see it render). Playwright via system Chrome + `@clerk/testing` testing-token headless sign-in. Needs `CLERK_SECRET_KEY` + `E2E_TEST_EMAIL`/`E2E_TEST_PASSWORD` (dedicated test account) in `.env`. Excluded from vitest/tsc; e2e lints clean.