### PR TITLE
feat(connectors): canonical schema package (CVS-139)

### DIFF
--- a/docs/data/canonical-schemas.md
+++ b/docs/data/canonical-schemas.md
@@ -1,0 +1,86 @@
+# Canonical schemas (data layer)
+
+The canonical schema package (`src/shared/lib/connectors/canonical/`, CVS-139) is the
+shared data contract for **both** ingestion paths:
+
+- **Native connectors** — Metrimap fetches from a source API, normalizes into canonical
+  records (CVS-140–150).
+- **Agent push** — the user's agent fetches elsewhere and pushes via MCP/API
+  (CVS-98–104).
+
+Both validate, bind, and materialize through the same schemas, so metric logic is never
+reinvented per integration. Design authority: the vault doc *"PRD/4. Product/5. Canonical
+Schemas and Native Connectors"* and the locked decision on Linear **CVS-137**.
+
+## The envelope
+
+Every canonical record carries the same envelope (`envelope.ts`):
+
+| field | meaning |
+| --- | --- |
+| `schema` | canonical schema name (discriminator), e.g. `payment` |
+| `schema_version` | semver of the schema contract (`1.0.0`) |
+| `source` | connector id, e.g. `stripe`, `ga4` |
+| `source_account_id` | the connected account/property/store id |
+| `source_object_id` | the source's id for this object (lineage + dedupe) |
+| `workspace_id` | owning workspace (RLS scope) |
+| `observed_at` / `occurred_at` | when Metrimap saw it / when it happened (ISO-8601, offset ok) |
+| `currency` / `amount` / `amount_unit` | money (see below); present only on money-bearing schemas |
+| `attributes` | typed, per-schema fields |
+| `lineage` | `{ connector_version, cursor?, normalizer_version }` |
+
+**Money:** `amount` is the record's principal monetary value (payment amount, order total,
+invoice total, line total, product price) and is stored in **minor units** by default
+(`amount_unit: "minor"`, e.g. cents). `amount` must be an integer when the unit is minor.
+Use the `money.ts` helpers (`toMinor` / `toMajor` / `currencyExponent`, which handle
+zero-decimal currencies like JPY and three-decimal like KWD).
+
+## MVP schemas (v1)
+
+Only the schemas the Tier-1 connectors need are fully defined; the rest are reserved names
+in `registry.ts` (`LATER_SCHEMA_NAMES`) and defined when their connector lands.
+
+| family | schemas |
+| --- | --- |
+| payments | `payment`, `refund`, `payout`, `subscription`, `invoice` |
+| commerce | `commerce_order`, `order_line_item`, `product`, `customer` |
+| analytics | `analytics_event`, `page_metric`, `funnel_step`, `cohort` |
+
+Reserved for later (marketing/sales/long tail): `ad_campaign`, `ad_metric`, `lead`, `deal`,
+`ticket`, `balance_transaction`, `dispute`, `tax_document`, `ledger_entry`, `inventory_item`,
+`session`, `feature_flag`, … (see `LATER_SCHEMA_NAMES`).
+
+Source-specific extras belong in the typed `attributes` object of a schema **only when a
+known use case needs them** — not as a dumping ground for raw payload fields. No raw
+third-party payloads are stored by default (locked in CVS-137).
+
+## Validating a record
+
+```ts
+import { validateRecord, dedupeKey } from '@/shared/lib/connectors/canonical';
+
+const res = validateRecord(record);
+if (!res.ok) {
+  // res.errors: { path, code, message }[] — surface in a connector run report
+} else {
+  const key = dedupeKey(res.record); // stable upsert key across runs
+}
+```
+
+`validateRecord` never throws. Beyond Zod shape validation it enforces two cross-field
+rules: the `schema_version` must match the registered version, and `amount` must be an
+integer when `amount_unit` is `"minor"`. Error codes include `unknown_schema`,
+`schema_not_yet_supported` (a reserved name), `version_mismatch`, and `non_integer_minor`.
+
+## Versioning
+
+`schema_version` is explicit per record and checked on validation. Bump
+`CANONICAL_SCHEMA_VERSION` (and a schema's registered `version`) on a breaking change;
+normalizers then emit the new version and old records fail fast with `version_mismatch`
+rather than silently mis-binding.
+
+## Not here
+
+Manifest/JSON-Schema export (for the connector registry + external contract) is **CVS-140**;
+the fetch/normalization/binding runtime is **CVS-141–145**. This package is contracts +
+validation only.

--- a/src/shared/lib/connectors/canonical/canonical.test.ts
+++ b/src/shared/lib/connectors/canonical/canonical.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CANONICAL_SCHEMAS,
+  CANONICAL_SCHEMA_NAMES,
+  CANONICAL_SCHEMA_VERSION,
+  LATER_SCHEMA_NAMES,
+  SCHEMA_FAMILIES,
+  dedupeKey,
+  getSchemaDef,
+  validateRecord,
+} from './index';
+import { currencyExponent, formatMoney, toMajor, toMinor } from './money';
+import { SOURCE_FIXTURES } from './fixtures';
+
+describe('canonical registry', () => {
+  it('registers the 13 MVP schemas with consistent metadata', () => {
+    expect(CANONICAL_SCHEMA_NAMES).toHaveLength(13);
+    for (const name of CANONICAL_SCHEMA_NAMES) {
+      const def = CANONICAL_SCHEMAS[name];
+      expect(def.name).toBe(name);
+      expect(def.mvp).toBe(true);
+      expect(def.version).toBe(CANONICAL_SCHEMA_VERSION);
+      expect(SCHEMA_FAMILIES).toContain(def.family);
+      expect(['required', 'optional', 'none']).toContain(def.money);
+    }
+  });
+
+  it('does not overlap MVP names with the reserved later-schema names', () => {
+    const later = new Set<string>(LATER_SCHEMA_NAMES);
+    for (const name of CANONICAL_SCHEMA_NAMES) expect(later.has(name)).toBe(false);
+  });
+});
+
+describe('validateRecord — source fixtures', () => {
+  for (const fx of SOURCE_FIXTURES) {
+    it(`${fx.source}: accepts a well-formed ${fx.schema}`, () => {
+      const res = validateRecord(fx.valid);
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.record.schema).toBe(fx.schema);
+        expect(res.def.name).toBe(fx.schema);
+      }
+    });
+
+    it(`${fx.source}: rejects a bad ${fx.schema} (${fx.invalidReason})`, () => {
+      const res = validateRecord(fx.invalid);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.errors.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+describe('validateRecord — structured errors', () => {
+  const base = SOURCE_FIXTURES[1].valid as Record<string, unknown>; // stripe payment
+
+  it('flags a non-object input', () => {
+    const res = validateRecord(42);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('invalid_type');
+  });
+
+  it('flags a missing schema discriminator', () => {
+    const noSchema = Object.fromEntries(Object.entries(base).filter(([k]) => k !== 'schema'));
+    const res = validateRecord(noSchema);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('missing_schema');
+  });
+
+  it('flags a totally unknown schema', () => {
+    const res = validateRecord({ ...base, schema: 'not_a_thing' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('unknown_schema');
+  });
+
+  it('flags a reserved-but-unimplemented schema distinctly', () => {
+    const res = validateRecord({ ...base, schema: 'ledger_entry' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('schema_not_yet_supported');
+  });
+
+  it('flags a schema_version mismatch', () => {
+    const res = validateRecord({ ...base, schema_version: '2.0.0' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('version_mismatch');
+  });
+
+  it('flags a non-integer amount when amount_unit is "minor"', () => {
+    const res = validateRecord({ ...base, amount: 129.5 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.some((e) => e.code === 'non_integer_minor')).toBe(true);
+  });
+});
+
+describe('validateRecord — defaults', () => {
+  it('applies the analytics_event count default', () => {
+    const posthog = SOURCE_FIXTURES[4].valid as Record<string, unknown>;
+    const attrs = posthog.attributes as Record<string, unknown>;
+    const withoutCount = { ...posthog, attributes: { ...attrs, count: undefined } };
+    const res = validateRecord(withoutCount);
+    expect(res.ok).toBe(true);
+    if (res.ok && res.record.schema === 'analytics_event') {
+      expect(res.record.attributes.count).toBe(1);
+    }
+  });
+});
+
+describe('dedupeKey', () => {
+  it('is stable and namespaced by source/account/schema/object', () => {
+    const rec = { source: 'stripe', source_account_id: 'acct_1', schema: 'payment', source_object_id: 'pi_9' };
+    expect(dedupeKey(rec)).toBe('stripe:acct_1:payment:pi_9');
+    expect(dedupeKey(rec)).toBe(dedupeKey({ ...rec }));
+  });
+});
+
+describe('getSchemaDef', () => {
+  it('returns a def for a known schema and undefined otherwise', () => {
+    expect(getSchemaDef('payment')?.name).toBe('payment');
+    expect(getSchemaDef('nope')).toBeUndefined();
+  });
+});
+
+describe('money helpers', () => {
+  it('knows minor-unit exponents', () => {
+    expect(currencyExponent('USD')).toBe(2);
+    expect(currencyExponent('myr')).toBe(2);
+    expect(currencyExponent('JPY')).toBe(0);
+    expect(currencyExponent('KWD')).toBe(3);
+  });
+
+  it('round-trips minor/major across exponents', () => {
+    expect(toMinor(12.9, 'MYR')).toBe(1290);
+    expect(toMajor(1290, 'MYR')).toBe(12.9);
+    expect(toMinor(1000, 'JPY')).toBe(1000);
+    expect(toMinor(1.234, 'KWD')).toBe(1234);
+  });
+
+  it('formats a minor amount without throwing on odd codes', () => {
+    expect(formatMoney(1290, 'MYR')).toContain('12.90');
+    expect(() => formatMoney(1000, 'ZZZ')).not.toThrow();
+  });
+});

--- a/src/shared/lib/connectors/canonical/envelope.ts
+++ b/src/shared/lib/connectors/canonical/envelope.ts
@@ -1,0 +1,94 @@
+// Canonical record envelope + schema-definition helper (CVS-139).
+//
+// Every canonical record — regardless of source (Stripe, GA4, WooCommerce, …) —
+// carries the same envelope. Per-schema shapes extend it with a `schema` literal
+// and a typed `attributes` object. Validation and versioning rules live in
+// `registry.ts`; this file only defines the shared contract. See the locked
+// decision on Linear CVS-137 and docs/data/canonical-schemas.md.
+import { z } from 'zod';
+
+/** Current envelope + schema contract version. Bump on breaking schema changes. */
+export const CANONICAL_SCHEMA_VERSION = '1.0.0';
+
+// ISO-8601 timestamp; accepts both `Z` and numeric offsets like `+08:00`.
+const isoDateTime = z.string().datetime({ offset: true });
+
+export const AmountUnit = z.enum(['minor', 'major']);
+export type AmountUnit = z.infer<typeof AmountUnit>;
+
+/** Provenance carried on every record so materialized metrics stay traceable. */
+export const Lineage = z.object({
+  connector_version: z.string().min(1),
+  cursor: z.string().optional(),
+  normalizer_version: z.string().min(1),
+});
+export type Lineage = z.infer<typeof Lineage>;
+
+export const SCHEMA_FAMILIES = [
+  'payments',
+  'commerce',
+  'analytics',
+  'marketing',
+  'sales',
+] as const;
+export type SchemaFamily = (typeof SCHEMA_FAMILIES)[number];
+
+/** Whether a schema requires the money fields (currency/amount/amount_unit). */
+export type MoneyMode = 'required' | 'optional' | 'none';
+
+/**
+ * The shared envelope every canonical record carries. Money fields are optional
+ * at the base; money-bearing schemas (payment, order, …) re-require them via
+ * `moneyRequired`. `amount` is the record's principal monetary value (payment
+ * amount, order total, invoice total, line total, product price).
+ */
+export const canonicalEnvelope = z.object({
+  schema: z.string().min(1),
+  schema_version: z.string().min(1),
+  source: z.string().min(1),
+  source_account_id: z.string().min(1),
+  source_object_id: z.string().min(1),
+  workspace_id: z.string().min(1),
+  observed_at: isoDateTime,
+  occurred_at: isoDateTime,
+  currency: z.string().length(3).optional(),
+  amount: z.number().finite().optional(),
+  amount_unit: AmountUnit.optional(),
+  attributes: z.record(z.unknown()),
+  lineage: Lineage,
+});
+export type CanonicalEnvelope = z.infer<typeof canonicalEnvelope>;
+
+/** Shape fragment that makes the money fields required (spread into `.extend`). */
+export const moneyRequired = {
+  currency: z.string().length(3),
+  amount: z.number().finite(),
+  amount_unit: AmountUnit,
+} as const;
+
+/** A registered canonical schema: its Zod contract plus metadata. */
+export interface CanonicalSchemaDef<Name extends string = string> {
+  name: Name;
+  version: string;
+  family: SchemaFamily;
+  mvp: boolean;
+  money: MoneyMode;
+  schema: z.ZodTypeAny;
+}
+
+/** Wrap a built Zod record schema with its registry metadata. */
+export function canonical<Name extends string>(
+  name: Name,
+  family: SchemaFamily,
+  schema: z.ZodTypeAny,
+  opts: { money?: MoneyMode; mvp?: boolean; version?: string } = {}
+): CanonicalSchemaDef<Name> {
+  return {
+    name,
+    family,
+    schema,
+    money: opts.money ?? 'none',
+    mvp: opts.mvp ?? true,
+    version: opts.version ?? CANONICAL_SCHEMA_VERSION,
+  };
+}

--- a/src/shared/lib/connectors/canonical/fixtures.ts
+++ b/src/shared/lib/connectors/canonical/fixtures.ts
@@ -1,0 +1,153 @@
+// Canonical record fixtures for the Tier-1 connector families (CVS-139).
+//
+// Each entry is a NORMALIZED canonical record (what a connector's normalizer emits,
+// not the raw source JSON) plus a deliberately-broken variant. Used by the tests
+// and reusable as golden inputs for the normalization runtime (CVS-143) later.
+import type { CanonicalSchemaName } from './registry';
+import type {
+  AnalyticsEventRecord,
+  CommerceOrderRecord,
+  OrderLineItemRecord,
+  PageMetricRecord,
+  PaymentRecord,
+} from './schemas';
+
+export interface SourceFixture {
+  source: string;
+  schema: CanonicalSchemaName;
+  /** A well-formed record that must validate. */
+  valid: unknown;
+  /** A malformed record that must be rejected, and why. */
+  invalid: unknown;
+  invalidReason: string;
+}
+
+const ga4PageMetric = {
+  schema: 'page_metric',
+  schema_version: '1.0.0',
+  source: 'ga4',
+  source_account_id: 'properties/123456',
+  source_object_id: 'ga4:2026-07-01:/pricing:screenPageViews',
+  workspace_id: 'ws_1',
+  observed_at: '2026-07-02T00:00:00Z',
+  occurred_at: '2026-07-01T00:00:00Z',
+  attributes: {
+    page_path: '/pricing',
+    metric: 'screenPageViews',
+    value: 1240,
+    dimensions: { country: 'MY' },
+  },
+  lineage: { connector_version: 'ga4@1.0.0', normalizer_version: 'page_metric@1.0.0' },
+} satisfies PageMetricRecord;
+
+const stripePayment = {
+  schema: 'payment',
+  schema_version: '1.0.0',
+  source: 'stripe',
+  source_account_id: 'acct_123',
+  source_object_id: 'pi_abc',
+  workspace_id: 'ws_1',
+  observed_at: '2026-07-03T12:31:00Z',
+  occurred_at: '2026-07-03T12:30:00+08:00',
+  currency: 'MYR',
+  amount: 12900,
+  amount_unit: 'minor',
+  attributes: { status: 'succeeded', customer_source_id: 'cus_1', payment_method: 'card' },
+  lineage: { connector_version: 'stripe@1.0.0', normalizer_version: 'payment@1.0.0' },
+} satisfies PaymentRecord;
+
+const wooOrder = {
+  schema: 'commerce_order',
+  schema_version: '1.0.0',
+  source: 'woocommerce',
+  source_account_id: 'store_1',
+  source_object_id: 'order_1001',
+  workspace_id: 'ws_1',
+  observed_at: '2026-07-03T09:00:00Z',
+  occurred_at: '2026-07-03T08:59:00Z',
+  currency: 'MYR',
+  amount: 25990,
+  amount_unit: 'minor',
+  attributes: { status: 'completed', customer_source_id: 'cust_5', line_item_count: 3 },
+  lineage: { connector_version: 'woocommerce@1.0.0', normalizer_version: 'commerce_order@1.0.0' },
+} satisfies CommerceOrderRecord;
+
+const shopifyLineItem = {
+  schema: 'order_line_item',
+  schema_version: '1.0.0',
+  source: 'shopify',
+  source_account_id: 'shop_1',
+  source_object_id: 'li_9',
+  workspace_id: 'ws_1',
+  observed_at: '2026-07-03T09:00:00Z',
+  occurred_at: '2026-07-03T08:59:00Z',
+  currency: 'MYR',
+  amount: 8990,
+  amount_unit: 'minor',
+  attributes: {
+    order_source_id: 'order_77',
+    product_source_id: 'prod_3',
+    sku: 'TSHIRT-M',
+    title: 'T-Shirt',
+    quantity: 2,
+    unit_amount: 4495,
+  },
+  lineage: { connector_version: 'shopify@1.0.0', normalizer_version: 'order_line_item@1.0.0' },
+} satisfies OrderLineItemRecord;
+
+const posthogEvent = {
+  schema: 'analytics_event',
+  schema_version: '1.0.0',
+  source: 'posthog',
+  source_account_id: 'proj_1',
+  source_object_id: 'evt_555',
+  workspace_id: 'ws_1',
+  observed_at: '2026-07-03T10:00:00Z',
+  occurred_at: '2026-07-03T09:59:00Z',
+  attributes: {
+    event_name: 'signed_up',
+    user_source_id: 'user_9',
+    session_id: 'sess_2',
+    count: 1,
+    properties: { plan: 'pro' },
+  },
+  lineage: { connector_version: 'posthog@1.0.0', normalizer_version: 'analytics_event@1.0.0' },
+} satisfies AnalyticsEventRecord;
+
+export const SOURCE_FIXTURES: SourceFixture[] = [
+  {
+    source: 'ga4',
+    schema: 'page_metric',
+    valid: ga4PageMetric,
+    invalid: { ...ga4PageMetric, attributes: { page_path: '/pricing', metric: 'screenPageViews' } },
+    invalidReason: 'page_metric.attributes.value is required',
+  },
+  {
+    source: 'stripe',
+    schema: 'payment',
+    valid: stripePayment,
+    invalid: { ...stripePayment, amount: 129.5 },
+    invalidReason: 'amount must be an integer when amount_unit is "minor"',
+  },
+  {
+    source: 'woocommerce',
+    schema: 'commerce_order',
+    valid: wooOrder,
+    invalid: Object.fromEntries(Object.entries(wooOrder).filter(([k]) => k !== 'amount')),
+    invalidReason: 'commerce_order requires amount (money required)',
+  },
+  {
+    source: 'shopify',
+    schema: 'order_line_item',
+    valid: shopifyLineItem,
+    invalid: { ...shopifyLineItem, attributes: { ...shopifyLineItem.attributes, quantity: 0 } },
+    invalidReason: 'order_line_item.attributes.quantity must be positive',
+  },
+  {
+    source: 'posthog',
+    schema: 'analytics_event',
+    valid: posthogEvent,
+    invalid: { ...posthogEvent, attributes: { user_source_id: 'user_9' } },
+    invalidReason: 'analytics_event.attributes.event_name is required',
+  },
+];

--- a/src/shared/lib/connectors/canonical/index.ts
+++ b/src/shared/lib/connectors/canonical/index.ts
@@ -1,0 +1,7 @@
+// Canonical data layer (CVS-139): the shared contracts both ingestion paths use —
+// native connectors (Metrimap fetches → normalizes) and agent push (MCP/API,
+// CVS-98–104). Import from here. See docs/data/canonical-schemas.md.
+export * from './envelope';
+export * from './money';
+export * from './schemas';
+export * from './registry';

--- a/src/shared/lib/connectors/canonical/money.ts
+++ b/src/shared/lib/connectors/canonical/money.ts
@@ -1,0 +1,41 @@
+// Currency minor-unit helpers for canonical money handling (CVS-139).
+//
+// Canonical records store money in MINOR units by default (e.g. cents), matching
+// how Stripe and most payment APIs represent amounts. These helpers convert to and
+// from major units for display and for ingesting sources that report major units.
+
+// ISO 4217 currencies whose minor unit is the same as the major unit (no decimals).
+const ZERO_DECIMAL = new Set([
+  'JPY', 'KRW', 'VND', 'CLP', 'ISK', 'XOF', 'XAF', 'XPF', 'BIF', 'DJF', 'GNF',
+  'KMF', 'MGA', 'PYG', 'RWF', 'UGX', 'VUV', 'XAG', 'XAU',
+]);
+// Currencies with three minor digits.
+const THREE_DECIMAL = new Set(['BHD', 'KWD', 'OMR', 'TND', 'JOD', 'LYD', 'IQD']);
+
+/** Number of minor-unit digits for an ISO 4217 currency (default 2). */
+export function currencyExponent(currency: string): number {
+  const c = currency.toUpperCase();
+  if (ZERO_DECIMAL.has(c)) return 0;
+  if (THREE_DECIMAL.has(c)) return 3;
+  return 2;
+}
+
+/** Convert a major-unit amount (e.g. 12.90) to minor units (e.g. 1290). */
+export function toMinor(major: number, currency: string): number {
+  return Math.round(major * 10 ** currencyExponent(currency));
+}
+
+/** Convert a minor-unit amount (e.g. 1290) to major units (e.g. 12.90). */
+export function toMajor(minor: number, currency: string): number {
+  return minor / 10 ** currencyExponent(currency);
+}
+
+/** Localized currency string from a minor-unit amount; falls back if Intl rejects the code. */
+export function formatMoney(minor: number, currency: string): string {
+  const major = toMajor(minor, currency);
+  try {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(major);
+  } catch {
+    return `${major} ${currency.toUpperCase()}`;
+  }
+}

--- a/src/shared/lib/connectors/canonical/registry.ts
+++ b/src/shared/lib/connectors/canonical/registry.ts
@@ -1,0 +1,150 @@
+// Canonical schema registry + validation + dedupe (CVS-139).
+//
+// One place that knows every canonical schema, validates an unknown record against
+// the right one, and derives a stable dedupe key. Both ingestion paths use this:
+// native connectors (Metrimap fetches → normalizes) and agent push (MCP/API,
+// CVS-98–104). See docs/data/canonical-schemas.md and the locked decision on CVS-137.
+import type { z } from 'zod';
+import type { CanonicalSchemaDef } from './envelope';
+import { MVP_SCHEMA_DEFS, type AnyCanonicalRecord } from './schemas';
+
+/** name → definition, for the MVP (fully-defined) schemas. */
+export const CANONICAL_SCHEMAS = Object.fromEntries(
+  MVP_SCHEMA_DEFS.map((d) => [d.name, d])
+) as Record<(typeof MVP_SCHEMA_DEFS)[number]['name'], CanonicalSchemaDef>;
+
+export type CanonicalSchemaName = keyof typeof CANONICAL_SCHEMAS;
+export const CANONICAL_SCHEMA_NAMES = Object.keys(CANONICAL_SCHEMAS) as CanonicalSchemaName[];
+
+/**
+ * Schemas named by the design (vault doc) but not yet defined — they get a full
+ * definition when their connector lands (Tier-2/3). Kept here so the registry is
+ * the single list of canonical names and nothing silently invents a new one.
+ */
+export const LATER_SCHEMA_NAMES = [
+  // payments/finance
+  'balance_transaction',
+  'dispute',
+  'tax_document',
+  'ledger_entry',
+  // commerce
+  'inventory_item',
+  'cart',
+  'fulfillment',
+  // analytics
+  'session',
+  'feature_flag',
+  // marketing
+  'ad_campaign',
+  'ad_metric',
+  'social_post',
+  'social_engagement',
+  'email_campaign',
+  'search_query_metric',
+  'video_metric',
+  // sales & support
+  'lead',
+  'deal',
+  'company',
+  'ticket',
+  'customer_health',
+] as const;
+export type LaterSchemaName = (typeof LATER_SCHEMA_NAMES)[number];
+
+/** Look up a defined schema by name. */
+export function getSchemaDef(name: string): CanonicalSchemaDef | undefined {
+  return CANONICAL_SCHEMAS[name as CanonicalSchemaName];
+}
+
+// --- Validation -----------------------------------------------------------
+
+export interface ValidationError {
+  path: string;
+  code: string;
+  message: string;
+}
+
+export type ValidationResult =
+  | { ok: true; record: CanonicalRecord; def: CanonicalSchemaDef }
+  | { ok: false; errors: ValidationError[] };
+
+/** A validated canonical record — the discriminated union of every MVP schema. */
+export type CanonicalRecord = AnyCanonicalRecord;
+
+function issuePath(issue: z.ZodIssue): string {
+  return issue.path.length ? issue.path.join('.') : '$';
+}
+
+/**
+ * Validate an unknown value against its declared canonical schema. Returns a
+ * structured result so connector run reports can surface exactly what failed —
+ * never throws. Also enforces the two cross-field rules the Zod object can't:
+ * schema-version match and integer amounts when `amount_unit` is "minor".
+ */
+export function validateRecord(input: unknown): ValidationResult {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return { ok: false, errors: [{ path: '$', code: 'invalid_type', message: 'Record must be an object' }] };
+  }
+  const name = (input as { schema?: unknown }).schema;
+  if (typeof name !== 'string' || name.length === 0) {
+    return { ok: false, errors: [{ path: 'schema', code: 'missing_schema', message: 'Record is missing a "schema" discriminator' }] };
+  }
+  const def = getSchemaDef(name);
+  if (!def) {
+    const later = (LATER_SCHEMA_NAMES as readonly string[]).includes(name);
+    return {
+      ok: false,
+      errors: [{
+        path: 'schema',
+        code: later ? 'schema_not_yet_supported' : 'unknown_schema',
+        message: later
+          ? `Canonical schema "${name}" is registered but not yet implemented`
+          : `Unknown canonical schema "${name}"`,
+      }],
+    };
+  }
+
+  const parsed = def.schema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: parsed.error.issues.map((i) => ({ path: issuePath(i), code: i.code, message: i.message })),
+    };
+  }
+  const record = parsed.data as CanonicalRecord;
+
+  if (record.schema_version !== def.version) {
+    return {
+      ok: false,
+      errors: [{
+        path: 'schema_version',
+        code: 'version_mismatch',
+        message: `Expected ${def.name}@${def.version}, got "${record.schema_version}"`,
+      }],
+    };
+  }
+  if (record.amount_unit === 'minor' && record.amount !== undefined && !Number.isInteger(record.amount)) {
+    return {
+      ok: false,
+      errors: [{ path: 'amount', code: 'non_integer_minor', message: 'amount must be an integer when amount_unit is "minor"' }],
+    };
+  }
+
+  return { ok: true, record, def };
+}
+
+// --- Dedupe / lineage -----------------------------------------------------
+
+/**
+ * Stable key for deduping and upserting a record across runs. Source object ids
+ * are unique per (source, account, schema), so the same object always maps to the
+ * same key regardless of when it was fetched.
+ */
+export function dedupeKey(record: {
+  source: string;
+  source_account_id: string;
+  schema: string;
+  source_object_id: string;
+}): string {
+  return `${record.source}:${record.source_account_id}:${record.schema}:${record.source_object_id}`;
+}

--- a/src/shared/lib/connectors/canonical/schemas.ts
+++ b/src/shared/lib/connectors/canonical/schemas.ts
@@ -1,0 +1,247 @@
+// MVP canonical schema definitions (CVS-139).
+//
+// 13 schemas across three families prove the contract for the Tier-1 connectors
+// (GA4, Stripe, WooCommerce, Shopify, PostHog). Each is the shared envelope
+// extended with a `schema` literal and a typed `attributes` object; money-bearing
+// schemas re-require currency/amount/amount_unit. Later schemas (marketing, sales,
+// balance_transaction, …) are registered as names in `registry.ts` and defined
+// when their connectors land. See docs/data/canonical-schemas.md.
+import { z } from 'zod';
+import { canonical, canonicalEnvelope, moneyRequired } from './envelope';
+
+// --- Payments & finance ---------------------------------------------------
+
+export const PaymentStatus = z.enum([
+  'succeeded',
+  'pending',
+  'failed',
+  'refunded',
+  'partially_refunded',
+  'canceled',
+]);
+
+export const paymentSchema = canonicalEnvelope.extend({
+  schema: z.literal('payment'),
+  ...moneyRequired,
+  attributes: z.object({
+    status: PaymentStatus,
+    customer_source_id: z.string().optional(),
+    payment_method: z.string().optional(),
+    description: z.string().optional(),
+  }),
+});
+export type PaymentRecord = z.infer<typeof paymentSchema>;
+
+export const RefundStatus = z.enum(['succeeded', 'pending', 'failed', 'canceled']);
+
+export const refundSchema = canonicalEnvelope.extend({
+  schema: z.literal('refund'),
+  ...moneyRequired,
+  attributes: z.object({
+    status: RefundStatus,
+    payment_source_id: z.string().optional(),
+    reason: z.string().optional(),
+  }),
+});
+export type RefundRecord = z.infer<typeof refundSchema>;
+
+export const PayoutStatus = z.enum(['paid', 'pending', 'in_transit', 'failed', 'canceled']);
+
+export const payoutSchema = canonicalEnvelope.extend({
+  schema: z.literal('payout'),
+  ...moneyRequired,
+  attributes: z.object({
+    status: PayoutStatus,
+    arrival_date: z.string().datetime({ offset: true }).optional(),
+    method: z.string().optional(),
+  }),
+});
+export type PayoutRecord = z.infer<typeof payoutSchema>;
+
+export const SubscriptionStatus = z.enum([
+  'active',
+  'trialing',
+  'past_due',
+  'canceled',
+  'unpaid',
+  'paused',
+  'incomplete',
+]);
+export const BillingInterval = z.enum(['day', 'week', 'month', 'year']);
+
+export const subscriptionSchema = canonicalEnvelope.extend({
+  schema: z.literal('subscription'),
+  attributes: z.object({
+    status: SubscriptionStatus,
+    customer_source_id: z.string().optional(),
+    plan: z.string().optional(),
+    interval: BillingInterval.optional(),
+    quantity: z.number().int().nonnegative().optional(),
+    current_period_start: z.string().datetime({ offset: true }).optional(),
+    current_period_end: z.string().datetime({ offset: true }).optional(),
+  }),
+});
+export type SubscriptionRecord = z.infer<typeof subscriptionSchema>;
+
+export const InvoiceStatus = z.enum(['draft', 'open', 'paid', 'void', 'uncollectible']);
+
+export const invoiceSchema = canonicalEnvelope.extend({
+  schema: z.literal('invoice'),
+  ...moneyRequired,
+  attributes: z.object({
+    status: InvoiceStatus,
+    customer_source_id: z.string().optional(),
+    number: z.string().optional(),
+    due_at: z.string().datetime({ offset: true }).optional(),
+    paid_at: z.string().datetime({ offset: true }).optional(),
+  }),
+});
+export type InvoiceRecord = z.infer<typeof invoiceSchema>;
+
+// --- Commerce -------------------------------------------------------------
+
+export const OrderStatus = z.enum([
+  'pending',
+  'paid',
+  'fulfilled',
+  'shipped',
+  'delivered',
+  'completed',
+  'canceled',
+  'refunded',
+]);
+
+export const commerceOrderSchema = canonicalEnvelope.extend({
+  schema: z.literal('commerce_order'),
+  ...moneyRequired,
+  attributes: z.object({
+    status: OrderStatus,
+    customer_source_id: z.string().optional(),
+    line_item_count: z.number().int().nonnegative().optional(),
+    financial_status: z.string().optional(),
+    fulfillment_status: z.string().optional(),
+  }),
+});
+export type CommerceOrderRecord = z.infer<typeof commerceOrderSchema>;
+
+export const orderLineItemSchema = canonicalEnvelope.extend({
+  schema: z.literal('order_line_item'),
+  attributes: z.object({
+    order_source_id: z.string().min(1),
+    product_source_id: z.string().optional(),
+    sku: z.string().optional(),
+    title: z.string().optional(),
+    quantity: z.number().int().positive(),
+    unit_amount: z.number().finite().optional(),
+  }),
+});
+export type OrderLineItemRecord = z.infer<typeof orderLineItemSchema>;
+
+export const ProductStatus = z.enum(['active', 'archived', 'draft']);
+
+export const productSchema = canonicalEnvelope.extend({
+  schema: z.literal('product'),
+  attributes: z.object({
+    title: z.string().min(1),
+    sku: z.string().optional(),
+    status: ProductStatus.optional(),
+    vendor: z.string().optional(),
+    product_type: z.string().optional(),
+  }),
+});
+export type ProductRecord = z.infer<typeof productSchema>;
+
+export const customerSchema = canonicalEnvelope.extend({
+  schema: z.literal('customer'),
+  attributes: z.object({
+    email: z.string().email().optional(),
+    name: z.string().optional(),
+    country: z.string().optional(),
+    orders_count: z.number().int().nonnegative().optional(),
+    created_source_at: z.string().datetime({ offset: true }).optional(),
+  }),
+});
+export type CustomerRecord = z.infer<typeof customerSchema>;
+
+// --- Analytics & product usage (no money) ---------------------------------
+
+export const analyticsEventSchema = canonicalEnvelope.extend({
+  schema: z.literal('analytics_event'),
+  attributes: z.object({
+    event_name: z.string().min(1),
+    user_source_id: z.string().optional(),
+    session_id: z.string().optional(),
+    count: z.number().int().nonnegative().default(1),
+    properties: z.record(z.unknown()).optional(),
+  }),
+});
+export type AnalyticsEventRecord = z.infer<typeof analyticsEventSchema>;
+
+export const pageMetricSchema = canonicalEnvelope.extend({
+  schema: z.literal('page_metric'),
+  attributes: z.object({
+    page_path: z.string().min(1),
+    metric: z.string().min(1),
+    value: z.number().finite(),
+    dimensions: z.record(z.unknown()).optional(),
+  }),
+});
+export type PageMetricRecord = z.infer<typeof pageMetricSchema>;
+
+export const funnelStepSchema = canonicalEnvelope.extend({
+  schema: z.literal('funnel_step'),
+  attributes: z.object({
+    funnel: z.string().min(1),
+    step_name: z.string().min(1),
+    step_index: z.number().int().nonnegative(),
+    users: z.number().int().nonnegative(),
+    conversion_rate: z.number().min(0).max(1).optional(),
+  }),
+});
+export type FunnelStepRecord = z.infer<typeof funnelStepSchema>;
+
+export const cohortSchema = canonicalEnvelope.extend({
+  schema: z.literal('cohort'),
+  attributes: z.object({
+    cohort_key: z.string().min(1),
+    cohort_date: z.string().datetime({ offset: true }).optional(),
+    size: z.number().int().nonnegative(),
+    metric: z.string().optional(),
+    value: z.number().finite().optional(),
+  }),
+});
+export type CohortRecord = z.infer<typeof cohortSchema>;
+
+// --- Registered definitions (name → def + metadata) -----------------------
+
+/** Union of every MVP canonical record type — the validated output of `validateRecord`. */
+export type AnyCanonicalRecord =
+  | PaymentRecord
+  | RefundRecord
+  | PayoutRecord
+  | SubscriptionRecord
+  | InvoiceRecord
+  | CommerceOrderRecord
+  | OrderLineItemRecord
+  | ProductRecord
+  | CustomerRecord
+  | AnalyticsEventRecord
+  | PageMetricRecord
+  | FunnelStepRecord
+  | CohortRecord;
+
+export const MVP_SCHEMA_DEFS = [
+  canonical('payment', 'payments', paymentSchema, { money: 'required' }),
+  canonical('refund', 'payments', refundSchema, { money: 'required' }),
+  canonical('payout', 'payments', payoutSchema, { money: 'required' }),
+  canonical('subscription', 'payments', subscriptionSchema, { money: 'optional' }),
+  canonical('invoice', 'payments', invoiceSchema, { money: 'required' }),
+  canonical('commerce_order', 'commerce', commerceOrderSchema, { money: 'required' }),
+  canonical('order_line_item', 'commerce', orderLineItemSchema, { money: 'optional' }),
+  canonical('product', 'commerce', productSchema, { money: 'optional' }),
+  canonical('customer', 'commerce', customerSchema, { money: 'none' }),
+  canonical('analytics_event', 'analytics', analyticsEventSchema, { money: 'none' }),
+  canonical('page_metric', 'analytics', pageMetricSchema, { money: 'none' }),
+  canonical('funnel_step', 'analytics', funnelStepSchema, { money: 'none' }),
+  canonical('cohort', 'analytics', cohortSchema, { money: 'none' }),
+] as const;


### PR DESCRIPTION
Closes the build for **CVS-139** — the canonical schema package, milestone 1 of the *Canonical schemas & native connectors* lane. Grounded in the locked decision on CVS-137.

## What
The shared data contract both ingestion paths validate/bind through — native connectors (fetch → normalize) and agent push (MCP/API, CVS-98–104) — so metric logic isn't reinvented per integration.

- **Envelope** (`envelope.ts`) — schema/version/source/ids/workspace/timestamps/money/attributes/lineage. Money in **minor units** by default; `money.ts` handles zero-decimal (JPY) and three-decimal (KWD) currencies.
- **13 MVP schemas** (`schemas.ts`) across payments / commerce / analytics — the shapes the Tier-1 connectors (GA4, Stripe, WooCommerce, Shopify, PostHog) need. Later families reserved as names in the registry so nothing invents a canonical name silently.
- **`validateRecord`** (`registry.ts`) — structured, never-throwing errors for connector run reports; enforces schema-version match + integer-minor-amount beyond Zod shape. `dedupeKey` for stable upserts.
- **Fixtures** (happy + rejected per source family) + **24 unit tests**. Doc: `docs/data/canonical-schemas.md`.

## Acceptance criteria
- [x] Canonical schema package exists + importable by app/server (`@/shared/lib/connectors/canonical`)
- [x] Validation returns structured errors for run reports
- [x] Schema versions explicit + test-covered
- [x] Fixtures cover ≥1 happy + 1 rejected per MVP source family
- [x] Docs explain field semantics + where source-specific extras belong

## Scope notes
- JSON-Schema export (for manifests/external contract) is intentionally deferred to **CVS-140** per the CVS-137 decision — this package is Zod contracts + validation only.
- Marketing/sales schemas are reserved names, defined when their connectors land (Tier-2/3).

type-check + lint (0 warnings) + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)