### PR TITLE
feat(cvs-261): redesign edge centre chip into a tone-aware score pill

### DIFF
--- a/src/features/canvas/components/edges/DynamicEdge.tsx
+++ b/src/features/canvas/components/edges/DynamicEdge.tsx
@@ -4,12 +4,6 @@
 // this directive — do not add new code here assuming it is type-checked.
 import { useConfirm } from '@/shared/components/ConfirmDialog';
 import { Badge } from '@/shared/components/ui/badge';
-import { Button } from '@/shared/components/ui/button';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/shared/components/ui/popover';
 import type {
   ConfidenceLevel,
   Relationship,
@@ -23,7 +17,6 @@ import {
   getSmoothStepPath,
   useReactFlow,
 } from '@xyflow/react';
-import { Eye, MoreHorizontal, Settings, Trash2 } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import EnhancedEdgeButton, {
   useEdgeActions,
@@ -143,7 +136,6 @@ export default function DynamicEdge({
   const { deleteElements } = useReactFlow();
   const confirm = useConfirm();
   const [isHovered, setIsHovered] = useState(false);
-  const [showActions, setShowActions] = useState(false);
 
   const {
     relationship,
@@ -273,40 +265,6 @@ export default function DynamicEdge({
     }
   }, [confirm, deleteElements, id]);
 
-  const handleOpenSheet = useCallback(() => {
-    console.log('🔗 handleOpenSheet called for relationship:', relationship.id);
-    console.log('🔗 Sheet open:', isRelationshipSheetOpen);
-    console.log(
-      '🔗 onSwitchToRelationship available:',
-      !!onSwitchToRelationship
-    );
-    console.log(
-      '🔗 onOpenRelationshipSheet available:',
-      !!onOpenRelationshipSheet
-    );
-
-    if (isRelationshipSheetOpen && onSwitchToRelationship) {
-      onSwitchToRelationship(relationship.id);
-      console.log('🔗 Called onSwitchToRelationship with:', relationship.id);
-    } else if (onOpenRelationshipSheet) {
-      onOpenRelationshipSheet(relationship.id);
-      console.log('🔗 Called onOpenRelationshipSheet with:', relationship.id);
-    } else {
-      console.error('❌ No relationship sheet handler defined!');
-    }
-    setShowActions(false);
-  }, [
-    onOpenRelationshipSheet,
-    onSwitchToRelationship,
-    relationship.id,
-    isRelationshipSheetOpen,
-  ]);
-
-  const handleViewEvidence = useCallback(() => {
-    console.log('View evidence for relationship:', relationship.id);
-    setShowActions(false);
-  }, [relationship.id]);
-
   return (
     <>
       {/* Main Edge Path with Relationship Type Styling */}
@@ -347,92 +305,44 @@ export default function DynamicEdge({
         onClick={handleEdgeClick} // Make the entire edge clickable
       />
 
-      {/* Edge Label and Actions */}
+      {/* Hover detail — floats ABOVE the centre pill (which owns the actions). */}
       <EdgeLabelRenderer>
         <div
           style={{
             position: 'absolute',
-            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY - 30}px)`,
             fontSize: 12,
-            pointerEvents: 'all',
+            pointerEvents: 'none',
           }}
           className={cn(
             'transition-all duration-200',
             selected || isHovered ? 'opacity-100' : 'opacity-0'
           )}
         >
-          {/* Relationship Info */}
-          <div className="flex flex-col items-center gap-1">
-            {/* Type and Confidence Badges */}
-            <div className="flex items-center gap-1">
-              <Badge
-                variant="outline"
-                className={cn('text-xs font-normal', typeConfig.color)}
-              >
-                <typeConfig.icon className="mr-1 h-3 w-3" />
-                {typeConfig.label}
-              </Badge>
-              <Badge
-                variant="outline"
-                className={cn('text-xs font-normal', confidenceConfig.badge)}
-              >
-                {relationship.confidence}
-              </Badge>
-            </div>
-
-            {/* Evidence Count */}
+          <div className="flex items-center gap-1 whitespace-nowrap">
+            <Badge
+              variant="outline"
+              className={cn(
+                'bg-card/95 text-xs font-normal backdrop-blur-sm',
+                typeConfig.color
+              )}
+            >
+              <typeConfig.icon className="mr-1 h-3 w-3" />
+              {typeConfig.label}
+            </Badge>
+            <Badge
+              variant="outline"
+              className={cn(
+                'bg-card/95 text-xs font-normal backdrop-blur-sm',
+                confidenceConfig.badge
+              )}
+            >
+              {relationship.confidence}
+            </Badge>
             {relationship.evidence.length > 0 && (
               <Badge variant="secondary" className="text-xs">
                 {relationship.evidence.length} evidence
               </Badge>
-            )}
-
-            {/* Action Buttons */}
-            {(selected || isHovered) && (
-              <div className="flex items-center gap-1 mt-1">
-                <Popover open={showActions} onOpenChange={setShowActions}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-6 w-6 p-0 bg-card/95 backdrop-blur-sm"
-                    >
-                      <MoreHorizontal className="h-3 w-3" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-48 p-1" align="center">
-                    <div className="space-y-1">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleOpenSheet}
-                        className="w-full justify-start text-xs"
-                      >
-                        <Settings className="mr-2 h-3 w-3" />
-                        Edit Relationship
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleViewEvidence}
-                        className="w-full justify-start text-xs"
-                      >
-                        <Eye className="mr-2 h-3 w-3" />
-                        View Evidence ({relationship.evidence.length})
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleDelete}
-                        className="w-full justify-start text-xs text-destructive hover:text-destructive"
-                      >
-                        <Trash2 className="mr-2 h-3 w-3" />
-                        Delete
-                      </Button>
-                    </div>
-                  </PopoverContent>
-                </Popover>
-              </div>
             )}
           </div>
         </div>

--- a/src/features/canvas/components/edges/shared/EnhancedEdgeButton.tsx
+++ b/src/features/canvas/components/edges/shared/EnhancedEdgeButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { EdgeLabelRenderer } from '@xyflow/react';
+import { cn } from '@/shared/utils';
 import { Button } from '@/shared/components/ui/button';
 import {
   Popover,
@@ -19,9 +20,40 @@ import {
   GitBranch,
 } from 'lucide-react';
 import {
+  getRelationshipEdgeStyle,
   getRelationshipTypeMeta,
   getRelationshipWeightLabel,
 } from '@/features/canvas/constants/relationshipTypeMeta';
+
+// Tone → pill classes, matching the drawn line's semantics (CVS-165): a
+// relationship's centre chip reads the same colour as its edge, so a negative or
+// weak link never looks like a healthy green one.
+const TONE_PILL: Record<
+  string,
+  { bg: string; border: string; text: string }
+> = {
+  positive: {
+    bg: 'bg-green-50',
+    border: 'border-green-300',
+    text: 'text-green-700',
+  },
+  negative: { bg: 'bg-red-50', border: 'border-red-300', text: 'text-red-700' },
+  weak: {
+    bg: 'bg-amber-50',
+    border: 'border-amber-300',
+    text: 'text-amber-700',
+  },
+  neutral: {
+    bg: 'bg-gray-50',
+    border: 'border-gray-300',
+    text: 'text-gray-600',
+  },
+  structural: {
+    bg: 'bg-slate-50',
+    border: 'border-slate-300',
+    text: 'text-slate-600',
+  },
+};
 
 interface EnhancedEdgeButtonProps {
   // Position
@@ -127,6 +159,17 @@ export default function EnhancedEdgeButton({
   const Icon = customIcon || config.icon;
   const label = customLabel || config.label;
 
+  // Relationship edges: tint the chip by the edge's tone (direction/strength) so
+  // it matches the line. Other edge types keep their own config colours.
+  const relStyle =
+    edgeType === 'relationshipEdge'
+      ? getRelationshipEdgeStyle(relationshipType, weight)
+      : null;
+  const pill = relStyle
+    ? TONE_PILL[relStyle.tone] ?? TONE_PILL.neutral
+    : { bg: config.bgColor, border: config.borderColor, text: config.color };
+  const loose = relStyle?.loose ?? false;
+
   // Actions for the toolbar
   const actions = [
     {
@@ -203,27 +246,27 @@ export default function EnhancedEdgeButton({
         className="nodrag nopan"
       >
         <div className="flex items-center gap-1">
-          {/* Main Edge Button */}
-          <Button
-            variant="outline"
-            size="sm"
+          {/* Centre chip — compact tone-aware score pill (CVS-165). */}
+          <button
+            type="button"
             onClick={handleMainButtonClick}
-            className={`
-              h-10 w-10 p-0 rounded-full shadow-lg transition-all duration-200 border-2
-              ${config.bgColor} ${config.borderColor} ${config.color} ${config.hoverBg}
-              ${selected ? 'ring-2 ring-blue-500 ring-offset-1' : ''}
-              ${isHovered ? 'scale-110' : 'hover:scale-110'}
-              hover:shadow-xl
-            `}
-            title={`${config.description} - Click to open settings`}
+            title={`${config.description} — click to open settings`}
+            className={cn(
+              'flex items-center gap-1 rounded-full border bg-clip-padding px-2 py-0.5',
+              'shadow-sm backdrop-blur-sm transition-all duration-200',
+              pill.bg,
+              pill.border,
+              pill.text,
+              loose ? 'border-dashed opacity-90' : '',
+              selected ? 'ring-2 ring-blue-500 ring-offset-1' : '',
+              isHovered ? 'scale-110 shadow-md' : 'hover:scale-110'
+            )}
           >
-            <div className="flex flex-col items-center justify-center">
-              <Icon className="h-3 w-3 mb-0.5" />
-              <span className="text-[8px] font-mono font-bold leading-none">
-                {label}
-              </span>
-            </div>
-          </Button>
+            <Icon className="h-3 w-3 shrink-0" />
+            <span className="font-mono text-[10px] font-semibold leading-none">
+              {label}
+            </span>
+          </button>
 
           {/* Toolbar Actions */}
           {showToolbar && (selected || isHovered) && actions.length > 0 && (


### PR DESCRIPTION
Closes **CVS-261** — the last open **CVS-165** AC (polish the centre icon/badge).

## Before → after
- The always-visible centre control was a heavy **40px round button** coloured by static per-type meta — a negative/weak link's chip still looked neutral. On hover, `DynamicEdge` drew a **second** badge+action popover **on top of** it (duplicate actions).
- Now: a **compact rounded pill** (icon + score) tinted by the edge's **tone** (`getRelationshipEdgeStyle`) — green positive / red negative / amber weak / gray neutral / slate structural — so the chip matches the line. **Dashed + dim** for loose/exploratory. Hover detail (type · confidence · evidence) floats **above** the pill; the duplicate popover is gone (the pill's toolbar owns actions). dataFlow/reference edges keep their own chips.

## Verification
- `type-check` ✅ · `lint` ✅ (0 errors; cleaned up orphaned imports/handlers) · **full vitest 272/272** ✅. UI only, no DB. Reuses the tested tone functions.

Visual QA (zoom / selected / hover / each type + exploratory) is in the manual test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)