### PR TITLE
feat(connectors): manifest registry + stream catalog (CVS-140)

### DIFF
--- a/docs/data/connector-manifests.md
+++ b/docs/data/connector-manifests.md
@@ -1,0 +1,67 @@
+# Connector manifests & stream catalog (data layer)
+
+The connector manifest registry (`src/shared/lib/connectors/manifests/`, CVS-140) is the
+typed catalog of every connector Metrimap can pull from. Each connector declares how it
+authenticates, which **streams** it exposes, and — the load-bearing link — which
+[canonical schema](./canonical-schemas.md) (CVS-139) each stream normalizes into.
+
+Manifests live **versioned in repo code** and are the source of truth; the Settings /
+Connected-accounts catalog is a **read projection** of them (locked decision on Linear
+**CVS-137 §2**). Nothing here fetches a source, runs OAuth, or touches secrets — that is
+CVS-141 (connection/token model) and CVS-142 (fetch runtime).
+
+## The manifest
+
+Every connector (`manifest.ts`) carries:
+
+| field | meaning |
+| --- | --- |
+| `id` | lower_snake slug, unique (`stripe`, `csv_manual`) |
+| `display_name`, `category` | catalog label + grouping (`analytics`, `payments`, `commerce`, `product_analytics`, `manual`, `research`) |
+| `status` | `mvp` (fully specified) or `placeholder` (registered stub, e.g. Airbyte) |
+| `auth` | `{ type, recommended_scopes? }` — `oauth2` \| `api_key` \| `basic_auth` \| `manual_upload` \| `none` |
+| `history_modes` / `default_history_mode` | `live_query` \| `metric_materialization` \| `customer_owned_destination` (CVS-137 §3) |
+| `storage_policy`, `stores_raw_payloads` | retention posture. **No connector stores raw payloads in v1** — all MVP connectors are `metric_materialization` with `stores_raw_payloads: false` |
+| `normalizer_version`, `rate_limit` | runtime-internal; used by the fetch/normalize runtime, not shown in the UI |
+| `streams[]` | the pullable streams (below) |
+
+Each **stream** declares `name`, `display_name`, its `canonical_schema`, an optional
+`cursor_field` (drives incremental sync), `supported_sync_modes`
+(`full_refresh` / `incremental`), and metric-binding metadata
+(`default_dimensions`, `default_metrics`, `freshness`) consumed later by CVS-144.
+
+## MVP connectors (locked Tier order — CVS-137 §6)
+
+**Tier 0:** `csv_manual` (schema-agnostic import, CVS-151).
+**Tier 1:** `ga4` → `stripe` → `woocommerce` → `shopify` → `posthog` (CVS-146–150).
+**Research placeholder:** `airbyte` (CVS-152 spike).
+
+## Validation
+
+`validateManifest(input)` returns a structured `{ ok, errors }` result (never throws) and
+enforces the rules the Zod shape can't:
+
+- every stream's `canonical_schema` is a **known canonical name** (MVP or registered-later);
+- `default_history_mode` is one of `history_modes`;
+- stream names are unique within a connector;
+- `stores_raw_payloads` is false when `storage_policy` is `no_raw_payload`;
+- an `mvp` connector declares at least one stream.
+
+Every declared manifest is validated in the test suite, so a bad manifest fails CI.
+
+## Reading the registry
+
+```ts
+import {
+  listConnectors,     // filter by { category, status, canonicalSchema }
+  listStreams,        // flattened stream catalog, each tagged with connector + family
+  connectorsForSchema,// which connectors can populate a canonical schema
+  streamsForSchema,   // which streams normalize into a canonical schema
+  publicCatalog,      // secret-free projection for the Settings UI / DB
+} from '@/shared/lib/connectors/manifests';
+```
+
+`toPublicManifest` / `publicCatalog` drop runtime-internal fields (cursor field,
+rate-limit strategy, normalizer version) so the client only ever sees catalog metadata.
+When the Settings UI lands it consumes this projection instead of a hard-coded connector
+list (CVS-90 / CVS-141).

