### PR TITLE
chore(e2e): visual harness works — dev instance over HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ supabase/.temp/
 /test-results/
 /playwright-report/
 /e2e/screenshots/
+/e2e/certs/

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,15 +1,39 @@
 import { clerkSetup } from '@clerk/testing/playwright';
 
-// Fetches a Clerk Testing Token (using CLERK_SECRET_KEY) so headless sign-in
-// bypasses bot protection. Runs once before the suite.
+// The dev (pk_test) instance is a separate user pool, so ensure the e2e user
+// exists there. Idempotent — "already exists" is fine. Uses the dev secret key.
+async function ensureTestUser() {
+  const sk = process.env.CLERK_SECRET_KEY;
+  const email = process.env.E2E_TEST_EMAIL;
+  const password = process.env.E2E_TEST_PASSWORD;
+  if (!sk?.startsWith('sk_test') || !email || !password) return;
+  const res = await fetch('https://api.clerk.com/v1/users', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${sk}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email_address: [email],
+      password,
+      skip_password_checks: true,
+    }),
+  });
+  if (res.ok) {
+    console.log('[e2e] created dev test user');
+  } else {
+    const t = await res.text();
+    if (/already|taken|exists|identifier/i.test(t))
+      console.log('[e2e] dev test user already exists');
+    else console.warn(`[e2e] user create failed (${res.status}): ${t.slice(0, 200)}`);
+  }
+}
+
 export default async function globalSetup() {
   if (!process.env.CLERK_SECRET_KEY) {
-    console.warn(
-      '[e2e] CLERK_SECRET_KEY not set — sign-in specs will be skipped.'
-    );
+    console.warn('[e2e] CLERK_SECRET_KEY not set — sign-in specs will be skipped.');
     return;
   }
-  await clerkSetup({
-    publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
-  });
+  await clerkSetup({ publishableKey: process.env.CLERK_PUBLISHABLE_KEY });
+  await ensureTestUser();
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "husky",
     "test": "vitest",
     "test:rls": "tsx src/tests/run-rls-tests.ts",
+    "prescreenshots": "test -f e2e/certs/key.pem || (mkdir -p e2e/certs && openssl req -x509 -newkey rsa:2048 -nodes -keyout e2e/certs/key.pem -out e2e/certs/cert.pem -days 365 -subj '/CN=dev.canvasm.app' -addext 'subjectAltName=DNS:dev.canvasm.app')",
     "screenshots": "playwright test",
     "sync:errors": "node scripts/sync-error-reports.mjs",
     "sync:userback": "node scripts/sync-userback.mjs"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,8 +2,7 @@ import { readFileSync } from 'node:fs';
 import { defineConfig, devices } from '@playwright/test';
 
 // Load .env into the Playwright (node) process — Vite loads it for the app, but
-// the runner + clerkSetup need CLERK_SECRET_KEY / E2E_* (which are NOT VITE_-
-// prefixed, so they never reach import.meta.env). Values stay server-side.
+// the runner + clerkSetup need the E2E_* keys (not VITE_-prefixed). Server-side.
 try {
   for (const line of readFileSync('.env', 'utf8').split('\n')) {
     const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
@@ -13,9 +12,15 @@ try {
 } catch {
   /* no .env in this checkout — env may be injected directly */
 }
-// @clerk/testing expects CLERK_PUBLISHABLE_KEY; the app stores it VITE_-prefixed.
-if (!process.env.CLERK_PUBLISHABLE_KEY && process.env.VITE_CLERK_PUBLISHABLE_KEY)
-  process.env.CLERK_PUBLISHABLE_KEY = process.env.VITE_CLERK_PUBLISHABLE_KEY;
+
+// Drive e2e against the Clerk DEVELOPMENT instance (pk_test): production keys
+// (pk_live) are domain-locked to canvasm.app and refuse localhost, and Web
+// Crypto needs a secure context — localhost qualifies, dev.canvasm.app:3000 (http)
+// does not. So point clerkSetup + the app at the dev instance on localhost.
+const E2E_PK = process.env.E2E_CLERK_PUBLISHABLE_KEY;
+const E2E_SK = process.env.E2E_CLERK_SECRET_KEY;
+process.env.CLERK_PUBLISHABLE_KEY = E2E_PK || process.env.VITE_CLERK_PUBLISHABLE_KEY;
+if (E2E_SK) process.env.CLERK_SECRET_KEY = E2E_SK;
 
 export default defineConfig({
   testDir: './e2e',
@@ -24,20 +29,27 @@ export default defineConfig({
   fullyParallel: false,
   reporter: 'list',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: 'https://dev.canvasm.app:3000',
+    ignoreHTTPSErrors: true, // self-signed local cert
     viewport: { width: 1440, height: 900 },
   },
   projects: [
     {
       name: 'chrome',
-      // Use the system Google Chrome (installed) instead of downloading Chromium.
       use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     },
   ],
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: true,
+    url: 'https://dev.canvasm.app:3000',
+    ignoreHTTPSErrors: true,
+    // Serve HTTPS (E2E_HTTPS) + use the dev pk_test for the e2e server only.
+    // Vite gives real env vars priority over .env files, so this wins.
+    env: {
+      E2E_HTTPS: '1',
+      ...(E2E_PK ? { VITE_CLERK_PUBLISHABLE_KEY: E2E_PK } : {}),
+    },
+    reuseExistingServer: false,
     timeout: 120_000,
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
+import fs from "fs";
 import path from "path";
 import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
@@ -18,7 +19,21 @@ export default defineConfig({
   },
   server: {
     port: 3000,
-    host: "0.0.0.0"
+    host: "0.0.0.0",
+    // Local dev + e2e are served on dev.canvasm.app (a canvasm.app subdomain);
+    // Clerk keys reject bare localhost.
+    allowedHosts: [".canvasm.app"],
+    // HTTPS only when E2E_HTTPS is set (self-signed cert under e2e/certs, git-
+    // ignored). A non-localhost origin needs https to be a secure context, or
+    // Clerk's Web Crypto (crypto.subtle) is undefined. Normal `npm run dev` = http.
+    ...(process.env.E2E_HTTPS && fs.existsSync("e2e/certs/key.pem")
+      ? {
+          https: {
+            key: fs.readFileSync("e2e/certs/key.pem"),
+            cert: fs.readFileSync("e2e/certs/cert.pem"),
+          },
+        }
+      : {}),
   },
   build: {
     // 'hidden' sourcemaps: emit .map files (so React #185 / error_reports stacks


### PR DESCRIPTION
Makes `npm run screenshots` actually capture the app. `pk_live` is domain-locked + needs a secure context, so the harness now serves HTTPS on `dev.canvasm.app` using the Clerk **Development** instance (`pk_test`, no domain lock). Opt-in HTTPS via `E2E_HTTPS` (self-signed cert, auto-generated, gitignored); normal `npm run dev` untouched. Verified: signs in headlessly + captures home/explore/catalog/feed — **confirmed the CVS-156 Logo fix + app-shell render correctly.**