### PR TITLE
feat(cvs-254): first-class Exploratory relationship type (loose links)

### DIFF
--- a/src/features/canvas/constants/relationshipTypeMeta.test.ts
+++ b/src/features/canvas/constants/relationshipTypeMeta.test.ts
@@ -60,6 +60,15 @@ describe('getRelationshipEdgeStyle', () => {
     const strong = getRelationshipEdgeStyle('Causal', 90, 'High').strokeWidth;
     expect(strong).toBeGreaterThan(weak);
   });
+
+  it('exploratory links read loose: neutral, dashed, dim — even with a strong weight', () => {
+    const s = getRelationshipEdgeStyle('Exploratory', 90, 'High');
+    expect(s.tone).toBe('neutral');
+    expect(s.stroke).toBe('#9ca3af'); // neutral gray, never strength-coloured
+    expect(s.loose).toBe(true);
+    expect(s.strokeDasharray).toBeTruthy();
+    expect(s.opacity).toBeLessThan(1); // dimmer than a validated link
+  });
 });
 
 describe('getRelationshipStroke (delegates to edge style)', () => {

--- a/src/features/canvas/constants/relationshipTypeMeta.ts
+++ b/src/features/canvas/constants/relationshipTypeMeta.ts
@@ -11,7 +11,14 @@
  * The `tooltip` copy is kept in sync with docs/reference/metric-tree-methodology.md
  * (components vs. influences). It powers the in-app `(!)` InfoHint.
  */
-import { ArrowRight, Layers, Network, TrendingUp, Zap } from 'lucide-react';
+import {
+  ArrowRight,
+  CircleDashed,
+  Layers,
+  Network,
+  TrendingUp,
+  Zap,
+} from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import type { ConfidenceLevel, RelationshipType } from '@/shared/types';
 
@@ -123,6 +130,24 @@ export const RELATIONSHIP_TYPE_META: Record<
     showWeightButton: false,
     defaultWeightLabel: '1.0',
   },
+  Exploratory: {
+    value: 'Exploratory',
+    label: 'Exploratory',
+    icon: CircleDashed,
+    description: 'Loose / inferred — not yet validated',
+    tooltip:
+      'A loose, exploratory link: you suspect a relationship but have not yet validated its type, direction, or strength. Firm it up later with evidence and a concrete type (correlation, causal, …).',
+    layer: 'influence',
+    textColor: 'text-amber-700',
+    bgColor: 'bg-amber-50',
+    borderColor: 'border-amber-300',
+    hoverBg: 'hover:bg-amber-100',
+    baseStroke: GRAY,
+    strokeByWeight: false,
+    lineStyle: 'dotted',
+    showWeightButton: false,
+    defaultWeightLabel: '?',
+  },
 };
 
 /** Fallback used when a relationship has an unknown/empty type. */
@@ -150,6 +175,7 @@ export const RELATIONSHIP_TYPE_LIST: RelationshipTypeMeta[] = [
   RELATIONSHIP_TYPE_META.Probabilistic,
   RELATIONSHIP_TYPE_META.Causal,
   RELATIONSHIP_TYPE_META.Compositional,
+  RELATIONSHIP_TYPE_META.Exploratory,
 ];
 
 export function getRelationshipTypeMeta(
@@ -213,6 +239,19 @@ export function getRelationshipEdgeStyle(
   confidence?: ConfidenceLevel | string
 ): RelationshipEdgeStyle {
   const meta = getRelationshipTypeMeta(type);
+
+  // Exploratory links read as loose/uncertain: muted, dashed, dim — clearly not
+  // a validated relationship yet.
+  if (meta.value === 'Exploratory') {
+    return {
+      stroke: EDGE_COLORS.neutral,
+      strokeWidth: 1.75,
+      strokeDasharray: '4,4',
+      opacity: 0.55,
+      tone: 'neutral',
+      loose: true,
+    };
+  }
 
   // Structural types are definitional — not coloured by statistical strength.
   if (!meta.strokeByWeight) {

--- a/src/shared/lib/api/schemas.ts
+++ b/src/shared/lib/api/schemas.ts
@@ -17,6 +17,7 @@ export const RELATIONSHIP_TYPES = [
   'Probabilistic',
   'Causal',
   'Compositional',
+  'Exploratory',
 ] as const;
 
 export const CONFIDENCE_LEVELS = ['High', 'Medium', 'Low'] as const;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -33,7 +33,10 @@ export type RelationshipType =
   | 'Deterministic'
   | 'Probabilistic'
   | 'Causal'
-  | 'Compositional';
+  | 'Compositional'
+  // A loose, exploratory link: suspected but not yet validated (type/strength
+  // unknown). Firm it up later with evidence + a concrete type (CVS-165).
+  | 'Exploratory';
 
 export type ConfidenceLevel = 'High' | 'Medium' | 'Low';
 

--- a/supabase/migrations/20260714120000_relationship_exploratory_type.sql
+++ b/supabase/migrations/20260714120000_relationship_exploratory_type.sql
@@ -1,0 +1,25 @@
+-- =====================================================================
+-- EXPLORATORY RELATIONSHIP TYPE — allow a loose/exploratory link that users can
+-- firm up later (CVS-165 follow-up). Relaxes the relationships.type CHECK to
+-- include 'Exploratory' alongside the four validated types.
+-- =====================================================================
+BEGIN;
+
+ALTER TABLE public.relationships
+  DROP CONSTRAINT IF EXISTS relationships_type_check;
+
+ALTER TABLE public.relationships
+  ADD CONSTRAINT relationships_type_check
+  CHECK (
+    type = ANY (
+      ARRAY[
+        'Deterministic',
+        'Probabilistic',
+        'Causal',
+        'Compositional',
+        'Exploratory'
+      ]::text[]
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
Closes **CVS-254** (CVS-165 follow-up, priority 3 "loose connection style"). Adds a first-class **Exploratory** relationship type — a loose/suspected link you firm up later.

## What
- **DB:** relaxes `relationships.type` CHECK to allow `'Exploratory'` (`20260714120000`).
- **Type + schema:** `RelationshipType` + MCP `RELATIONSHIP_TYPES` gain `'Exploratory'` (agents can create them via `create_relationship` too).
- **Meta + edge style:** `RELATIONSHIP_TYPE_META.Exploratory` (CircleDashed icon, amber accents, dotted); `getRelationshipEdgeStyle` draws exploratory edges **loose** — neutral gray, dashed, dim (0.55 opacity), never strength-coloured, even at strong weight.
- **Picker:** auto-included via `RELATIONSHIP_TYPE_LIST`.

## Verification
- `type-check` ✅ (no exhaustive-switch breakage — all have defaults) · `lint` ✅ (0 new) · **full vitest 272/272** ✅ — new test asserts exploratory = loose/neutral/dim.

## ⚠️ Merge order
**Apply `20260714120000_relationship_exploratory_type.sql` to prod first**, then merge — otherwise the UI would offer "Exploratory" before the DB CHECK accepts it. (I intentionally did not self-apply/merge this one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)