--- a/src/shared/lib/connectors/manifests/definitions.ts
+++ b/src/shared/lib/connectors/manifests/definitions.ts
@@ -1,0 +1,194 @@
+// MVP connector manifests (CVS-140).
+//
+// The Tier-1 native connectors from the locked sequence (GA4 → Stripe → WooCommerce
+// → Shopify → PostHog), plus the Tier-0 CSV/manual adapter and an Airbyte research
+// placeholder (locked decision CVS-137 §6). Each stream names the CVS-139 canonical
+// schema its records normalize into. Per the decision, no raw payloads are stored:
+// every connector is `metric_materialization` with `stores_raw_payloads: false`.
+// These are data only — fetching/OAuth land in CVS-141/142/146–150.
+import type { ConnectorManifest } from './manifest';
+
+const NORMALIZER_V1 = '1.0.0';
+
+/** GA4 — analytics pull via the Data API (CVS-146). */
+export const ga4Manifest: ConnectorManifest = {
+  id: 'ga4',
+  display_name: 'Google Analytics 4',
+  category: 'analytics',
+  status: 'mvp',
+  auth: {
+    type: 'oauth2',
+    recommended_scopes: ['https://www.googleapis.com/auth/analytics.readonly'],
+  },
+  history_modes: ['live_query', 'metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'token_bucket', requests_per_minute: 600, notes: 'GA4 Data API token/property quotas' },
+  streams: [
+    {
+      name: 'events',
+      display_name: 'Events',
+      canonical_schema: 'analytics_event',
+      cursor_field: 'date',
+      supported_sync_modes: ['full_refresh', 'incremental'],
+      default_dimensions: ['date', 'eventName'],
+      default_metrics: ['eventCount'],
+      freshness: 'P1D',
+    },
+    {
+      name: 'page_metrics',
+      display_name: 'Page metrics',
+      canonical_schema: 'page_metric',
+      cursor_field: 'date',
+      supported_sync_modes: ['full_refresh', 'incremental'],
+      default_dimensions: ['date', 'pagePath'],
+      default_metrics: ['screenPageViews', 'sessions'],
+      freshness: 'P1D',
+    },
+    {
+      name: 'funnels',
+      display_name: 'Funnels',
+      canonical_schema: 'funnel_step',
+      cursor_field: 'date',
+      supported_sync_modes: ['full_refresh'],
+      freshness: 'P1D',
+    },
+  ],
+};
+
+/** Stripe — payments/finance family (CVS-147). */
+export const stripeManifest: ConnectorManifest = {
+  id: 'stripe',
+  display_name: 'Stripe',
+  category: 'payments',
+  status: 'mvp',
+  auth: { type: 'api_key', recommended_scopes: ['rak_read_only'] },
+  history_modes: ['live_query', 'metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'token_bucket', requests_per_minute: 6000, notes: 'Stripe ~100 read req/s live' },
+  streams: [
+    { name: 'payments', display_name: 'Payments', canonical_schema: 'payment', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['gross_volume'], freshness: 'PT1H' },
+    { name: 'refunds', display_name: 'Refunds', canonical_schema: 'refund', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'PT1H' },
+    { name: 'payouts', display_name: 'Payouts', canonical_schema: 'payout', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'PT6H' },
+    { name: 'subscriptions', display_name: 'Subscriptions', canonical_schema: 'subscription', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['mrr', 'active_subscriptions'], freshness: 'PT1H' },
+    { name: 'invoices', display_name: 'Invoices', canonical_schema: 'invoice', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'PT1H' },
+    { name: 'customers', display_name: 'Customers', canonical_schema: 'customer', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['new_customers'], freshness: 'PT1H' },
+  ],
+};
+
+/** WooCommerce — commerce via the REST API, basic auth with consumer key/secret (CVS-148). */
+export const wooCommerceManifest: ConnectorManifest = {
+  id: 'woocommerce',
+  display_name: 'WooCommerce',
+  category: 'commerce',
+  status: 'mvp',
+  auth: { type: 'basic_auth', recommended_scopes: ['read'] },
+  history_modes: ['live_query', 'metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'concurrency', max_concurrency: 4, notes: 'Self-hosted store capacity varies' },
+  streams: [
+    { name: 'orders', display_name: 'Orders', canonical_schema: 'commerce_order', cursor_field: 'date_modified_gmt', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['revenue', 'order_count'], freshness: 'PT1H' },
+    { name: 'order_line_items', display_name: 'Order line items', canonical_schema: 'order_line_item', supported_sync_modes: ['full_refresh'], freshness: 'PT1H' },
+    { name: 'products', display_name: 'Products', canonical_schema: 'product', cursor_field: 'date_modified_gmt', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'P1D' },
+    { name: 'customers', display_name: 'Customers', canonical_schema: 'customer', cursor_field: 'date_modified_gmt', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['new_customers'], freshness: 'P1D' },
+    { name: 'refunds', display_name: 'Refunds', canonical_schema: 'refund', cursor_field: 'date_created_gmt', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'PT1H' },
+  ],
+};
+
+/** Shopify — commerce via the GraphQL Admin API (CVS-149). */
+export const shopifyManifest: ConnectorManifest = {
+  id: 'shopify',
+  display_name: 'Shopify',
+  category: 'commerce',
+  status: 'mvp',
+  auth: { type: 'oauth2', recommended_scopes: ['read_orders', 'read_products', 'read_customers'] },
+  history_modes: ['live_query', 'metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'token_bucket', notes: 'Shopify GraphQL calculated query cost / leaky bucket' },
+  streams: [
+    { name: 'orders', display_name: 'Orders', canonical_schema: 'commerce_order', cursor_field: 'updatedAt', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['revenue', 'order_count'], freshness: 'PT1H' },
+    { name: 'order_line_items', display_name: 'Order line items', canonical_schema: 'order_line_item', supported_sync_modes: ['full_refresh'], freshness: 'PT1H' },
+    { name: 'products', display_name: 'Products', canonical_schema: 'product', cursor_field: 'updatedAt', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'P1D' },
+    { name: 'customers', display_name: 'Customers', canonical_schema: 'customer', cursor_field: 'updatedAt', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['new_customers'], freshness: 'P1D' },
+  ],
+};
+
+/** PostHog — product analytics (CVS-150). */
+export const posthogManifest: ConnectorManifest = {
+  id: 'posthog',
+  display_name: 'PostHog',
+  category: 'product_analytics',
+  status: 'mvp',
+  auth: { type: 'api_key', recommended_scopes: ['read'] },
+  history_modes: ['live_query', 'metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'fixed_window', requests_per_minute: 120, notes: 'PostHog personal API key limits' },
+  streams: [
+    { name: 'events', display_name: 'Events', canonical_schema: 'analytics_event', cursor_field: 'timestamp', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['event_count'], freshness: 'PT1H' },
+    { name: 'funnels', display_name: 'Funnels', canonical_schema: 'funnel_step', supported_sync_modes: ['full_refresh'], freshness: 'P1D' },
+    { name: 'cohorts', display_name: 'Cohorts', canonical_schema: 'cohort', supported_sync_modes: ['full_refresh'], freshness: 'P1D' },
+    { name: 'persons', display_name: 'Persons', canonical_schema: 'customer', cursor_field: 'created_at', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'P1D' },
+  ],
+};
+
+/** CSV / Sheets / manual paste — Tier-0 schema-agnostic import (CVS-151). */
+export const csvManualManifest: ConnectorManifest = {
+  id: 'csv_manual',
+  display_name: 'CSV / manual import',
+  category: 'manual',
+  status: 'mvp',
+  auth: { type: 'manual_upload' },
+  history_modes: ['metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'none' },
+  streams: [
+    { name: 'orders', display_name: 'Orders', canonical_schema: 'commerce_order', supported_sync_modes: ['full_refresh'] },
+    { name: 'payments', display_name: 'Payments', canonical_schema: 'payment', supported_sync_modes: ['full_refresh'] },
+    { name: 'events', display_name: 'Events', canonical_schema: 'analytics_event', supported_sync_modes: ['full_refresh'] },
+    { name: 'page_metrics', display_name: 'Metrics', canonical_schema: 'page_metric', supported_sync_modes: ['full_refresh'] },
+  ],
+};
+
+/** Airbyte — long-tail research adapter, not yet implemented (CVS-152 spike). */
+export const airbytePlaceholderManifest: ConnectorManifest = {
+  id: 'airbyte',
+  display_name: 'Airbyte (research)',
+  category: 'research',
+  status: 'placeholder',
+  auth: { type: 'none' },
+  history_modes: ['metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'no_raw_payload',
+  stores_raw_payloads: false,
+  normalizer_version: '0.0.0',
+  rate_limit: { strategy: 'none' },
+  streams: [],
+};
+
+/** Every manifest the registry serves, in the locked Tier order (CVS-137 §6). */
+export const ALL_MANIFESTS: readonly ConnectorManifest[] = [
+  ga4Manifest,
+  stripeManifest,
+  wooCommerceManifest,
+  shopifyManifest,
+  posthogManifest,
+  csvManualManifest,
+  airbytePlaceholderManifest,
+];

--- a/src/shared/lib/connectors/manifests/index.ts
+++ b/src/shared/lib/connectors/manifests/index.ts
@@ -1,0 +1,6 @@
+// Connector manifest registry (CVS-140): the typed catalog of connectors and the
+// canonical schema (CVS-139) each of their streams normalizes into. Import from here.
+// See docs/data/connector-manifests.md.
+export * from './manifest';
+export * from './definitions';
+export * from './registry';

--- a/src/shared/lib/connectors/manifests/manifest.test.ts
+++ b/src/shared/lib/connectors/manifests/manifest.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONNECTOR_MANIFESTS,
+  connectorsForSchema,
+  getConnector,
+  listConnectors,
+  listStreams,
+  publicCatalog,
+  streamsForSchema,
+  toPublicManifest,
+  validateManifest,
+  type ConnectorManifest,
+} from './index';
+import { KNOWN_CANONICAL_NAMES } from './manifest';
+
+const stripe = getConnector('stripe') as ConnectorManifest;
+
+describe('connector registry', () => {
+  it('registers the seven MVP + placeholder connectors with unique ids', () => {
+    const ids = CONNECTOR_MANIFESTS.map((m) => m.id);
+    expect(ids).toEqual(['ga4', 'stripe', 'woocommerce', 'shopify', 'posthog', 'csv_manual', 'airbyte']);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every declared manifest validates', () => {
+    for (const m of CONNECTOR_MANIFESTS) {
+      const res = validateManifest(m);
+      expect(res.ok, `${m.id}: ${res.ok ? '' : JSON.stringify(res.errors)}`).toBe(true);
+    }
+  });
+
+  it('every stream targets a known canonical schema', () => {
+    for (const m of CONNECTOR_MANIFESTS) {
+      for (const s of m.streams) {
+        expect(KNOWN_CANONICAL_NAMES).toContain(s.canonical_schema);
+      }
+    }
+  });
+
+  it('no connector stores raw payloads (locked decision CVS-137 §3)', () => {
+    for (const m of CONNECTOR_MANIFESTS) expect(m.stores_raw_payloads).toBe(false);
+  });
+});
+
+describe('filtering', () => {
+  it('getConnector returns a manifest by id, undefined otherwise', () => {
+    expect(getConnector('stripe')?.display_name).toBe('Stripe');
+    expect(getConnector('nope')).toBeUndefined();
+  });
+
+  it('lists connectors by category', () => {
+    const commerce = listConnectors({ category: 'commerce' }).map((m) => m.id);
+    expect(commerce).toEqual(['woocommerce', 'shopify']);
+  });
+
+  it('lists connectors by status', () => {
+    expect(listConnectors({ status: 'placeholder' }).map((m) => m.id)).toEqual(['airbyte']);
+  });
+
+  it('finds connectors that can populate a canonical schema', () => {
+    expect(connectorsForSchema('payment').map((m) => m.id).sort()).toEqual(['csv_manual', 'stripe']);
+    // analytics_event is served by both GA4 and PostHog
+    expect(connectorsForSchema('analytics_event').map((m) => m.id).sort()).toEqual(['csv_manual', 'ga4', 'posthog']);
+  });
+});
+
+describe('stream catalog', () => {
+  it('flattens streams and tags each with its connector + schema family', () => {
+    const all = listStreams();
+    const total = CONNECTOR_MANIFESTS.reduce((n, m) => n + m.streams.length, 0);
+    expect(all).toHaveLength(total);
+    const payments = all.find((s) => s.canonical_schema === 'payment');
+    expect(payments?.family).toBe('payments');
+  });
+
+  it('streamsForSchema returns only matching streams', () => {
+    const streams = streamsForSchema('commerce_order');
+    expect(streams.length).toBeGreaterThan(0);
+    expect(streams.every((s) => s.canonical_schema === 'commerce_order')).toBe(true);
+    expect(streams.map((s) => s.connector_id).sort()).toEqual(['csv_manual', 'shopify', 'woocommerce']);
+  });
+});
+
+describe('public projection', () => {
+  it('drops runtime-internal fields and stays JSON-serializable', () => {
+    const pub = toPublicManifest(stripe);
+    expect(pub).not.toHaveProperty('normalizer_version');
+    expect(pub).not.toHaveProperty('rate_limit');
+    // streams lose the cursor field but keep binding metadata
+    for (const s of pub.streams) expect(s).not.toHaveProperty('cursor_field');
+    expect(() => JSON.stringify(pub)).not.toThrow();
+    expect(pub.streams.find((s) => s.name === 'payments')?.family).toBe('payments');
+  });
+
+  it('publicCatalog projects every connector', () => {
+    expect(publicCatalog()).toHaveLength(CONNECTOR_MANIFESTS.length);
+  });
+});
+
+describe('validateManifest — rejects malformed manifests', () => {
+  const base = (): ConnectorManifest => structuredClone(stripe);
+
+  it('rejects an unknown canonical schema', () => {
+    const m = base();
+    m.streams[0].canonical_schema = 'not_a_schema';
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('unknown_canonical_schema');
+  });
+
+  it('rejects duplicate stream names', () => {
+    const m = base();
+    m.streams[1].name = m.streams[0].name;
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.some((e) => e.code === 'duplicate_stream_name')).toBe(true);
+  });
+
+  it('rejects a default history mode that is not supported', () => {
+    const m = base();
+    m.history_modes = ['live_query'];
+    m.default_history_mode = 'metric_materialization';
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.some((e) => e.code === 'default_mode_unsupported')).toBe(true);
+  });
+
+  it('rejects storing raw payloads under a no_raw_payload policy', () => {
+    const m = base();
+    m.storage_policy = 'no_raw_payload';
+    m.stores_raw_payloads = true;
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.some((e) => e.code === 'raw_payload_conflict')).toBe(true);
+  });
+
+  it('rejects an MVP connector with no streams', () => {
+    const m = base();
+    m.streams = [];
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.some((e) => e.code === 'mvp_without_streams')).toBe(true);
+  });
+
+  it('rejects a malformed id via the Zod shape', () => {
+    const m = base();
+    (m as { id: string }).id = 'Bad Id';
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/shared/lib/connectors/manifests/manifest.ts
+++ b/src/shared/lib/connectors/manifests/manifest.ts
@@ -1,0 +1,199 @@
+// Connector manifest shape + validation (CVS-140).
+//
+// A manifest is the single typed description of a connector: how it authenticates,
+// which streams it exposes, which canonical schema each stream normalizes into
+// (CVS-139), its cursor/sync/rate-limit behavior, and its storage posture. Manifests
+// live versioned in repo code — the source of truth — and are projected into the DB
+// for the Settings/Connected-accounts catalog (locked decision on Linear CVS-137 §2).
+// Nothing here fetches a source or touches secrets; that is CVS-141/142.
+import { z } from 'zod';
+import { CANONICAL_SCHEMA_NAMES, LATER_SCHEMA_NAMES } from '../canonical';
+
+/** Every canonical schema name a stream may target — defined (MVP) or registered-for-later. */
+export const KNOWN_CANONICAL_NAMES: readonly string[] = [
+  ...CANONICAL_SCHEMA_NAMES,
+  ...LATER_SCHEMA_NAMES,
+];
+
+/** How a connector proves identity to its source. */
+export const AuthType = z.enum([
+  'oauth2',
+  'api_key',
+  'basic_auth',
+  'manual_upload',
+  'none',
+]);
+export type AuthType = z.infer<typeof AuthType>;
+
+/**
+ * How a connector retains history (locked decision CVS-137 §3). v1 defaults bound
+ * metrics to `metric_materialization`; `customer_owned_destination` is deferred to
+ * CVS-155. `live_query` reads on demand and persists nothing.
+ */
+export const HistoryMode = z.enum([
+  'live_query',
+  'metric_materialization',
+  'customer_owned_destination',
+]);
+export type HistoryMode = z.infer<typeof HistoryMode>;
+
+/**
+ * The declared retention posture for source data. Per the locked decision, no raw
+ * third-party payloads are stored by default and there is no short-TTL raw table in
+ * v1 — MVP connectors are `metric_materialization`. The other values exist so the
+ * registry can describe future postures without a schema change.
+ */
+export const StoragePolicy = z.enum([
+  'no_raw_payload',
+  'short_ttl_staging',
+  'metric_materialization',
+  'customer_owned_destination',
+]);
+export type StoragePolicy = z.infer<typeof StoragePolicy>;
+
+export const SyncMode = z.enum(['full_refresh', 'incremental']);
+export type SyncMode = z.infer<typeof SyncMode>;
+
+/** Whether a connector is fully specified (`mvp`) or a registered stub (`placeholder`). */
+export const ConnectorStatus = z.enum(['mvp', 'placeholder']);
+export type ConnectorStatus = z.infer<typeof ConnectorStatus>;
+
+/** UI/category grouping for the connected-accounts catalog. */
+export const ConnectorCategory = z.enum([
+  'analytics',
+  'product_analytics',
+  'payments',
+  'commerce',
+  'manual',
+  'research',
+]);
+export type ConnectorCategory = z.infer<typeof ConnectorCategory>;
+
+export const rateLimitStrategySchema = z.object({
+  strategy: z.enum(['token_bucket', 'fixed_window', 'concurrency', 'none']),
+  requests_per_minute: z.number().int().positive().optional(),
+  max_concurrency: z.number().int().positive().optional(),
+  notes: z.string().optional(),
+});
+export type RateLimitStrategy = z.infer<typeof rateLimitStrategySchema>;
+
+/**
+ * One pullable stream. `canonical_schema` names the CVS-139 schema its records
+ * normalize into; `cursor_field` is the source field that drives incremental sync;
+ * `default_dimensions`/`default_metrics`/`freshness` feed metric binding (CVS-144).
+ */
+export const streamManifestSchema = z.object({
+  name: z.string().min(1),
+  display_name: z.string().min(1),
+  canonical_schema: z.string().min(1),
+  cursor_field: z.string().min(1).optional(),
+  supported_sync_modes: z.array(SyncMode).nonempty(),
+  default_dimensions: z.array(z.string().min(1)).optional(),
+  default_metrics: z.array(z.string().min(1)).optional(),
+  freshness: z.string().min(1).optional(),
+});
+export type StreamManifest = z.infer<typeof streamManifestSchema>;
+
+export const connectorManifestSchema = z.object({
+  id: z.string().regex(/^[a-z0-9_]+$/, 'id must be lower_snake slug'),
+  display_name: z.string().min(1),
+  category: ConnectorCategory,
+  status: ConnectorStatus,
+  auth: z.object({
+    type: AuthType,
+    recommended_scopes: z.array(z.string().min(1)).optional(),
+  }),
+  history_modes: z.array(HistoryMode).nonempty(),
+  default_history_mode: HistoryMode,
+  storage_policy: StoragePolicy,
+  stores_raw_payloads: z.boolean(),
+  normalizer_version: z.string().min(1),
+  rate_limit: rateLimitStrategySchema,
+  streams: z.array(streamManifestSchema),
+});
+export type ConnectorManifest = z.infer<typeof connectorManifestSchema>;
+
+// --- Validation -----------------------------------------------------------
+
+export interface ManifestError {
+  path: string;
+  code: string;
+  message: string;
+}
+
+export type ManifestValidationResult =
+  | { ok: true; manifest: ConnectorManifest }
+  | { ok: false; errors: ManifestError[] };
+
+function issuePath(issue: z.ZodIssue): string {
+  return issue.path.length ? issue.path.join('.') : '$';
+}
+
+/**
+ * Validate an unknown value as a connector manifest. Returns structured errors so
+ * a manifest build or an admin import can report exactly what is wrong — never
+ * throws. Beyond the Zod shape it enforces the cross-field rules the object can't:
+ * known canonical schema per stream, default mode within supported modes, unique
+ * stream names, the no-raw-payload invariant, and that MVP connectors have streams.
+ */
+export function validateManifest(input: unknown): ManifestValidationResult {
+  const parsed = connectorManifestSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: parsed.error.issues.map((i) => ({
+        path: issuePath(i),
+        code: i.code,
+        message: i.message,
+      })),
+    };
+  }
+  const m = parsed.data;
+  const errors: ManifestError[] = [];
+
+  m.streams.forEach((s, idx) => {
+    if (!KNOWN_CANONICAL_NAMES.includes(s.canonical_schema)) {
+      errors.push({
+        path: `streams.${idx}.canonical_schema`,
+        code: 'unknown_canonical_schema',
+        message: `Stream "${s.name}" targets unknown canonical schema "${s.canonical_schema}"`,
+      });
+    }
+  });
+
+  const names = m.streams.map((s) => s.name);
+  const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+  if (dupes.length) {
+    errors.push({
+      path: 'streams',
+      code: 'duplicate_stream_name',
+      message: `Duplicate stream names: ${[...new Set(dupes)].join(', ')}`,
+    });
+  }
+
+  if (!m.history_modes.includes(m.default_history_mode)) {
+    errors.push({
+      path: 'default_history_mode',
+      code: 'default_mode_unsupported',
+      message: `default_history_mode "${m.default_history_mode}" is not in history_modes`,
+    });
+  }
+
+  if (m.storage_policy === 'no_raw_payload' && m.stores_raw_payloads) {
+    errors.push({
+      path: 'stores_raw_payloads',
+      code: 'raw_payload_conflict',
+      message: 'stores_raw_payloads must be false when storage_policy is "no_raw_payload"',
+    });
+  }
+
+  if (m.status === 'mvp' && m.streams.length === 0) {
+    errors.push({
+      path: 'streams',
+      code: 'mvp_without_streams',
+      message: 'An MVP connector must declare at least one stream',
+    });
+  }
+
+  return errors.length ? { ok: false, errors } : { ok: true, manifest: m };
+}

--- a/src/shared/lib/connectors/manifests/registry.ts
+++ b/src/shared/lib/connectors/manifests/registry.ts
@@ -1,0 +1,142 @@
+// Connector manifest registry + stream catalog (CVS-140).
+//
+// One place that knows every connector manifest, lets callers filter connectors and
+// streams by category or canonical schema, and projects a secret-free shape for the
+// Settings/Connected-accounts UI. Repo manifests are the source of truth; the DB is a
+// read projection (locked decision CVS-137 §2). Runtime fetch/OAuth is CVS-141/142.
+import { getSchemaDef } from '../canonical';
+import { ALL_MANIFESTS } from './definitions';
+import type {
+  ConnectorCategory,
+  ConnectorManifest,
+  ConnectorStatus,
+  StreamManifest,
+} from './manifest';
+
+/** All connector manifests, keyed by id. */
+export const CONNECTOR_MANIFESTS: readonly ConnectorManifest[] = ALL_MANIFESTS;
+
+const BY_ID = new Map(CONNECTOR_MANIFESTS.map((m) => [m.id, m]));
+
+export interface ConnectorFilter {
+  category?: ConnectorCategory;
+  status?: ConnectorStatus;
+  /** Only connectors that expose a stream targeting this canonical schema. */
+  canonicalSchema?: string;
+}
+
+/** Look up a connector manifest by id. */
+export function getConnector(id: string): ConnectorManifest | undefined {
+  return BY_ID.get(id);
+}
+
+function matches(m: ConnectorManifest, f: ConnectorFilter): boolean {
+  if (f.category && m.category !== f.category) return false;
+  if (f.status && m.status !== f.status) return false;
+  if (f.canonicalSchema && !m.streams.some((s) => s.canonical_schema === f.canonicalSchema)) return false;
+  return true;
+}
+
+/** List connectors, optionally filtered by category, status, or canonical schema. */
+export function listConnectors(filter: ConnectorFilter = {}): ConnectorManifest[] {
+  return CONNECTOR_MANIFESTS.filter((m) => matches(m, filter));
+}
+
+/** A stream flattened out of its connector — the shape the stream catalog serves. */
+export interface CatalogStream extends StreamManifest {
+  connector_id: string;
+  connector_display_name: string;
+  category: ConnectorCategory;
+  /** Canonical schema family (payments/commerce/…), or null if the schema is a later stub. */
+  family: string | null;
+}
+
+function toCatalogStream(m: ConnectorManifest, s: StreamManifest): CatalogStream {
+  return {
+    ...s,
+    connector_id: m.id,
+    connector_display_name: m.display_name,
+    category: m.category,
+    family: getSchemaDef(s.canonical_schema)?.family ?? null,
+  };
+}
+
+/** The full stream catalog, optionally filtered by category / status / canonical schema. */
+export function listStreams(filter: ConnectorFilter = {}): CatalogStream[] {
+  return listConnectors(filter).flatMap((m) =>
+    m.streams
+      .filter((s) => !filter.canonicalSchema || s.canonical_schema === filter.canonicalSchema)
+      .map((s) => toCatalogStream(m, s))
+  );
+}
+
+/** Every stream (across connectors) that normalizes into a given canonical schema. */
+export function streamsForSchema(canonicalSchema: string): CatalogStream[] {
+  return listStreams({ canonicalSchema });
+}
+
+/** Connectors that can populate a given canonical schema. */
+export function connectorsForSchema(canonicalSchema: string): ConnectorManifest[] {
+  return listConnectors({ canonicalSchema });
+}
+
+// --- Public projection (Settings UI / DB) ---------------------------------
+
+export interface PublicStream {
+  name: string;
+  display_name: string;
+  canonical_schema: string;
+  family: string | null;
+  supported_sync_modes: StreamManifest['supported_sync_modes'];
+  default_dimensions?: string[];
+  default_metrics?: string[];
+  freshness?: string;
+}
+
+export interface PublicConnectorManifest {
+  id: string;
+  display_name: string;
+  category: ConnectorCategory;
+  status: ConnectorStatus;
+  auth: { type: ConnectorManifest['auth']['type']; recommended_scopes?: string[] };
+  history_modes: ConnectorManifest['history_modes'];
+  default_history_mode: ConnectorManifest['default_history_mode'];
+  storage_policy: ConnectorManifest['storage_policy'];
+  stores_raw_payloads: boolean;
+  streams: PublicStream[];
+}
+
+/**
+ * Project a manifest into the catalog shape the Settings UI and DB consume. Manifests
+ * carry no secrets, but this deliberately drops runtime-internal fields (cursor field,
+ * rate-limit strategy, normalizer version) so the client only sees catalog metadata —
+ * satisfying "expose manifest data without leaking secrets or runtime internals".
+ */
+export function toPublicManifest(m: ConnectorManifest): PublicConnectorManifest {
+  return {
+    id: m.id,
+    display_name: m.display_name,
+    category: m.category,
+    status: m.status,
+    auth: { type: m.auth.type, recommended_scopes: m.auth.recommended_scopes },
+    history_modes: m.history_modes,
+    default_history_mode: m.default_history_mode,
+    storage_policy: m.storage_policy,
+    stores_raw_payloads: m.stores_raw_payloads,
+    streams: m.streams.map((s) => ({
+      name: s.name,
+      display_name: s.display_name,
+      canonical_schema: s.canonical_schema,
+      family: getSchemaDef(s.canonical_schema)?.family ?? null,
+      supported_sync_modes: s.supported_sync_modes,
+      default_dimensions: s.default_dimensions,
+      default_metrics: s.default_metrics,
+      freshness: s.freshness,
+    })),
+  };
+}
+
+/** The whole catalog as public manifests — the payload the Settings page would render. */
+export function publicCatalog(filter: ConnectorFilter = {}): PublicConnectorManifest[] {
+  return listConnectors(filter).map(toPublicManifest);
+}


### PR DESCRIPTION
Closes CVS-140. Part of the *Canonical schemas & native connectors* project (milestone 1 — Schema foundation).

> **Stacked on #115 (CVS-139).** Base is the `mnadeemramli/cvs-139-build-canonical-schema-package` branch — the manifest registry validates streams against that canonical schema package. Retarget base to `main` once #115 merges.

## What this adds
`src/shared/lib/connectors/manifests/` — the typed connector catalog:

- **`manifest.ts`** — the `ConnectorManifest` / `StreamManifest` shape (Zod) plus `validateManifest`, which enforces the cross-field rules the shape can't: every stream's `canonical_schema` is a known CVS-139 schema, `default_history_mode ∈ history_modes`, unique stream names, the no-raw-payload invariant, and MVP-has-streams.
- **`definitions.ts`** — MVP manifests in the locked Tier order (CVS-137 §6): GA4, Stripe, WooCommerce, Shopify, PostHog, CSV/manual, and an Airbyte research placeholder. Each stream names the canonical schema it normalizes into.
- **`registry.ts`** — `getConnector`, `listConnectors`, `listStreams`, `connectorsForSchema`, `streamsForSchema` (filter by category / status / canonical schema), plus `toPublicManifest` / `publicCatalog` — a **secret-free** projection that drops runtime-internal fields (cursor field, rate-limit strategy, normalizer version) for the future Settings catalog.
- **`docs/data/connector-manifests.md`** — infra doc.

## Locked-decision alignment (CVS-137)
- §2 — manifests versioned in repo code (source of truth), projected for the UI.
- §3 — no raw payloads: every connector is `metric_materialization`, `stores_raw_payloads: false` (asserted in tests).
- §6 — MVP schemas + Tier-1 connector order.

## Acceptance criteria
- [x] Manifest schema implemented and validated
- [x] MVP connector manifests exist and are test-covered
- [x] Registry lists connectors and streams by category / canonical schema
- [x] Storage policy explicit per connector
- [x] Settings UI can consume registry metadata later (public projection) without hard-coded lists

## Verification
18 manifest tests + full suite (314 tests), type-check, and lint pass via the Husky pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)