### PR TITLE
feat(canvas): wire node-toolbar view/edit/settings/copy actions (CVS-135)

### DIFF
--- a/src/features/canvas/components/nodes/shared/EnhancedNodeToolbar.tsx
+++ b/src/features/canvas/components/nodes/shared/EnhancedNodeToolbar.tsx
@@ -268,25 +268,44 @@ export default function EnhancedNodeToolbar({
 
 // Helper hook for common node toolbar actions
 export function useNodeToolbarActions(nodeId: string, nodeType: string) {
+  // view / edit / settings open the node's settings-and-detail sheet. That sheet
+  // lives in page-local CanvasPage state, so this decoupled hook bridges to it via
+  // a window CustomEvent CanvasPage listens for — no per-node JSX plumbing (CVS-135,
+  // follow-up to CVS-67). settings requests the "settings" tab; view/edit open the
+  // sheet as-is (it contains both).
+  const openSettingsSheet = React.useCallback(
+    (tab?: string) => {
+      window.dispatchEvent(
+        new CustomEvent('canvas:open-node-settings', {
+          detail: { nodeId, tab },
+        })
+      );
+    },
+    [nodeId]
+  );
+
   const handleView = React.useCallback(() => {
-    console.log(`👁️ View ${nodeType} node:`, nodeId);
-    // Implement view logic
-  }, [nodeId, nodeType]);
+    openSettingsSheet();
+  }, [openSettingsSheet]);
 
   const handleEdit = React.useCallback(() => {
-    console.log(`✏️ Edit ${nodeType} node:`, nodeId);
-    // Implement edit logic
-  }, [nodeId, nodeType]);
+    openSettingsSheet();
+  }, [openSettingsSheet]);
 
   const handleSettings = React.useCallback(() => {
-    console.log(`⚙️ Settings for ${nodeType} node:`, nodeId);
-    // This will be connected to the settings sheets
-  }, [nodeId, nodeType]);
+    openSettingsSheet('settings');
+  }, [openSettingsSheet]);
 
   const handleCopy = React.useCallback(() => {
-    console.log(`📋 Copy ${nodeType} node:`, nodeId);
-    // Implement copy logic
-  }, [nodeId, nodeType]);
+    // Duplicate through the store (offset copy) — the same action used elsewhere on
+    // the canvas; it persists via the canvas autosave. Was a console.log stub.
+    try {
+      useCanvasStore.getState().duplicateNode(nodeId);
+    } catch (e) {
+      console.error('Toolbar duplicate failed:', e);
+      toast.error('Failed to duplicate');
+    }
+  }, [nodeId]);
 
   const handleDelete = React.useCallback(() => {
     // The per-node toolbar delete was a no-op stub (CVS-61). Wire it to the real

--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -693,6 +693,27 @@ function CanvasPageInner() {
     ]
   );
 
+  // Bridge for the per-node toolbar's view/edit/settings actions (CVS-135). Those
+  // live in the decoupled `useNodeToolbarActions` hook, which can't reach this
+  // page-local settings-sheet state — so it dispatches a window CustomEvent and we
+  // open the sheet here (switching to the requested tab when one is given).
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as
+        | { nodeId?: string; tab?: string }
+        | undefined;
+      if (!detail?.nodeId) return;
+      if (detail.tab) {
+        stableHandleSwitchToCard(detail.nodeId, detail.tab);
+      } else {
+        stableHandleOpenSettingsSheet(detail.nodeId);
+      }
+    };
+    window.addEventListener('canvas:open-node-settings', handler);
+    return () =>
+      window.removeEventListener('canvas:open-node-settings', handler);
+  }, [stableHandleOpenSettingsSheet, stableHandleSwitchToCard]);
+
   const stableHandleToggleCollapse = useCallback((groupId: string) => {
     log.debug('📁 Toggle collapse for group:', groupId);
     // Update group collapse state in canvas


### PR DESCRIPTION
Follow-up to CVS-67. The per-node floating toolbar's **view / edit / settings / copy** were `console.log` stubs (only *delete* was wired, in CVS-61). This makes them functional.

## What's wired
- **copy** → `useCanvasStore.duplicateNode(nodeId)` — offset duplicate, persists via the canvas autosave.
- **view / edit / settings** → open the node's settings-and-detail sheet. The sheet is page-local `CanvasPage` state, so the decoupled `useNodeToolbarActions` hook dispatches a `canvas:open-node-settings` CustomEvent that `CanvasPage` listens for and routes to its existing `handleOpenSettingsSheet` / `switchToCard` handlers (settings → the "settings" tab). No per-node JSX plumbing — works for metric / value / action / hypothesis toolbars uniformly.

## Deferred (still on CVS-135)
Migrating MetricCard's own ~9-icon toolbar + the comment/source/chart/whiteboard toolbars to the capability manifest, the richer comment/chart/data/connect/resolve actions, and removing `@ts-nocheck` (coordinate with the type-debt sweep, CVS-64/72).

## Verification
type-check ✓ (CanvasPage is not @ts-nocheck — the bridge is type-checked), lint ✓ (0 new errors), manifest tests 5/5 ✓, full build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)