### PR TITLE
CVS-163 (slice 1): Filter Canvas owner IDs → codenames

### DIFF
--- a/src/features/canvas/components/mini-control/FilterControls.tsx
+++ b/src/features/canvas/components/mini-control/FilterControls.tsx
@@ -13,10 +13,17 @@ import {
 import { Input } from '@/shared/components/ui/input';
 import { Label } from '@/shared/components/ui/label';
 import type { MetricCard as MetricCardType } from '@/shared/types';
+import { userCodename } from '@/shared/utils/codename';
 import { Calendar, Filter, RefreshCw, Search } from 'lucide-react';
 import { useState } from 'react';
 
 type CardCategory = MetricCardType['category'];
+
+// Never show a raw Clerk id (`user_…`) as an owner — resolve it to the same
+// stable pseudonymous codename comments use (CVS-33). Real name strings (which
+// don't start with `user_`) pass through unchanged so they aren't hashed away.
+const ownerLabel = (owner: string): string =>
+  /^user_/.test(owner) ? userCodename(owner) : owner;
 
 interface FilterState {
   searchTerm: string;
@@ -259,7 +266,7 @@ export default function FilterControls() {
                     className="cursor-pointer"
                     onClick={() => handleOwnerToggle(owner)}
                   >
-                    {owner}
+                    {ownerLabel(owner)}
                   </Badge>
                 ))}
               </div>


### PR DESCRIPTION
Slice 1 of CVS-163 — AC #2 (no raw owner IDs). Owner chips resolve `user_…` ids through the shared `userCodename` util (guarded so real names pass through). Text-only change, no layout risk. Compact-popover redesign = slice 2 (needs browser verification via the e2e harness). type-check · 0 lint · 255 tests.