### PR TITLE
feat(canvas): "Unlinked" auto-group + focus for orphan cards (CVS-76)

### DIFF
--- a/src/features/canvas/components/left-sidepanel/GroupsPanel.tsx
+++ b/src/features/canvas/components/left-sidepanel/GroupsPanel.tsx
@@ -14,6 +14,7 @@ import {
   Minus,
   Plus,
   Trash2,
+  Unlink,
   X,
 } from 'lucide-react';
 import { useState } from 'react';
@@ -41,6 +42,10 @@ interface GroupsPanelProps {
   onRename: (groupId: string, name: string) => void;
   onRecolor: (groupId: string, color: string) => void;
   onDelete: (groupId: string) => void;
+  /** Count of cards with no typed relationship (computed "Unlinked" group). */
+  unlinkedCount: number;
+  /** Select + fit-view the unlinked cards so they can be wired or culled. */
+  onFocusUnlinked: () => void;
 }
 
 export default function GroupsPanel({
@@ -55,6 +60,8 @@ export default function GroupsPanel({
   onRename,
   onRecolor,
   onDelete,
+  unlinkedCount,
+  onFocusUnlinked,
 }: GroupsPanelProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftName, setDraftName] = useState('');
@@ -112,6 +119,36 @@ export default function GroupsPanel({
       )}
 
       <div className="p-2 space-y-1.5">
+        {/* Computed "Unlinked" group: cards with no typed relationship. Muted +
+            dashed to signal it isn't a real saved group — just a focus shortcut. */}
+        {unlinkedCount > 0 && (
+          <div className="rounded-md border border-dashed border-muted-foreground/30 bg-muted/40 p-2">
+            <div className="flex items-center gap-2">
+              <Unlink className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="flex-1 min-w-0 truncate text-left text-xs font-medium text-muted-foreground">
+                Unlinked
+              </span>
+              <Badge variant="outline" className="text-[10px] shrink-0">
+                {unlinkedCount}
+              </Badge>
+            </div>
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              {unlinkedCount === 1 ? '1 card has' : `${unlinkedCount} cards have`}{' '}
+              no relationship yet.
+            </p>
+            <Button
+              size="sm"
+              variant="outline"
+              className="mt-2 h-7 w-full gap-1 px-2 text-xs"
+              onClick={onFocusUnlinked}
+              title="Select and zoom to the unlinked cards to wire or remove them"
+            >
+              <Crosshair className="h-3 w-3" />
+              Focus to wire or cull
+            </Button>
+          </div>
+        )}
+
         {groups.length === 0 ? (
           <p className="px-2 py-6 text-center text-xs text-muted-foreground">
             No groups yet.

--- a/src/features/canvas/pages/CanvasPage.tsx
+++ b/src/features/canvas/pages/CanvasPage.tsx
@@ -602,6 +602,36 @@ function CanvasPageInner() {
 
   const handleClearFocus = useCallback(() => setFocusedGroupId(null), []);
 
+  // "Unlinked" cards: nodes with no typed relationship (never a source or target
+  // of any edge). Surfaced as a computed muted group in GroupsPanel so users can
+  // one-click focus them and wire-or-cull (CVS-76). Memoized so it doesn't add
+  // per-render churn to the fragile canvas render path.
+  const unlinkedNodeIds = useMemo(() => {
+    const allNodes = canvas?.nodes || [];
+    if (allNodes.length === 0) return [] as string[];
+    const connected = new Set<string>();
+    for (const e of canvas?.edges || []) {
+      const s = (e as any).sourceId ?? (e as any).source;
+      const t = (e as any).targetId ?? (e as any).target;
+      if (s) connected.add(s);
+      if (t) connected.add(t);
+    }
+    return allNodes.filter((n) => !connected.has(n.id)).map((n) => n.id);
+  }, [canvas?.nodes, canvas?.edges]);
+
+  const handleFocusUnlinked = useCallback(() => {
+    if (unlinkedNodeIds.length === 0) return;
+    // Select them (highlight + make them actionable) then fit the view to them.
+    useCanvasStore.setState({ selectedNodeIds: unlinkedNodeIds });
+    setTimeout(() => {
+      const ids = new Set(unlinkedNodeIds);
+      const toFit = getNodes().filter((n) => ids.has(n.id));
+      if (toFit.length > 0) {
+        fitView({ nodes: toFit as any, padding: 0.35, duration: 600 });
+      }
+    }, 60);
+  }, [unlinkedNodeIds, getNodes, fitView]);
+
   const handleAddSelectedToGroup = useCallback(
     (groupId: string) => {
       const group = (canvas?.groups || []).find((g) => g.id === groupId);
@@ -2167,6 +2197,8 @@ function CanvasPageInner() {
                       onRename={handleRenameGroup}
                       onRecolor={handleRecolorGroup}
                       onDelete={handleDeleteGroup}
+                      unlinkedCount={unlinkedNodeIds.length}
+                      onFocusUnlinked={handleFocusUnlinked}
                     />
                   )}
                 </div>


### PR DESCRIPTION
Detects cards with **no typed relationship** (never a source/target of any edge) and surfaces them as a computed, muted **"Unlinked (N)"** entry at the top of the Groups panel, with one-click **focus to wire-or-cull**.

## Behavior
- Shows only when ≥1 unlinked card exists; dashed + muted styling signals it's a computed shortcut, not a saved group.
- **Focus to wire or cull** → selects the orphan cards + `fitView` zooms to them, so you can immediately connect or delete them.
- `unlinkedNodeIds` is **memoized** on `canvas.nodes + canvas.edges` — no added churn on the canvas render path (deliberate, given the recent React #185 fixes).
- Reuses the existing `fitView({ nodes })` focus pattern + the store selection setter; no changes to the fragile controlled-nodes flow.

## Verification
type-check ✓ (both files are type-checked, not @ts-nocheck), lint ✓ (0 errors), full build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)