### PR TITLE
fix(cvs-259): relationship Analysis tab computes real correlation

### DIFF
--- a/src/features/canvas/components/panels/relationship-panel/RelationshipSheet.tsx
+++ b/src/features/canvas/components/panels/relationship-panel/RelationshipSheet.tsx
@@ -270,22 +270,11 @@ export default function RelationshipSheet({
     }
   };
 
-  // Function to generate mock data for analysis
-  const generateMockData = (): number[] => {
-    // Generate mock time series data for demonstration
-    // In a real implementation, this would come from the node's actual data
-    const baseValue = Math.random() * 100;
-    const trend = (Math.random() - 0.5) * 0.5;
-    const data: number[] = [];
-
-    for (let i = 0; i < 30; i++) {
-      const noise = (Math.random() - 0.5) * 10;
-      const value = baseValue + trend * i + noise;
-      data.push(Math.max(0, value)); // Ensure non-negative values
-    }
-
-    return data;
-  };
+  // Extract a node's real numeric value series (from its tracked metric data).
+  const seriesFromNode = (node: typeof sourceNode): number[] =>
+    (node?.data ?? [])
+      .map((d: { value?: number }) => d?.value)
+      .filter((v: unknown): v is number => typeof v === 'number');
 
   // Function to run statistical analysis
   const handleRunAnalysis = async () => {
@@ -298,14 +287,19 @@ export default function RelationshipSheet({
     setAnalysisError(null);
 
     try {
-      // Generate mock data for the nodes
-      const sourceData = generateMockData();
-      const targetData = generateMockData();
+      // Use the nodes' REAL metric values (not mock data).
+      const sourceData = seriesFromNode(sourceNode);
+      const targetData = seriesFromNode(targetNode);
 
-      // Check if we have enough data
+      // Need enough overlapping data to correlate.
       if (sourceData.length < 3 || targetData.length < 3) {
         throw new Error(
-          'Insufficient data for statistical analysis. At least 3 data points required.'
+          `Need at least 3 data points in each metric to analyze correlation (have ${sourceData.length} and ${targetData.length}). Add values to both cards first.`
+        );
+      }
+      if (sourceData.length !== targetData.length) {
+        throw new Error(
+          `Both metrics must have the same number of data points to correlate (have ${sourceData.length} vs ${targetData.length}).`
         );
       }
 


### PR DESCRIPTION
Closes **CVS-259** (CVS-165 follow-up / correctness). The relationship sheet's Analysis tab (Probabilistic) correlated **`generateMockData()`** — random numbers — so its correlation, p-value, significance and effect size were **fake**. That undermined priority 2 ("negative/low correlation should warn"): the warning is only trustworthy if the correlation is real.

## Fix
- `handleRunAnalysis` now feeds the nodes' **real** metric values (`node.data[].value`) into the correlation worker — the same extraction `CorrelationAnalysisPanel` already uses.
- Guards: ≥3 points per metric + equal-length series, with messages naming the actual counts so the user knows to add data.
- Removed `generateMockData`.

## Verification
- `type-check` ✅ · `lint` ✅ (0 new) · **full vitest 271/271** ✅. No DB change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)