### PR TITLE
feat(search): global cross-canvas search command palette (CVS-83)

### DIFF
--- a/docs/data/canonical-schemas.md
+++ b/docs/data/canonical-schemas.md
@@ -1,0 +1,86 @@
+# Canonical schemas (data layer)
+
+The canonical schema package (`src/shared/lib/connectors/canonical/`, CVS-139) is the
+shared data contract for **both** ingestion paths:
+
+- **Native connectors** — Metrimap fetches from a source API, normalizes into canonical
+  records (CVS-140–150).
+- **Agent push** — the user's agent fetches elsewhere and pushes via MCP/API
+  (CVS-98–104).
+
+Both validate, bind, and materialize through the same schemas, so metric logic is never
+reinvented per integration. Design authority: the vault doc *"PRD/4. Product/5. Canonical
+Schemas and Native Connectors"* and the locked decision on Linear **CVS-137**.
+
+## The envelope
+
+Every canonical record carries the same envelope (`envelope.ts`):
+
+| field | meaning |
+| --- | --- |
+| `schema` | canonical schema name (discriminator), e.g. `payment` |
+| `schema_version` | semver of the schema contract (`1.0.0`) |
+| `source` | connector id, e.g. `stripe`, `ga4` |
+| `source_account_id` | the connected account/property/store id |
+| `source_object_id` | the source's id for this object (lineage + dedupe) |
+| `workspace_id` | owning workspace (RLS scope) |
+| `observed_at` / `occurred_at` | when Metrimap saw it / when it happened (ISO-8601, offset ok) |
+| `currency` / `amount` / `amount_unit` | money (see below); present only on money-bearing schemas |
+| `attributes` | typed, per-schema fields |
+| `lineage` | `{ connector_version, cursor?, normalizer_version }` |
+
+**Money:** `amount` is the record's principal monetary value (payment amount, order total,
+invoice total, line total, product price) and is stored in **minor units** by default
+(`amount_unit: "minor"`, e.g. cents). `amount` must be an integer when the unit is minor.
+Use the `money.ts` helpers (`toMinor` / `toMajor` / `currencyExponent`, which handle
+zero-decimal currencies like JPY and three-decimal like KWD).
+
+## MVP schemas (v1)
+
+Only the schemas the Tier-1 connectors need are fully defined; the rest are reserved names
+in `registry.ts` (`LATER_SCHEMA_NAMES`) and defined when their connector lands.
+
+| family | schemas |
+| --- | --- |
+| payments | `payment`, `refund`, `payout`, `subscription`, `invoice` |
+| commerce | `commerce_order`, `order_line_item`, `product`, `customer` |
+| analytics | `analytics_event`, `page_metric`, `funnel_step`, `cohort` |
+
+Reserved for later (marketing/sales/long tail): `ad_campaign`, `ad_metric`, `lead`, `deal`,
+`ticket`, `balance_transaction`, `dispute`, `tax_document`, `ledger_entry`, `inventory_item`,
+`session`, `feature_flag`, … (see `LATER_SCHEMA_NAMES`).
+
+Source-specific extras belong in the typed `attributes` object of a schema **only when a
+known use case needs them** — not as a dumping ground for raw payload fields. No raw
+third-party payloads are stored by default (locked in CVS-137).
+
+## Validating a record
+
+```ts
+import { validateRecord, dedupeKey } from '@/shared/lib/connectors/canonical';
+
+const res = validateRecord(record);
+if (!res.ok) {
+  // res.errors: { path, code, message }[] — surface in a connector run report
+} else {
+  const key = dedupeKey(res.record); // stable upsert key across runs
+}
+```
+
+`validateRecord` never throws. Beyond Zod shape validation it enforces two cross-field
+rules: the `schema_version` must match the registered version, and `amount` must be an
+integer when `amount_unit` is `"minor"`. Error codes include `unknown_schema`,
+`schema_not_yet_supported` (a reserved name), `version_mismatch`, and `non_integer_minor`.
+
+## Versioning
+
+`schema_version` is explicit per record and checked on validation. Bump
+`CANONICAL_SCHEMA_VERSION` (and a schema's registered `version`) on a breaking change;
+normalizers then emit the new version and old records fail fast with `version_mismatch`
+rather than silently mis-binding.
+
+## Not here
+
+Manifest/JSON-Schema export (for the connector registry + external contract) is **CVS-140**;
+the fetch/normalization/binding runtime is **CVS-141–145**. This package is contracts +
+validation only.

--- a/docs/data/connector-manifests.md
+++ b/docs/data/connector-manifests.md
@@ -1,0 +1,67 @@
+# Connector manifests & stream catalog (data layer)
+
+The connector manifest registry (`src/shared/lib/connectors/manifests/`, CVS-140) is the
+typed catalog of every connector Metrimap can pull from. Each connector declares how it
+authenticates, which **streams** it exposes, and — the load-bearing link — which
+[canonical schema](./canonical-schemas.md) (CVS-139) each stream normalizes into.
+
+Manifests live **versioned in repo code** and are the source of truth; the Settings /
+Connected-accounts catalog is a **read projection** of them (locked decision on Linear
+**CVS-137 §2**). Nothing here fetches a source, runs OAuth, or touches secrets — that is
+CVS-141 (connection/token model) and CVS-142 (fetch runtime).
+
+## The manifest
+
+Every connector (`manifest.ts`) carries:
+
+| field | meaning |
+| --- | --- |
+| `id` | lower_snake slug, unique (`stripe`, `csv_manual`) |
+| `display_name`, `category` | catalog label + grouping (`analytics`, `payments`, `commerce`, `product_analytics`, `manual`, `research`) |
+| `status` | `mvp` (fully specified) or `placeholder` (registered stub, e.g. Airbyte) |
+| `auth` | `{ type, recommended_scopes? }` — `oauth2` \| `api_key` \| `basic_auth` \| `manual_upload` \| `none` |
+| `history_modes` / `default_history_mode` | `live_query` \| `metric_materialization` \| `customer_owned_destination` (CVS-137 §3) |
+| `storage_policy`, `stores_raw_payloads` | retention posture. **No connector stores raw payloads in v1** — all MVP connectors are `metric_materialization` with `stores_raw_payloads: false` |
+| `normalizer_version`, `rate_limit` | runtime-internal; used by the fetch/normalize runtime, not shown in the UI |
+| `streams[]` | the pullable streams (below) |
+
+Each **stream** declares `name`, `display_name`, its `canonical_schema`, an optional
+`cursor_field` (drives incremental sync), `supported_sync_modes`
+(`full_refresh` / `incremental`), and metric-binding metadata
+(`default_dimensions`, `default_metrics`, `freshness`) consumed later by CVS-144.
+
+## MVP connectors (locked Tier order — CVS-137 §6)
+
+**Tier 0:** `csv_manual` (schema-agnostic import, CVS-151).
+**Tier 1:** `ga4` → `stripe` → `woocommerce` → `shopify` → `posthog` (CVS-146–150).
+**Research placeholder:** `airbyte` (CVS-152 spike).
+
+## Validation
+
+`validateManifest(input)` returns a structured `{ ok, errors }` result (never throws) and
+enforces the rules the Zod shape can't:
+
+- every stream's `canonical_schema` is a **known canonical name** (MVP or registered-later);
+- `default_history_mode` is one of `history_modes`;
+- stream names are unique within a connector;
+- `stores_raw_payloads` is false when `storage_policy` is `no_raw_payload`;
+- an `mvp` connector declares at least one stream.
+
+Every declared manifest is validated in the test suite, so a bad manifest fails CI.
+
+## Reading the registry
+
+```ts
+import {
+  listConnectors,     // filter by { category, status, canonicalSchema }
+  listStreams,        // flattened stream catalog, each tagged with connector + family
+  connectorsForSchema,// which connectors can populate a canonical schema
+  streamsForSchema,   // which streams normalize into a canonical schema
+  publicCatalog,      // secret-free projection for the Settings UI / DB
+} from '@/shared/lib/connectors/manifests';
+```
+
+`toPublicManifest` / `publicCatalog` drop runtime-internal fields (cursor field,
+rate-limit strategy, normalizer version) so the client only ever sees catalog metadata.
+When the Settings UI lands it consumes this projection instead of a hard-coded connector
+list (CVS-90 / CVS-141).

--- a/src/features/canvas/components/search/QuickSearchCommand.tsx
+++ b/src/features/canvas/components/search/QuickSearchCommand.tsx
@@ -1,17 +1,26 @@
-import { Button } from '@/shared/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/shared/components/ui/command';
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
   DialogTitle,
 } from '@/shared/components/ui/dialog';
-import { Input } from '@/shared/components/ui/input';
-import { useState } from 'react';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import { searchAcrossCanvases } from '@/shared/lib/supabase/services/search';
+import { BarChart3, FileText } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
-interface QuickSearchResult {
+export interface QuickSearchResult {
   type: 'metric' | 'relationship' | 'evidence';
   id: string;
   title: string;
+  subtitle?: string;
   // The owning canvas/project id of the result, threaded through so the
   // consumer can navigate to the correct canvas instead of a hardcoded one.
   data?: { canvasId?: string };
@@ -36,32 +45,133 @@ export function useQuickSearch() {
 export default function QuickSearchCommand({
   isOpen,
   onClose,
+  onResultSelect,
 }: QuickSearchCommandProps) {
-  const [searchTerm, setSearchTerm] = useState('');
+  const client = useClerkSupabase();
+  const [term, setTerm] = useState('');
+  const [results, setResults] = useState<QuickSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // Reset state each time the palette closes so it opens fresh.
+  useEffect(() => {
+    if (!isOpen) {
+      setTerm('');
+      setResults([]);
+      setLoading(false);
+    }
+  }, [isOpen]);
+
+  // Debounced cross-canvas search (CVS-83). RLS scopes results to accessible
+  // canvases; cmdk filtering is disabled (shouldFilter=false) since the DB filters.
+  useEffect(() => {
+    if (!isOpen) return;
+    const q = term.trim();
+    if (q.length < 2) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    const handle = setTimeout(async () => {
+      try {
+        const found = await searchAcrossCanvases(q, client ?? undefined);
+        if (cancelled) return;
+        setResults(
+          found.map((r) => ({
+            type: r.type,
+            id: r.id,
+            title: r.title,
+            subtitle: r.subtitle,
+            data: { canvasId: r.canvasId ?? undefined },
+          }))
+        );
+      } catch (err) {
+        console.error('Global search failed:', err);
+        if (!cancelled) setResults([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [term, isOpen, client]);
+
+  const metrics = results.filter((r) => r.type === 'metric');
+  const evidence = results.filter((r) => r.type === 'evidence');
+  const select = (r: QuickSearchResult) => {
+    onResultSelect(r);
+    onClose();
+  };
+
+  const trimmed = term.trim();
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Quick Search</DialogTitle>
-        </DialogHeader>
-        <div className="p-4">
-          <Input
-            placeholder="Search metrics, relationships, evidence..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="mb-4"
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="overflow-hidden p-0" showCloseButton={false}>
+        <DialogTitle className="sr-only">Search all canvases</DialogTitle>
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Search all canvases — metrics, evidence…"
+            value={term}
+            onValueChange={setTerm}
           />
-          <p className="text-gray-600 mb-4">
-            Quick search is being rebuilt after the reorganization.
-          </p>
-          <Button onClick={onClose}>Close</Button>
-        </div>
+          <CommandList>
+            {trimmed.length < 2 ? (
+              <CommandEmpty>
+                Type at least 2 characters to search across your canvases.
+              </CommandEmpty>
+            ) : loading ? (
+              <CommandEmpty>Searching…</CommandEmpty>
+            ) : results.length === 0 ? (
+              <CommandEmpty>No matches for “{trimmed}”.</CommandEmpty>
+            ) : (
+              <>
+                {metrics.length > 0 && (
+                  <CommandGroup heading="Metrics">
+                    {metrics.map((r) => (
+                      <CommandItem
+                        key={`m-${r.id}`}
+                        value={`m-${r.id}`}
+                        onSelect={() => select(r)}
+                      >
+                        <BarChart3 className="mr-2 h-4 w-4 text-blue-600" />
+                        <span className="flex-1 truncate">{r.title}</span>
+                        {r.subtitle && (
+                          <span className="ml-2 shrink-0 truncate text-xs text-muted-foreground">
+                            {r.subtitle}
+                          </span>
+                        )}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+                {evidence.length > 0 && (
+                  <CommandGroup heading="Evidence">
+                    {evidence.map((r) => (
+                      <CommandItem
+                        key={`e-${r.id}`}
+                        value={`e-${r.id}`}
+                        onSelect={() => select(r)}
+                      >
+                        <FileText className="mr-2 h-4 w-4 text-green-600" />
+                        <span className="flex-1 truncate">{r.title}</span>
+                        {r.subtitle && (
+                          <span className="ml-2 shrink-0 truncate text-xs text-muted-foreground">
+                            {r.subtitle}
+                          </span>
+                        )}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+              </>
+            )}
+          </CommandList>
+        </Command>
       </DialogContent>
     </Dialog>
   );
 }
-
-
-
-

--- a/src/shared/components/layout/AppShell.tsx
+++ b/src/shared/components/layout/AppShell.tsx
@@ -9,10 +9,10 @@ import {
   Sparkles,
   Star,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom';
 
-import AdvancedSearchModal from '@/features/canvas/components/search/AdvancedSearchModal';
+import QuickSearchCommand from '@/features/canvas/components/search/QuickSearchCommand';
 import { NotificationInbox } from '@/features/notifications/components/NotificationInbox';
 import { useProjectsStore } from '@/lib/stores';
 import { Logo } from '@/shared/components/layout/Logo';
@@ -53,6 +53,33 @@ export default function AppShell() {
   const location = useLocation();
   const navigate = useNavigate();
   const [searchOpen, setSearchOpen] = useState(false);
+
+  // Shift+F opens global cross-canvas search (matches the sidebar tooltip).
+  // Ignored while typing in an input/textarea/contenteditable.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (
+        t &&
+        (t.tagName === 'INPUT' ||
+          t.tagName === 'TEXTAREA' ||
+          t.isContentEditable)
+      )
+        return;
+      if (
+        e.shiftKey &&
+        e.key.toLowerCase() === 'f' &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey
+      ) {
+        e.preventDefault();
+        setSearchOpen(true);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
 
   const projects = useProjectsStore((s) => s.projects);
   const pinned = (Array.isArray(projects) ? projects : [])
@@ -153,7 +180,7 @@ export default function AppShell() {
         </div>
       </SidebarInset>
 
-      <AdvancedSearchModal
+      <QuickSearchCommand
         isOpen={searchOpen}
         onClose={() => setSearchOpen(false)}
         onResultSelect={(result) => {

--- a/src/shared/lib/connectors/canonical/canonical.test.ts
+++ b/src/shared/lib/connectors/canonical/canonical.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CANONICAL_SCHEMAS,
+  CANONICAL_SCHEMA_NAMES,
+  CANONICAL_SCHEMA_VERSION,
+  LATER_SCHEMA_NAMES,
+  SCHEMA_FAMILIES,
+  dedupeKey,
+  getSchemaDef,
+  validateRecord,
+} from './index';
+import { currencyExponent, formatMoney, toMajor, toMinor } from './money';
+import { SOURCE_FIXTURES } from './fixtures';
+
+describe('canonical registry', () => {
+  it('registers the 13 MVP schemas with consistent metadata', () => {
+    expect(CANONICAL_SCHEMA_NAMES).toHaveLength(13);
+    for (const name of CANONICAL_SCHEMA_NAMES) {
+      const def = CANONICAL_SCHEMAS[name];
+      expect(def.name).toBe(name);
+      expect(def.mvp).toBe(true);
+      expect(def.version).toBe(CANONICAL_SCHEMA_VERSION);
+      expect(SCHEMA_FAMILIES).toContain(def.family);
+      expect(['required', 'optional', 'none']).toContain(def.money);
+    }
+  });
+
+  it('does not overlap MVP names with the reserved later-schema names', () => {
+    const later = new Set<string>(LATER_SCHEMA_NAMES);
+    for (const name of CANONICAL_SCHEMA_NAMES) expect(later.has(name)).toBe(false);
+  });
+});
+
+describe('validateRecord — source fixtures', () => {
+  for (const fx of SOURCE_FIXTURES) {
+    it(`${fx.source}: accepts a well-formed ${fx.schema}`, () => {
+      const res = validateRecord(fx.valid);
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.record.schema).toBe(fx.schema);
+        expect(res.def.name).toBe(fx.schema);
+      }
+    });
+
+    it(`${fx.source}: rejects a bad ${fx.schema} (${fx.invalidReason})`, () => {
+      const res = validateRecord(fx.invalid);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.errors.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+describe('validateRecord — structured errors', () => {
+  const base = SOURCE_FIXTURES[1].valid as Record<string, unknown>; // stripe payment
+
+  it('flags a non-object input', () => {
+    const res = validateRecord(42);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('invalid_type');
+  });
+
+  it('flags a missing schema discriminator', () => {
+    const noSchema = Object.fromEntries(Object.entries(base).filter(([k]) => k !== 'schema'));
+    const res = validateRecord(noSchema);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('missing_schema');
+  });
+
+  it('flags a totally unknown schema', () => {
+    const res = validateRecord({ ...base, schema: 'not_a_thing' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('unknown_schema');
+  });
+
+  it('flags a reserved-but-unimplemented schema distinctly', () => {
+    const res = validateRecord({ ...base, schema: 'ledger_entry' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('schema_not_yet_supported');
+  });
+
+  it('flags a schema_version mismatch', () => {
+    const res = validateRecord({ ...base, schema_version: '2.0.0' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('version_mismatch');
+  });
+
+  it('flags a non-integer amount when amount_unit is "minor"', () => {
+    const res = validateRecord({ ...base, amount: 129.5 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.some((e) => e.code === 'non_integer_minor')).toBe(true);
+  });
+});
+
+describe('validateRecord — defaults', () => {
+  it('applies the analytics_event count default', () => {
+    const posthog = SOURCE_FIXTURES[4].valid as Record<string, unknown>;
+    const attrs = posthog.attributes as Record<string, unknown>;
+    const withoutCount = { ...posthog, attributes: { ...attrs, count: undefined } };
+    const res = validateRecord(withoutCount);
+    expect(res.ok).toBe(true);
+    if (res.ok && res.record.schema === 'analytics_event') {
+      expect(res.record.attributes.count).toBe(1);
+    }
+  });
+});
+
+describe('dedupeKey', () => {
+  it('is stable and namespaced by source/account/schema/object', () => {
+    const rec = { source: 'stripe', source_account_id: 'acct_1', schema: 'payment', source_object_id: 'pi_9' };
+    expect(dedupeKey(rec)).toBe('stripe:acct_1:payment:pi_9');
+    expect(dedupeKey(rec)).toBe(dedupeKey({ ...rec }));
+  });
+});
+
+describe('getSchemaDef', () => {
+  it('returns a def for a known schema and undefined otherwise', () => {
+    expect(getSchemaDef('payment')?.name).toBe('payment');
+    expect(getSchemaDef('nope')).toBeUndefined();
+  });
+});
+
+describe('money helpers', () => {
+  it('knows minor-unit exponents', () => {
+    expect(currencyExponent('USD')).toBe(2);
+    expect(currencyExponent('myr')).toBe(2);
+    expect(currencyExponent('JPY')).toBe(0);
+    expect(currencyExponent('KWD')).toBe(3);
+  });
+
+  it('round-trips minor/major across exponents', () => {
+    expect(toMinor(12.9, 'MYR')).toBe(1290);
+    expect(toMajor(1290, 'MYR')).toBe(12.9);
+    expect(toMinor(1000, 'JPY')).toBe(1000);
+    expect(toMinor(1.234, 'KWD')).toBe(1234);
+  });
+
+  it('formats a minor amount without throwing on odd codes', () => {
+    expect(formatMoney(1290, 'MYR')).toContain('12.90');
+    expect(() => formatMoney(1000, 'ZZZ')).not.toThrow();
+  });
+});

--- a/src/shared/lib/connectors/canonical/envelope.ts
+++ b/src/shared/lib/connectors/canonical/envelope.ts
@@ -1,0 +1,94 @@
+// Canonical record envelope + schema-definition helper (CVS-139).
+//
+// Every canonical record — regardless of source (Stripe, GA4, WooCommerce, …) —
+// carries the same envelope. Per-schema shapes extend it with a `schema` literal
+// and a typed `attributes` object. Validation and versioning rules live in
+// `registry.ts`; this file only defines the shared contract. See the locked
+// decision on Linear CVS-137 and docs/data/canonical-schemas.md.
+import { z } from 'zod';
+
+/** Current envelope + schema contract version. Bump on breaking schema changes. */
+export const CANONICAL_SCHEMA_VERSION = '1.0.0';
+
+// ISO-8601 timestamp; accepts both `Z` and numeric offsets like `+08:00`.
+const isoDateTime = z.string().datetime({ offset: true });
+
+export const AmountUnit = z.enum(['minor', 'major']);
+export type AmountUnit = z.infer<typeof AmountUnit>;
+
+/** Provenance carried on every record so materialized metrics stay traceable. */
+export const Lineage = z.object({
+  connector_version: z.string().min(1),
+  cursor: z.string().optional(),
+  normalizer_version: z.string().min(1),
+});
+export type Lineage = z.infer<typeof Lineage>;
+
+export const SCHEMA_FAMILIES = [
+  'payments',
+  'commerce',
+  'analytics',
+  'marketing',
+  'sales',
+] as const;
+export type SchemaFamily = (typeof SCHEMA_FAMILIES)[number];
+
+/** Whether a schema requires the money fields (currency/amount/amount_unit). */
+export type MoneyMode = 'required' | 'optional' | 'none';
+
+/**
+ * The shared envelope every canonical record carries. Money fields are optional
+ * at the base; money-bearing schemas (payment, order, …) re-require them via
+ * `moneyRequired`. `amount` is the record's principal monetary value (payment
+ * amount, order total, invoice total, line total, product price).
+ */
+export const canonicalEnvelope = z.object({
+  schema: z.string().min(1),
+  schema_version: z.string().min(1),
+  source: z.string().min(1),
+  source_account_id: z.string().min(1),
+  source_object_id: z.string().min(1),
+  workspace_id: z.string().min(1),
+  observed_at: isoDateTime,
+  occurred_at: isoDateTime,
+  currency: z.string().length(3).optional(),
+  amount: z.number().finite().optional(),
+  amount_unit: AmountUnit.optional(),
+  attributes: z.record(z.unknown()),
+  lineage: Lineage,
+});
+export type CanonicalEnvelope = z.infer<typeof canonicalEnvelope>;
+
+/** Shape fragment that makes the money fields required (spread into `.extend`). */
+export const moneyRequired = {
+  currency: z.string().length(3),
+  amount: z.number().finite(),
+  amount_unit: AmountUnit,
+} as const;
+
+/** A registered canonical schema: its Zod contract plus metadata. */
+export interface CanonicalSchemaDef<Name extends string = string> {
+  name: Name;
+  version: string;
+  family: SchemaFamily;
+  mvp: boolean;
+  money: MoneyMode;
+  schema: z.ZodTypeAny;
+}
+
+/** Wrap a built Zod record schema with its registry metadata. */
+export function canonical<Name extends string>(
+  name: Name,
+  family: SchemaFamily,
+  schema: z.ZodTypeAny,
+  opts: { money?: MoneyMode; mvp?: boolean; version?: string } = {}
+): CanonicalSchemaDef<Name> {
+  return {
+    name,
+    family,
+    schema,
+    money: opts.money ?? 'none',
+    mvp: opts.mvp ?? true,
+    version: opts.version ?? CANONICAL_SCHEMA_VERSION,
+  };
+}

--- a/src/shared/lib/connectors/canonical/fixtures.ts
+++ b/src/shared/lib/connectors/canonical/fixtures.ts
@@ -1,0 +1,153 @@
+// Canonical record fixtures for the Tier-1 connector families (CVS-139).
+//
+// Each entry is a NORMALIZED canonical record (what a connector's normalizer emits,
+// not the raw source JSON) plus a deliberately-broken variant. Used by the tests
+// and reusable as golden inputs for the normalization runtime (CVS-143) later.
+import type { CanonicalSchemaName } from './registry';
+import type {
+  AnalyticsEventRecord,
+  CommerceOrderRecord,
+  OrderLineItemRecord,
+  PageMetricRecord,
+  PaymentRecord,
+} from './schemas';
+
+export interface SourceFixture {
+  source: string;
+  schema: CanonicalSchemaName;
+  /** A well-formed record that must validate. */
+  valid: unknown;
+  /** A malformed record that must be rejected, and why. */
+  invalid: unknown;
+  invalidReason: string;
+}
+
+const ga4PageMetric = {
+  schema: 'page_metric',
+  schema_version: '1.0.0',
+  source: 'ga4',
+  source_account_id: 'properties/123456',
+  source_object_id: 'ga4:2026-07-01:/pricing:screenPageViews',
+  workspace_id: 'ws_1',
+  observed_at: '2026-07-02T00:00:00Z',
+  occurred_at: '2026-07-01T00:00:00Z',
+  attributes: {
+    page_path: '/pricing',
+    metric: 'screenPageViews',
+    value: 1240,
+    dimensions: { country: 'MY' },
+  },
+  lineage: { connector_version: 'ga4@1.0.0', normalizer_version: 'page_metric@1.0.0' },
+} satisfies PageMetricRecord;
+
+const stripePayment = {
+  schema: 'payment',
+  schema_version: '1.0.0',
+  source: 'stripe',
+  source_account_id: 'acct_123',
+  source_object_id: 'pi_abc',
+  workspace_id: 'ws_1',
+  observed_at: '2026-07-03T12:31:00Z',
+  occurred_at: '2026-07-03T12:30:00+08:00',
+  currency: 'MYR',
+  amount: 12900,
+  amount_unit: 'minor',
+  attributes: { status: 'succeeded', customer_source_id: 'cus_1', payment_method: 'card' },
+  lineage: { connector_version: 'stripe@1.0.0', normalizer_version: 'payment@1.0.0' },
+} satisfies PaymentRecord;
+
+const wooOrder = {
+  schema: 'commerce_order',
+  schema_version: '1.0.0',
+  source: 'woocommerce',
+  source_account_id: 'store_1',
+  source_object_id: 'order_1001',
+  workspace_id: 'ws_1',
+  observed_at: '2026-07-03T09:00:00Z',
+  occurred_at: '2026-07-03T08:59:00Z',
+  currency: 'MYR',
+  amount: 25990,
+  amount_unit: 'minor',
+  attributes: { status: 'completed', customer_source_id: 'cust_5', line_item_count: 3 },
+  lineage: { connector_version: 'woocommerce@1.0.0', normalizer_version: 'commerce_order@1.0.0' },
+} satisfies CommerceOrderRecord;
+
+const shopifyLineItem = {
+  schema: 'order_line_item',
+  schema_version: '1.0.0',
+  source: 'shopify',
+  source_account_id: 'shop_1',
+  source_object_id: 'li_9',
+  workspace_id: 'ws_1',
+  observed_at: '2026-07-03T09:00:00Z',
+  occurred_at: '2026-07-03T08:59:00Z',
+  currency: 'MYR',
+  amount: 8990,
+  amount_unit: 'minor',
+  attributes: {
+    order_source_id: 'order_77',
+    product_source_id: 'prod_3',
+    sku: 'TSHIRT-M',
+    title: 'T-Shirt',
+    quantity: 2,
+    unit_amount: 4495,
+  },
+  lineage: { connector_version: 'shopify@1.0.0', normalizer_version: 'order_line_item@1.0.0' },
+} satisfies OrderLineItemRecord;
+
+const posthogEvent = {
+  schema: 'analytics_event',
+  schema_version: '1.0.0',
+  source: 'posthog',
+  source_account_id: 'proj_1',
+  source_object_id: 'evt_555',
+  workspace_id: 'ws_1',
+  observed_at: '2026-07-03T10:00:00Z',
+  occurred_at: '2026-07-03T09:59:00Z',
+  attributes: {
+    event_name: 'signed_up',
+    user_source_id: 'user_9',
+    session_id: 'sess_2',
+    count: 1,
+    properties: { plan: 'pro' },
+  },
+  lineage: { connector_version: 'posthog@1.0.0', normalizer_version: 'analytics_event@1.0.0' },
+} satisfies AnalyticsEventRecord;
+
+export const SOURCE_FIXTURES: SourceFixture[] = [
+  {
+    source: 'ga4',
+    schema: 'page_metric',
+    valid: ga4PageMetric,
+    invalid: { ...ga4PageMetric, attributes: { page_path: '/pricing', metric: 'screenPageViews' } },
+    invalidReason: 'page_metric.attributes.value is required',
+  },
+  {
+    source: 'stripe',
+    schema: 'payment',
+    valid: stripePayment,
+    invalid: { ...stripePayment, amount: 129.5 },
+    invalidReason: 'amount must be an integer when amount_unit is "minor"',
+  },
+  {
+    source: 'woocommerce',
+    schema: 'commerce_order',
+    valid: wooOrder,
+    invalid: Object.fromEntries(Object.entries(wooOrder).filter(([k]) => k !== 'amount')),
+    invalidReason: 'commerce_order requires amount (money required)',
+  },
+  {
+    source: 'shopify',
+    schema: 'order_line_item',
+    valid: shopifyLineItem,
+    invalid: { ...shopifyLineItem, attributes: { ...shopifyLineItem.attributes, quantity: 0 } },
+    invalidReason: 'order_line_item.attributes.quantity must be positive',
+  },
+  {
+    source: 'posthog',
+    schema: 'analytics_event',
+    valid: posthogEvent,
+    invalid: { ...posthogEvent, attributes: { user_source_id: 'user_9' } },
+    invalidReason: 'analytics_event.attributes.event_name is required',
+  },
+];

--- a/src/shared/lib/connectors/canonical/index.ts
+++ b/src/shared/lib/connectors/canonical/index.ts
@@ -1,0 +1,7 @@
+// Canonical data layer (CVS-139): the shared contracts both ingestion paths use —
+// native connectors (Metrimap fetches → normalizes) and agent push (MCP/API,
+// CVS-98–104). Import from here. See docs/data/canonical-schemas.md.
+export * from './envelope';
+export * from './money';
+export * from './schemas';
+export * from './registry';

--- a/src/shared/lib/connectors/canonical/money.ts
+++ b/src/shared/lib/connectors/canonical/money.ts
@@ -1,0 +1,41 @@
+// Currency minor-unit helpers for canonical money handling (CVS-139).
+//
+// Canonical records store money in MINOR units by default (e.g. cents), matching
+// how Stripe and most payment APIs represent amounts. These helpers convert to and
+// from major units for display and for ingesting sources that report major units.
+
+// ISO 4217 currencies whose minor unit is the same as the major unit (no decimals).
+const ZERO_DECIMAL = new Set([
+  'JPY', 'KRW', 'VND', 'CLP', 'ISK', 'XOF', 'XAF', 'XPF', 'BIF', 'DJF', 'GNF',
+  'KMF', 'MGA', 'PYG', 'RWF', 'UGX', 'VUV', 'XAG', 'XAU',
+]);
+// Currencies with three minor digits.
+const THREE_DECIMAL = new Set(['BHD', 'KWD', 'OMR', 'TND', 'JOD', 'LYD', 'IQD']);
+
+/** Number of minor-unit digits for an ISO 4217 currency (default 2). */
+export function currencyExponent(currency: string): number {
+  const c = currency.toUpperCase();
+  if (ZERO_DECIMAL.has(c)) return 0;
+  if (THREE_DECIMAL.has(c)) return 3;
+  return 2;
+}
+
+/** Convert a major-unit amount (e.g. 12.90) to minor units (e.g. 1290). */
+export function toMinor(major: number, currency: string): number {
+  return Math.round(major * 10 ** currencyExponent(currency));
+}
+
+/** Convert a minor-unit amount (e.g. 1290) to major units (e.g. 12.90). */
+export function toMajor(minor: number, currency: string): number {
+  return minor / 10 ** currencyExponent(currency);
+}
+
+/** Localized currency string from a minor-unit amount; falls back if Intl rejects the code. */
+export function formatMoney(minor: number, currency: string): string {
+  const major = toMajor(minor, currency);
+  try {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(major);
+  } catch {
+    return `${major} ${currency.toUpperCase()}`;
+  }
+}

--- a/src/shared/lib/connectors/canonical/registry.ts
+++ b/src/shared/lib/connectors/canonical/registry.ts
@@ -1,0 +1,150 @@
+// Canonical schema registry + validation + dedupe (CVS-139).
+//
+// One place that knows every canonical schema, validates an unknown record against
+// the right one, and derives a stable dedupe key. Both ingestion paths use this:
+// native connectors (Metrimap fetches → normalizes) and agent push (MCP/API,
+// CVS-98–104). See docs/data/canonical-schemas.md and the locked decision on CVS-137.
+import type { z } from 'zod';
+import type { CanonicalSchemaDef } from './envelope';
+import { MVP_SCHEMA_DEFS, type AnyCanonicalRecord } from './schemas';
+
+/** name → definition, for the MVP (fully-defined) schemas. */
+export const CANONICAL_SCHEMAS = Object.fromEntries(
+  MVP_SCHEMA_DEFS.map((d) => [d.name, d])
+) as Record<(typeof MVP_SCHEMA_DEFS)[number]['name'], CanonicalSchemaDef>;
+
+export type CanonicalSchemaName = keyof typeof CANONICAL_SCHEMAS;
+export const CANONICAL_SCHEMA_NAMES = Object.keys(CANONICAL_SCHEMAS) as CanonicalSchemaName[];
+
+/**
+ * Schemas named by the design (vault doc) but not yet defined — they get a full
+ * definition when their connector lands (Tier-2/3). Kept here so the registry is
+ * the single list of canonical names and nothing silently invents a new one.
+ */
+export const LATER_SCHEMA_NAMES = [
+  // payments/finance
+  'balance_transaction',
+  'dispute',
+  'tax_document',
+  'ledger_entry',
+  // commerce
+  'inventory_item',
+  'cart',
+  'fulfillment',
+  // analytics
+  'session',
+  'feature_flag',
+  // marketing
+  'ad_campaign',
+  'ad_metric',
+  'social_post',
+  'social_engagement',
+  'email_campaign',
+  'search_query_metric',
+  'video_metric',
+  // sales & support
+  'lead',
+  'deal',
+  'company',
+  'ticket',
+  'customer_health',
+] as const;
+export type LaterSchemaName = (typeof LATER_SCHEMA_NAMES)[number];
+
+/** Look up a defined schema by name. */
+export function getSchemaDef(name: string): CanonicalSchemaDef | undefined {
+  return CANONICAL_SCHEMAS[name as CanonicalSchemaName];
+}
+
+// --- Validation -----------------------------------------------------------
+
+export interface ValidationError {
+  path: string;
+  code: string;
+  message: string;
+}
+
+export type ValidationResult =
+  | { ok: true; record: CanonicalRecord; def: CanonicalSchemaDef }
+  | { ok: false; errors: ValidationError[] };
+
+/** A validated canonical record — the discriminated union of every MVP schema. */
+export type CanonicalRecord = AnyCanonicalRecord;
+
+function issuePath(issue: z.ZodIssue): string {
+  return issue.path.length ? issue.path.join('.') : '$';
+}
+
+/**
+ * Validate an unknown value against its declared canonical schema. Returns a
+ * structured result so connector run reports can surface exactly what failed —
+ * never throws. Also enforces the two cross-field rules the Zod object can't:
+ * schema-version match and integer amounts when `amount_unit` is "minor".
+ */
+export function validateRecord(input: unknown): ValidationResult {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return { ok: false, errors: [{ path: '$', code: 'invalid_type', message: 'Record must be an object' }] };
+  }
+  const name = (input as { schema?: unknown }).schema;
+  if (typeof name !== 'string' || name.length === 0) {
+    return { ok: false, errors: [{ path: 'schema', code: 'missing_schema', message: 'Record is missing a "schema" discriminator' }] };
+  }
+  const def = getSchemaDef(name);
+  if (!def) {
+    const later = (LATER_SCHEMA_NAMES as readonly string[]).includes(name);
+    return {
+      ok: false,
+      errors: [{
+        path: 'schema',
+        code: later ? 'schema_not_yet_supported' : 'unknown_schema',
+        message: later
+          ? `Canonical schema "${name}" is registered but not yet implemented`
+          : `Unknown canonical schema "${name}"`,
+      }],
+    };
+  }
+
+  const parsed = def.schema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: parsed.error.issues.map((i) => ({ path: issuePath(i), code: i.code, message: i.message })),
+    };
+  }
+  const record = parsed.data as CanonicalRecord;
+
+  if (record.schema_version !== def.version) {
+    return {
+      ok: false,
+      errors: [{
+        path: 'schema_version',
+        code: 'version_mismatch',
+        message: `Expected ${def.name}@${def.version}, got "${record.schema_version}"`,
+      }],
+    };
+  }
+  if (record.amount_unit === 'minor' && record.amount !== undefined && !Number.isInteger(record.amount)) {
+    return {
+      ok: false,
+      errors: [{ path: 'amount', code: 'non_integer_minor', message: 'amount must be an integer when amount_unit is "minor"' }],
+    };
+  }
+
+  return { ok: true, record, def };
+}
+
+// --- Dedupe / lineage -----------------------------------------------------
+
+/**
+ * Stable key for deduping and upserting a record across runs. Source object ids
+ * are unique per (source, account, schema), so the same object always maps to the
+ * same key regardless of when it was fetched.
+ */
+export function dedupeKey(record: {
+  source: string;
+  source_account_id: string;
+  schema: string;
+  source_object_id: string;
+}): string {
+  return `${record.source}:${record.source_account_id}:${record.schema}:${record.source_object_id}`;
+}

--- a/src/shared/lib/connectors/canonical/schemas.ts
+++ b/src/shared/lib/connectors/canonical/schemas.ts
@@ -1,0 +1,247 @@
+// MVP canonical schema definitions (CVS-139).
+//
+// 13 schemas across three families prove the contract for the Tier-1 connectors
+// (GA4, Stripe, WooCommerce, Shopify, PostHog). Each is the shared envelope
+// extended with a `schema` literal and a typed `attributes` object; money-bearing
+// schemas re-require currency/amount/amount_unit. Later schemas (marketing, sales,
+// balance_transaction, …) are registered as names in `registry.ts` and defined
+// when their connectors land. See docs/data/canonical-schemas.md.
+import { z } from 'zod';
+import { canonical, canonicalEnvelope, moneyRequired } from './envelope';
+
+// --- Payments & finance ---------------------------------------------------
+
+export const PaymentStatus = z.enum([
+  'succeeded',
+  'pending',
+  'failed',
+  'refunded',
+  'partially_refunded',
+  'canceled',
+]);
+
+export const paymentSchema = canonicalEnvelope.extend({
+  schema: z.literal('payment'),
+  ...moneyRequired,
+  attributes: z.object({
+    status: PaymentStatus,
+    customer_source_id: z.string().optional(),
+    payment_method: z.string().optional(),
+    description: z.string().optional(),
+  }),
+});
+export type PaymentRecord = z.infer<typeof paymentSchema>;
+
+export const RefundStatus = z.enum(['succeeded', 'pending', 'failed', 'canceled']);
+
+export const refundSchema = canonicalEnvelope.extend({
+  schema: z.literal('refund'),
+  ...moneyRequired,
+  attributes: z.object({
+    status: RefundStatus,
+    payment_source_id: z.string().optional(),
+    reason: z.string().optional(),
+  }),
+});
+export type RefundRecord = z.infer<typeof refundSchema>;
+
+export const PayoutStatus = z.enum(['paid', 'pending', 'in_transit', 'failed', 'canceled']);
+
+export const payoutSchema = canonicalEnvelope.extend({
+  schema: z.literal('payout'),
+  ...moneyRequired,
+  attributes: z.object({
+    status: PayoutStatus,
+    arrival_date: z.string().datetime({ offset: true }).optional(),
+    method: z.string().optional(),
+  }),
+});
+export type PayoutRecord = z.infer<typeof payoutSchema>;
+
+export const SubscriptionStatus = z.enum([
+  'active',
+  'trialing',
+  'past_due',
+  'canceled',
+  'unpaid',
+  'paused',
+  'incomplete',
+]);
+export const BillingInterval = z.enum(['day', 'week', 'month', 'year']);
+
+export const subscriptionSchema = canonicalEnvelope.extend({
+  schema: z.literal('subscription'),
+  attributes: z.object({
+    status: SubscriptionStatus,
+    customer_source_id: z.string().optional(),
+    plan: z.string().optional(),
+    interval: BillingInterval.optional(),
+    quantity: z.number().int().nonnegative().optional(),
+    current_period_start: z.string().datetime({ offset: true }).optional(),
+    current_period_end: z.string().datetime({ offset: true }).optional(),
+  }),
+});
+export type SubscriptionRecord = z.infer<typeof subscriptionSchema>;
+
+export const InvoiceStatus = z.enum(['draft', 'open', 'paid', 'void', 'uncollectible']);
+
+export const invoiceSchema = canonicalEnvelope.extend({
+  schema: z.literal('invoice'),
+  ...moneyRequired,
+  attributes: z.object({
+    status: InvoiceStatus,
+    customer_source_id: z.string().optional(),
+    number: z.string().optional(),
+    due_at: z.string().datetime({ offset: true }).optional(),
+    paid_at: z.string().datetime({ offset: true }).optional(),
+  }),
+});
+export type InvoiceRecord = z.infer<typeof invoiceSchema>;
+
+// --- Commerce -------------------------------------------------------------
+
+export const OrderStatus = z.enum([
+  'pending',
+  'paid',
+  'fulfilled',
+  'shipped',
+  'delivered',
+  'completed',
+  'canceled',
+  'refunded',
+]);
+
+export const commerceOrderSchema = canonicalEnvelope.extend({
+  schema: z.literal('commerce_order'),
+  ...moneyRequired,
+  attributes: z.object({
+    status: OrderStatus,
+    customer_source_id: z.string().optional(),
+    line_item_count: z.number().int().nonnegative().optional(),
+    financial_status: z.string().optional(),
+    fulfillment_status: z.string().optional(),
+  }),
+});
+export type CommerceOrderRecord = z.infer<typeof commerceOrderSchema>;
+
+export const orderLineItemSchema = canonicalEnvelope.extend({
+  schema: z.literal('order_line_item'),
+  attributes: z.object({
+    order_source_id: z.string().min(1),
+    product_source_id: z.string().optional(),
+    sku: z.string().optional(),
+    title: z.string().optional(),
+    quantity: z.number().int().positive(),
+    unit_amount: z.number().finite().optional(),
+  }),
+});
+export type OrderLineItemRecord = z.infer<typeof orderLineItemSchema>;
+
+export const ProductStatus = z.enum(['active', 'archived', 'draft']);
+
+export const productSchema = canonicalEnvelope.extend({
+  schema: z.literal('product'),
+  attributes: z.object({
+    title: z.string().min(1),
+    sku: z.string().optional(),
+    status: ProductStatus.optional(),
+    vendor: z.string().optional(),
+    product_type: z.string().optional(),
+  }),
+});
+export type ProductRecord = z.infer<typeof productSchema>;
+
+export const customerSchema = canonicalEnvelope.extend({
+  schema: z.literal('customer'),
+  attributes: z.object({
+    email: z.string().email().optional(),
+    name: z.string().optional(),
+    country: z.string().optional(),
+    orders_count: z.number().int().nonnegative().optional(),
+    created_source_at: z.string().datetime({ offset: true }).optional(),
+  }),
+});
+export type CustomerRecord = z.infer<typeof customerSchema>;
+
+// --- Analytics & product usage (no money) ---------------------------------
+
+export const analyticsEventSchema = canonicalEnvelope.extend({
+  schema: z.literal('analytics_event'),
+  attributes: z.object({
+    event_name: z.string().min(1),
+    user_source_id: z.string().optional(),
+    session_id: z.string().optional(),
+    count: z.number().int().nonnegative().default(1),
+    properties: z.record(z.unknown()).optional(),
+  }),
+});
+export type AnalyticsEventRecord = z.infer<typeof analyticsEventSchema>;
+
+export const pageMetricSchema = canonicalEnvelope.extend({
+  schema: z.literal('page_metric'),
+  attributes: z.object({
+    page_path: z.string().min(1),
+    metric: z.string().min(1),
+    value: z.number().finite(),
+    dimensions: z.record(z.unknown()).optional(),
+  }),
+});
+export type PageMetricRecord = z.infer<typeof pageMetricSchema>;
+
+export const funnelStepSchema = canonicalEnvelope.extend({
+  schema: z.literal('funnel_step'),
+  attributes: z.object({
+    funnel: z.string().min(1),
+    step_name: z.string().min(1),
+    step_index: z.number().int().nonnegative(),
+    users: z.number().int().nonnegative(),
+    conversion_rate: z.number().min(0).max(1).optional(),
+  }),
+});
+export type FunnelStepRecord = z.infer<typeof funnelStepSchema>;
+
+export const cohortSchema = canonicalEnvelope.extend({
+  schema: z.literal('cohort'),
+  attributes: z.object({
+    cohort_key: z.string().min(1),
+    cohort_date: z.string().datetime({ offset: true }).optional(),
+    size: z.number().int().nonnegative(),
+    metric: z.string().optional(),
+    value: z.number().finite().optional(),
+  }),
+});
+export type CohortRecord = z.infer<typeof cohortSchema>;
+
+// --- Registered definitions (name → def + metadata) -----------------------
+
+/** Union of every MVP canonical record type — the validated output of `validateRecord`. */
+export type AnyCanonicalRecord =
+  | PaymentRecord
+  | RefundRecord
+  | PayoutRecord
+  | SubscriptionRecord
+  | InvoiceRecord
+  | CommerceOrderRecord
+  | OrderLineItemRecord
+  | ProductRecord
+  | CustomerRecord
+  | AnalyticsEventRecord
+  | PageMetricRecord
+  | FunnelStepRecord
+  | CohortRecord;
+
+export const MVP_SCHEMA_DEFS = [
+  canonical('payment', 'payments', paymentSchema, { money: 'required' }),
+  canonical('refund', 'payments', refundSchema, { money: 'required' }),
+  canonical('payout', 'payments', payoutSchema, { money: 'required' }),
+  canonical('subscription', 'payments', subscriptionSchema, { money: 'optional' }),
+  canonical('invoice', 'payments', invoiceSchema, { money: 'required' }),
+  canonical('commerce_order', 'commerce', commerceOrderSchema, { money: 'required' }),
+  canonical('order_line_item', 'commerce', orderLineItemSchema, { money: 'optional' }),
+  canonical('product', 'commerce', productSchema, { money: 'optional' }),
+  canonical('customer', 'commerce', customerSchema, { money: 'none' }),
+  canonical('analytics_event', 'analytics', analyticsEventSchema, { money: 'none' }),
+  canonical('page_metric', 'analytics', pageMetricSchema, { money: 'none' }),
+  canonical('funnel_step', 'analytics', funnelStepSchema, { money: 'none' }),
+  canonical('cohort', 'analytics', cohortSchema, { money: 'none' }),
+] as const;

--- a/src/shared/lib/connectors/manifests/definitions.ts
+++ b/src/shared/lib/connectors/manifests/definitions.ts
@@ -1,0 +1,194 @@
+// MVP connector manifests (CVS-140).
+//
+// The Tier-1 native connectors from the locked sequence (GA4 → Stripe → WooCommerce
+// → Shopify → PostHog), plus the Tier-0 CSV/manual adapter and an Airbyte research
+// placeholder (locked decision CVS-137 §6). Each stream names the CVS-139 canonical
+// schema its records normalize into. Per the decision, no raw payloads are stored:
+// every connector is `metric_materialization` with `stores_raw_payloads: false`.
+// These are data only — fetching/OAuth land in CVS-141/142/146–150.
+import type { ConnectorManifest } from './manifest';
+
+const NORMALIZER_V1 = '1.0.0';
+
+/** GA4 — analytics pull via the Data API (CVS-146). */
+export const ga4Manifest: ConnectorManifest = {
+  id: 'ga4',
+  display_name: 'Google Analytics 4',
+  category: 'analytics',
+  status: 'mvp',
+  auth: {
+    type: 'oauth2',
+    recommended_scopes: ['https://www.googleapis.com/auth/analytics.readonly'],
+  },
+  history_modes: ['live_query', 'metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'token_bucket', requests_per_minute: 600, notes: 'GA4 Data API token/property quotas' },
+  streams: [
+    {
+      name: 'events',
+      display_name: 'Events',
+      canonical_schema: 'analytics_event',
+      cursor_field: 'date',
+      supported_sync_modes: ['full_refresh', 'incremental'],
+      default_dimensions: ['date', 'eventName'],
+      default_metrics: ['eventCount'],
+      freshness: 'P1D',
+    },
+    {
+      name: 'page_metrics',
+      display_name: 'Page metrics',
+      canonical_schema: 'page_metric',
+      cursor_field: 'date',
+      supported_sync_modes: ['full_refresh', 'incremental'],
+      default_dimensions: ['date', 'pagePath'],
+      default_metrics: ['screenPageViews', 'sessions'],
+      freshness: 'P1D',
+    },
+    {
+      name: 'funnels',
+      display_name: 'Funnels',
+      canonical_schema: 'funnel_step',
+      cursor_field: 'date',
+      supported_sync_modes: ['full_refresh'],
+      freshness: 'P1D',
+    },
+  ],
+};
+
+/** Stripe — payments/finance family (CVS-147). */
+export const stripeManifest: ConnectorManifest = {
+  id: 'stripe',
+  display_name: 'Stripe',
+  category: 'payments',
+  status: 'mvp',
+  auth: { type: 'api_key', recommended_scopes: ['rak_read_only'] },
+  history_modes: ['live_query', 'metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'token_bucket', requests_per_minute: 6000, notes: 'Stripe ~100 read req/s live' },
+  streams: [
+    { name: 'payments', display_name: 'Payments', canonical_schema: 'payment', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['gross_volume'], freshness: 'PT1H' },
+    { name: 'refunds', display_name: 'Refunds', canonical_schema: 'refund', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'PT1H' },
+    { name: 'payouts', display_name: 'Payouts', canonical_schema: 'payout', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'PT6H' },
+    { name: 'subscriptions', display_name: 'Subscriptions', canonical_schema: 'subscription', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['mrr', 'active_subscriptions'], freshness: 'PT1H' },
+    { name: 'invoices', display_name: 'Invoices', canonical_schema: 'invoice', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'PT1H' },
+    { name: 'customers', display_name: 'Customers', canonical_schema: 'customer', cursor_field: 'created', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['new_customers'], freshness: 'PT1H' },
+  ],
+};
+
+/** WooCommerce — commerce via the REST API, basic auth with consumer key/secret (CVS-148). */
+export const wooCommerceManifest: ConnectorManifest = {
+  id: 'woocommerce',
+  display_name: 'WooCommerce',
+  category: 'commerce',
+  status: 'mvp',
+  auth: { type: 'basic_auth', recommended_scopes: ['read'] },
+  history_modes: ['live_query', 'metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'concurrency', max_concurrency: 4, notes: 'Self-hosted store capacity varies' },
+  streams: [
+    { name: 'orders', display_name: 'Orders', canonical_schema: 'commerce_order', cursor_field: 'date_modified_gmt', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['revenue', 'order_count'], freshness: 'PT1H' },
+    { name: 'order_line_items', display_name: 'Order line items', canonical_schema: 'order_line_item', supported_sync_modes: ['full_refresh'], freshness: 'PT1H' },
+    { name: 'products', display_name: 'Products', canonical_schema: 'product', cursor_field: 'date_modified_gmt', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'P1D' },
+    { name: 'customers', display_name: 'Customers', canonical_schema: 'customer', cursor_field: 'date_modified_gmt', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['new_customers'], freshness: 'P1D' },
+    { name: 'refunds', display_name: 'Refunds', canonical_schema: 'refund', cursor_field: 'date_created_gmt', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'PT1H' },
+  ],
+};
+
+/** Shopify — commerce via the GraphQL Admin API (CVS-149). */
+export const shopifyManifest: ConnectorManifest = {
+  id: 'shopify',
+  display_name: 'Shopify',
+  category: 'commerce',
+  status: 'mvp',
+  auth: { type: 'oauth2', recommended_scopes: ['read_orders', 'read_products', 'read_customers'] },
+  history_modes: ['live_query', 'metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'token_bucket', notes: 'Shopify GraphQL calculated query cost / leaky bucket' },
+  streams: [
+    { name: 'orders', display_name: 'Orders', canonical_schema: 'commerce_order', cursor_field: 'updatedAt', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['revenue', 'order_count'], freshness: 'PT1H' },
+    { name: 'order_line_items', display_name: 'Order line items', canonical_schema: 'order_line_item', supported_sync_modes: ['full_refresh'], freshness: 'PT1H' },
+    { name: 'products', display_name: 'Products', canonical_schema: 'product', cursor_field: 'updatedAt', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'P1D' },
+    { name: 'customers', display_name: 'Customers', canonical_schema: 'customer', cursor_field: 'updatedAt', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['new_customers'], freshness: 'P1D' },
+  ],
+};
+
+/** PostHog — product analytics (CVS-150). */
+export const posthogManifest: ConnectorManifest = {
+  id: 'posthog',
+  display_name: 'PostHog',
+  category: 'product_analytics',
+  status: 'mvp',
+  auth: { type: 'api_key', recommended_scopes: ['read'] },
+  history_modes: ['live_query', 'metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'fixed_window', requests_per_minute: 120, notes: 'PostHog personal API key limits' },
+  streams: [
+    { name: 'events', display_name: 'Events', canonical_schema: 'analytics_event', cursor_field: 'timestamp', supported_sync_modes: ['full_refresh', 'incremental'], default_metrics: ['event_count'], freshness: 'PT1H' },
+    { name: 'funnels', display_name: 'Funnels', canonical_schema: 'funnel_step', supported_sync_modes: ['full_refresh'], freshness: 'P1D' },
+    { name: 'cohorts', display_name: 'Cohorts', canonical_schema: 'cohort', supported_sync_modes: ['full_refresh'], freshness: 'P1D' },
+    { name: 'persons', display_name: 'Persons', canonical_schema: 'customer', cursor_field: 'created_at', supported_sync_modes: ['full_refresh', 'incremental'], freshness: 'P1D' },
+  ],
+};
+
+/** CSV / Sheets / manual paste — Tier-0 schema-agnostic import (CVS-151). */
+export const csvManualManifest: ConnectorManifest = {
+  id: 'csv_manual',
+  display_name: 'CSV / manual import',
+  category: 'manual',
+  status: 'mvp',
+  auth: { type: 'manual_upload' },
+  history_modes: ['metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'metric_materialization',
+  stores_raw_payloads: false,
+  normalizer_version: NORMALIZER_V1,
+  rate_limit: { strategy: 'none' },
+  streams: [
+    { name: 'orders', display_name: 'Orders', canonical_schema: 'commerce_order', supported_sync_modes: ['full_refresh'] },
+    { name: 'payments', display_name: 'Payments', canonical_schema: 'payment', supported_sync_modes: ['full_refresh'] },
+    { name: 'events', display_name: 'Events', canonical_schema: 'analytics_event', supported_sync_modes: ['full_refresh'] },
+    { name: 'page_metrics', display_name: 'Metrics', canonical_schema: 'page_metric', supported_sync_modes: ['full_refresh'] },
+  ],
+};
+
+/** Airbyte — long-tail research adapter, not yet implemented (CVS-152 spike). */
+export const airbytePlaceholderManifest: ConnectorManifest = {
+  id: 'airbyte',
+  display_name: 'Airbyte (research)',
+  category: 'research',
+  status: 'placeholder',
+  auth: { type: 'none' },
+  history_modes: ['metric_materialization'],
+  default_history_mode: 'metric_materialization',
+  storage_policy: 'no_raw_payload',
+  stores_raw_payloads: false,
+  normalizer_version: '0.0.0',
+  rate_limit: { strategy: 'none' },
+  streams: [],
+};
+
+/** Every manifest the registry serves, in the locked Tier order (CVS-137 §6). */
+export const ALL_MANIFESTS: readonly ConnectorManifest[] = [
+  ga4Manifest,
+  stripeManifest,
+  wooCommerceManifest,
+  shopifyManifest,
+  posthogManifest,
+  csvManualManifest,
+  airbytePlaceholderManifest,
+];

--- a/src/shared/lib/connectors/manifests/index.ts
+++ b/src/shared/lib/connectors/manifests/index.ts
@@ -1,0 +1,6 @@
+// Connector manifest registry (CVS-140): the typed catalog of connectors and the
+// canonical schema (CVS-139) each of their streams normalizes into. Import from here.
+// See docs/data/connector-manifests.md.
+export * from './manifest';
+export * from './definitions';
+export * from './registry';

--- a/src/shared/lib/connectors/manifests/manifest.test.ts
+++ b/src/shared/lib/connectors/manifests/manifest.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONNECTOR_MANIFESTS,
+  connectorsForSchema,
+  getConnector,
+  listConnectors,
+  listStreams,
+  publicCatalog,
+  streamsForSchema,
+  toPublicManifest,
+  validateManifest,
+  type ConnectorManifest,
+} from './index';
+import { KNOWN_CANONICAL_NAMES } from './manifest';
+
+const stripe = getConnector('stripe') as ConnectorManifest;
+
+describe('connector registry', () => {
+  it('registers the seven MVP + placeholder connectors with unique ids', () => {
+    const ids = CONNECTOR_MANIFESTS.map((m) => m.id);
+    expect(ids).toEqual(['ga4', 'stripe', 'woocommerce', 'shopify', 'posthog', 'csv_manual', 'airbyte']);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every declared manifest validates', () => {
+    for (const m of CONNECTOR_MANIFESTS) {
+      const res = validateManifest(m);
+      expect(res.ok, `${m.id}: ${res.ok ? '' : JSON.stringify(res.errors)}`).toBe(true);
+    }
+  });
+
+  it('every stream targets a known canonical schema', () => {
+    for (const m of CONNECTOR_MANIFESTS) {
+      for (const s of m.streams) {
+        expect(KNOWN_CANONICAL_NAMES).toContain(s.canonical_schema);
+      }
+    }
+  });
+
+  it('no connector stores raw payloads (locked decision CVS-137 §3)', () => {
+    for (const m of CONNECTOR_MANIFESTS) expect(m.stores_raw_payloads).toBe(false);
+  });
+});
+
+describe('filtering', () => {
+  it('getConnector returns a manifest by id, undefined otherwise', () => {
+    expect(getConnector('stripe')?.display_name).toBe('Stripe');
+    expect(getConnector('nope')).toBeUndefined();
+  });
+
+  it('lists connectors by category', () => {
+    const commerce = listConnectors({ category: 'commerce' }).map((m) => m.id);
+    expect(commerce).toEqual(['woocommerce', 'shopify']);
+  });
+
+  it('lists connectors by status', () => {
+    expect(listConnectors({ status: 'placeholder' }).map((m) => m.id)).toEqual(['airbyte']);
+  });
+
+  it('finds connectors that can populate a canonical schema', () => {
+    expect(connectorsForSchema('payment').map((m) => m.id).sort()).toEqual(['csv_manual', 'stripe']);
+    // analytics_event is served by both GA4 and PostHog
+    expect(connectorsForSchema('analytics_event').map((m) => m.id).sort()).toEqual(['csv_manual', 'ga4', 'posthog']);
+  });
+});
+
+describe('stream catalog', () => {
+  it('flattens streams and tags each with its connector + schema family', () => {
+    const all = listStreams();
+    const total = CONNECTOR_MANIFESTS.reduce((n, m) => n + m.streams.length, 0);
+    expect(all).toHaveLength(total);
+    const payments = all.find((s) => s.canonical_schema === 'payment');
+    expect(payments?.family).toBe('payments');
+  });
+
+  it('streamsForSchema returns only matching streams', () => {
+    const streams = streamsForSchema('commerce_order');
+    expect(streams.length).toBeGreaterThan(0);
+    expect(streams.every((s) => s.canonical_schema === 'commerce_order')).toBe(true);
+    expect(streams.map((s) => s.connector_id).sort()).toEqual(['csv_manual', 'shopify', 'woocommerce']);
+  });
+});
+
+describe('public projection', () => {
+  it('drops runtime-internal fields and stays JSON-serializable', () => {
+    const pub = toPublicManifest(stripe);
+    expect(pub).not.toHaveProperty('normalizer_version');
+    expect(pub).not.toHaveProperty('rate_limit');
+    // streams lose the cursor field but keep binding metadata
+    for (const s of pub.streams) expect(s).not.toHaveProperty('cursor_field');
+    expect(() => JSON.stringify(pub)).not.toThrow();
+    expect(pub.streams.find((s) => s.name === 'payments')?.family).toBe('payments');
+  });
+
+  it('publicCatalog projects every connector', () => {
+    expect(publicCatalog()).toHaveLength(CONNECTOR_MANIFESTS.length);
+  });
+});
+
+describe('validateManifest — rejects malformed manifests', () => {
+  const base = (): ConnectorManifest => structuredClone(stripe);
+
+  it('rejects an unknown canonical schema', () => {
+    const m = base();
+    m.streams[0].canonical_schema = 'not_a_schema';
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors[0].code).toBe('unknown_canonical_schema');
+  });
+
+  it('rejects duplicate stream names', () => {
+    const m = base();
+    m.streams[1].name = m.streams[0].name;
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.some((e) => e.code === 'duplicate_stream_name')).toBe(true);
+  });
+
+  it('rejects a default history mode that is not supported', () => {
+    const m = base();
+    m.history_modes = ['live_query'];
+    m.default_history_mode = 'metric_materialization';
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.some((e) => e.code === 'default_mode_unsupported')).toBe(true);
+  });
+
+  it('rejects storing raw payloads under a no_raw_payload policy', () => {
+    const m = base();
+    m.storage_policy = 'no_raw_payload';
+    m.stores_raw_payloads = true;
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.some((e) => e.code === 'raw_payload_conflict')).toBe(true);
+  });
+
+  it('rejects an MVP connector with no streams', () => {
+    const m = base();
+    m.streams = [];
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.errors.some((e) => e.code === 'mvp_without_streams')).toBe(true);
+  });
+
+  it('rejects a malformed id via the Zod shape', () => {
+    const m = base();
+    (m as { id: string }).id = 'Bad Id';
+    const res = validateManifest(m);
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/shared/lib/connectors/manifests/manifest.ts
+++ b/src/shared/lib/connectors/manifests/manifest.ts
@@ -1,0 +1,199 @@
+// Connector manifest shape + validation (CVS-140).
+//
+// A manifest is the single typed description of a connector: how it authenticates,
+// which streams it exposes, which canonical schema each stream normalizes into
+// (CVS-139), its cursor/sync/rate-limit behavior, and its storage posture. Manifests
+// live versioned in repo code — the source of truth — and are projected into the DB
+// for the Settings/Connected-accounts catalog (locked decision on Linear CVS-137 §2).
+// Nothing here fetches a source or touches secrets; that is CVS-141/142.
+import { z } from 'zod';
+import { CANONICAL_SCHEMA_NAMES, LATER_SCHEMA_NAMES } from '../canonical';
+
+/** Every canonical schema name a stream may target — defined (MVP) or registered-for-later. */
+export const KNOWN_CANONICAL_NAMES: readonly string[] = [
+  ...CANONICAL_SCHEMA_NAMES,
+  ...LATER_SCHEMA_NAMES,
+];
+
+/** How a connector proves identity to its source. */
+export const AuthType = z.enum([
+  'oauth2',
+  'api_key',
+  'basic_auth',
+  'manual_upload',
+  'none',
+]);
+export type AuthType = z.infer<typeof AuthType>;
+
+/**
+ * How a connector retains history (locked decision CVS-137 §3). v1 defaults bound
+ * metrics to `metric_materialization`; `customer_owned_destination` is deferred to
+ * CVS-155. `live_query` reads on demand and persists nothing.
+ */
+export const HistoryMode = z.enum([
+  'live_query',
+  'metric_materialization',
+  'customer_owned_destination',
+]);
+export type HistoryMode = z.infer<typeof HistoryMode>;
+
+/**
+ * The declared retention posture for source data. Per the locked decision, no raw
+ * third-party payloads are stored by default and there is no short-TTL raw table in
+ * v1 — MVP connectors are `metric_materialization`. The other values exist so the
+ * registry can describe future postures without a schema change.
+ */
+export const StoragePolicy = z.enum([
+  'no_raw_payload',
+  'short_ttl_staging',
+  'metric_materialization',
+  'customer_owned_destination',
+]);
+export type StoragePolicy = z.infer<typeof StoragePolicy>;
+
+export const SyncMode = z.enum(['full_refresh', 'incremental']);
+export type SyncMode = z.infer<typeof SyncMode>;
+
+/** Whether a connector is fully specified (`mvp`) or a registered stub (`placeholder`). */
+export const ConnectorStatus = z.enum(['mvp', 'placeholder']);
+export type ConnectorStatus = z.infer<typeof ConnectorStatus>;
+
+/** UI/category grouping for the connected-accounts catalog. */
+export const ConnectorCategory = z.enum([
+  'analytics',
+  'product_analytics',
+  'payments',
+  'commerce',
+  'manual',
+  'research',
+]);
+export type ConnectorCategory = z.infer<typeof ConnectorCategory>;
+
+export const rateLimitStrategySchema = z.object({
+  strategy: z.enum(['token_bucket', 'fixed_window', 'concurrency', 'none']),
+  requests_per_minute: z.number().int().positive().optional(),
+  max_concurrency: z.number().int().positive().optional(),
+  notes: z.string().optional(),
+});
+export type RateLimitStrategy = z.infer<typeof rateLimitStrategySchema>;
+
+/**
+ * One pullable stream. `canonical_schema` names the CVS-139 schema its records
+ * normalize into; `cursor_field` is the source field that drives incremental sync;
+ * `default_dimensions`/`default_metrics`/`freshness` feed metric binding (CVS-144).
+ */
+export const streamManifestSchema = z.object({
+  name: z.string().min(1),
+  display_name: z.string().min(1),
+  canonical_schema: z.string().min(1),
+  cursor_field: z.string().min(1).optional(),
+  supported_sync_modes: z.array(SyncMode).nonempty(),
+  default_dimensions: z.array(z.string().min(1)).optional(),
+  default_metrics: z.array(z.string().min(1)).optional(),
+  freshness: z.string().min(1).optional(),
+});
+export type StreamManifest = z.infer<typeof streamManifestSchema>;
+
+export const connectorManifestSchema = z.object({
+  id: z.string().regex(/^[a-z0-9_]+$/, 'id must be lower_snake slug'),
+  display_name: z.string().min(1),
+  category: ConnectorCategory,
+  status: ConnectorStatus,
+  auth: z.object({
+    type: AuthType,
+    recommended_scopes: z.array(z.string().min(1)).optional(),
+  }),
+  history_modes: z.array(HistoryMode).nonempty(),
+  default_history_mode: HistoryMode,
+  storage_policy: StoragePolicy,
+  stores_raw_payloads: z.boolean(),
+  normalizer_version: z.string().min(1),
+  rate_limit: rateLimitStrategySchema,
+  streams: z.array(streamManifestSchema),
+});
+export type ConnectorManifest = z.infer<typeof connectorManifestSchema>;
+
+// --- Validation -----------------------------------------------------------
+
+export interface ManifestError {
+  path: string;
+  code: string;
+  message: string;
+}
+
+export type ManifestValidationResult =
+  | { ok: true; manifest: ConnectorManifest }
+  | { ok: false; errors: ManifestError[] };
+
+function issuePath(issue: z.ZodIssue): string {
+  return issue.path.length ? issue.path.join('.') : '$';
+}
+
+/**
+ * Validate an unknown value as a connector manifest. Returns structured errors so
+ * a manifest build or an admin import can report exactly what is wrong — never
+ * throws. Beyond the Zod shape it enforces the cross-field rules the object can't:
+ * known canonical schema per stream, default mode within supported modes, unique
+ * stream names, the no-raw-payload invariant, and that MVP connectors have streams.
+ */
+export function validateManifest(input: unknown): ManifestValidationResult {
+  const parsed = connectorManifestSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: parsed.error.issues.map((i) => ({
+        path: issuePath(i),
+        code: i.code,
+        message: i.message,
+      })),
+    };
+  }
+  const m = parsed.data;
+  const errors: ManifestError[] = [];
+
+  m.streams.forEach((s, idx) => {
+    if (!KNOWN_CANONICAL_NAMES.includes(s.canonical_schema)) {
+      errors.push({
+        path: `streams.${idx}.canonical_schema`,
+        code: 'unknown_canonical_schema',
+        message: `Stream "${s.name}" targets unknown canonical schema "${s.canonical_schema}"`,
+      });
+    }
+  });
+
+  const names = m.streams.map((s) => s.name);
+  const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+  if (dupes.length) {
+    errors.push({
+      path: 'streams',
+      code: 'duplicate_stream_name',
+      message: `Duplicate stream names: ${[...new Set(dupes)].join(', ')}`,
+    });
+  }
+
+  if (!m.history_modes.includes(m.default_history_mode)) {
+    errors.push({
+      path: 'default_history_mode',
+      code: 'default_mode_unsupported',
+      message: `default_history_mode "${m.default_history_mode}" is not in history_modes`,
+    });
+  }
+
+  if (m.storage_policy === 'no_raw_payload' && m.stores_raw_payloads) {
+    errors.push({
+      path: 'stores_raw_payloads',
+      code: 'raw_payload_conflict',
+      message: 'stores_raw_payloads must be false when storage_policy is "no_raw_payload"',
+    });
+  }
+
+  if (m.status === 'mvp' && m.streams.length === 0) {
+    errors.push({
+      path: 'streams',
+      code: 'mvp_without_streams',
+      message: 'An MVP connector must declare at least one stream',
+    });
+  }
+
+  return errors.length ? { ok: false, errors } : { ok: true, manifest: m };
+}

--- a/src/shared/lib/connectors/manifests/registry.ts
+++ b/src/shared/lib/connectors/manifests/registry.ts
@@ -1,0 +1,142 @@
+// Connector manifest registry + stream catalog (CVS-140).
+//
+// One place that knows every connector manifest, lets callers filter connectors and
+// streams by category or canonical schema, and projects a secret-free shape for the
+// Settings/Connected-accounts UI. Repo manifests are the source of truth; the DB is a
+// read projection (locked decision CVS-137 §2). Runtime fetch/OAuth is CVS-141/142.
+import { getSchemaDef } from '../canonical';
+import { ALL_MANIFESTS } from './definitions';
+import type {
+  ConnectorCategory,
+  ConnectorManifest,
+  ConnectorStatus,
+  StreamManifest,
+} from './manifest';
+
+/** All connector manifests, keyed by id. */
+export const CONNECTOR_MANIFESTS: readonly ConnectorManifest[] = ALL_MANIFESTS;
+
+const BY_ID = new Map(CONNECTOR_MANIFESTS.map((m) => [m.id, m]));
+
+export interface ConnectorFilter {
+  category?: ConnectorCategory;
+  status?: ConnectorStatus;
+  /** Only connectors that expose a stream targeting this canonical schema. */
+  canonicalSchema?: string;
+}
+
+/** Look up a connector manifest by id. */
+export function getConnector(id: string): ConnectorManifest | undefined {
+  return BY_ID.get(id);
+}
+
+function matches(m: ConnectorManifest, f: ConnectorFilter): boolean {
+  if (f.category && m.category !== f.category) return false;
+  if (f.status && m.status !== f.status) return false;
+  if (f.canonicalSchema && !m.streams.some((s) => s.canonical_schema === f.canonicalSchema)) return false;
+  return true;
+}
+
+/** List connectors, optionally filtered by category, status, or canonical schema. */
+export function listConnectors(filter: ConnectorFilter = {}): ConnectorManifest[] {
+  return CONNECTOR_MANIFESTS.filter((m) => matches(m, filter));
+}
+
+/** A stream flattened out of its connector — the shape the stream catalog serves. */
+export interface CatalogStream extends StreamManifest {
+  connector_id: string;
+  connector_display_name: string;
+  category: ConnectorCategory;
+  /** Canonical schema family (payments/commerce/…), or null if the schema is a later stub. */
+  family: string | null;
+}
+
+function toCatalogStream(m: ConnectorManifest, s: StreamManifest): CatalogStream {
+  return {
+    ...s,
+    connector_id: m.id,
+    connector_display_name: m.display_name,
+    category: m.category,
+    family: getSchemaDef(s.canonical_schema)?.family ?? null,
+  };
+}
+
+/** The full stream catalog, optionally filtered by category / status / canonical schema. */
+export function listStreams(filter: ConnectorFilter = {}): CatalogStream[] {
+  return listConnectors(filter).flatMap((m) =>
+    m.streams
+      .filter((s) => !filter.canonicalSchema || s.canonical_schema === filter.canonicalSchema)
+      .map((s) => toCatalogStream(m, s))
+  );
+}
+
+/** Every stream (across connectors) that normalizes into a given canonical schema. */
+export function streamsForSchema(canonicalSchema: string): CatalogStream[] {
+  return listStreams({ canonicalSchema });
+}
+
+/** Connectors that can populate a given canonical schema. */
+export function connectorsForSchema(canonicalSchema: string): ConnectorManifest[] {
+  return listConnectors({ canonicalSchema });
+}
+
+// --- Public projection (Settings UI / DB) ---------------------------------
+
+export interface PublicStream {
+  name: string;
+  display_name: string;
+  canonical_schema: string;
+  family: string | null;
+  supported_sync_modes: StreamManifest['supported_sync_modes'];
+  default_dimensions?: string[];
+  default_metrics?: string[];
+  freshness?: string;
+}
+
+export interface PublicConnectorManifest {
+  id: string;
+  display_name: string;
+  category: ConnectorCategory;
+  status: ConnectorStatus;
+  auth: { type: ConnectorManifest['auth']['type']; recommended_scopes?: string[] };
+  history_modes: ConnectorManifest['history_modes'];
+  default_history_mode: ConnectorManifest['default_history_mode'];
+  storage_policy: ConnectorManifest['storage_policy'];
+  stores_raw_payloads: boolean;
+  streams: PublicStream[];
+}
+
+/**
+ * Project a manifest into the catalog shape the Settings UI and DB consume. Manifests
+ * carry no secrets, but this deliberately drops runtime-internal fields (cursor field,
+ * rate-limit strategy, normalizer version) so the client only sees catalog metadata —
+ * satisfying "expose manifest data without leaking secrets or runtime internals".
+ */
+export function toPublicManifest(m: ConnectorManifest): PublicConnectorManifest {
+  return {
+    id: m.id,
+    display_name: m.display_name,
+    category: m.category,
+    status: m.status,
+    auth: { type: m.auth.type, recommended_scopes: m.auth.recommended_scopes },
+    history_modes: m.history_modes,
+    default_history_mode: m.default_history_mode,
+    storage_policy: m.storage_policy,
+    stores_raw_payloads: m.stores_raw_payloads,
+    streams: m.streams.map((s) => ({
+      name: s.name,
+      display_name: s.display_name,
+      canonical_schema: s.canonical_schema,
+      family: getSchemaDef(s.canonical_schema)?.family ?? null,
+      supported_sync_modes: s.supported_sync_modes,
+      default_dimensions: s.default_dimensions,
+      default_metrics: s.default_metrics,
+      freshness: s.freshness,
+    })),
+  };
+}
+
+/** The whole catalog as public manifests — the payload the Settings page would render. */
+export function publicCatalog(filter: ConnectorFilter = {}): PublicConnectorManifest[] {
+  return listConnectors(filter).map(toPublicManifest);
+}

--- a/src/shared/lib/supabase/services/search.ts
+++ b/src/shared/lib/supabase/services/search.ts
@@ -1,0 +1,98 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { resolveClient } from '@/shared/utils/authenticatedClient';
+import type { Database } from '../types';
+
+type Client = SupabaseClient<Database>;
+
+export type GlobalSearchResult = {
+  type: 'metric' | 'evidence';
+  id: string;
+  title: string;
+  /** e.g. "Growth canvas · Metric" — the owning canvas + a type/category hint. */
+  subtitle: string;
+  /** The owning canvas/project id, so the caller can navigate to it. */
+  canvasId: string | null;
+};
+
+// Escape LIKE wildcards so a user typing "50%" doesn't match everything.
+function escapeLike(term: string): string {
+  return term.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
+/**
+ * Cross-canvas search (CVS-83): match metric cards and evidence items by title
+ * across every canvas the viewer can access. RLS scopes the rows automatically,
+ * so results are already limited to what the user is allowed to see. Distinct
+ * from AdvancedSearchModal, which only searches the currently-open canvas.
+ */
+export async function searchAcrossCanvases(
+  query: string,
+  authenticatedClient?: Client
+): Promise<GlobalSearchResult[]> {
+  const q = query.trim();
+  if (q.length < 2) return [];
+
+  const client = resolveClient(authenticatedClient);
+  const like = `%${escapeLike(q)}%`;
+
+  const [cardsRes, evidenceRes] = await Promise.all([
+    client
+      .from('metric_cards')
+      .select('id, title, category, project_id')
+      .ilike('title', like)
+      .limit(25),
+    client
+      .from('evidence_items')
+      .select('id, title, type, project_id')
+      .ilike('title', like)
+      .limit(25),
+  ]);
+
+  const cards = cardsRes.data ?? [];
+  const evidence = evidenceRes.data ?? [];
+
+  // Resolve canvas/project names for the result subtitles (one batched query).
+  const projectIds = Array.from(
+    new Set(
+      [...cards, ...evidence]
+        .map((r) => r.project_id)
+        .filter((id): id is string => Boolean(id))
+    )
+  );
+  const nameById = new Map<string, string>();
+  if (projectIds.length > 0) {
+    const { data: projects } = await client
+      .from('projects')
+      .select('id, name')
+      .in('id', projectIds);
+    for (const p of projects ?? []) {
+      nameById.set(p.id, (p.name as string) ?? 'Untitled canvas');
+    }
+  }
+
+  const subtitle = (projectId: string | null, hint?: string | null) =>
+    [projectId ? nameById.get(projectId) : null, hint]
+      .filter(Boolean)
+      .join(' · ');
+
+  const results: GlobalSearchResult[] = [];
+  for (const card of cards) {
+    results.push({
+      type: 'metric',
+      id: card.id,
+      title: card.title,
+      subtitle: subtitle(card.project_id, card.category),
+      canvasId: card.project_id,
+    });
+  }
+  for (const ev of evidence) {
+    results.push({
+      type: 'evidence',
+      id: ev.id,
+      title: ev.title,
+      subtitle: subtitle(ev.project_id, ev.type),
+      canvasId: ev.project_id,
+    });
+  }
+  return results;
+}


### PR DESCRIPTION
The sidebar **Search** (Shift+F) opened `AdvancedSearchModal`, which only searches the *currently-open* canvas — so it was useless from Home or anywhere outside a canvas. This points it at a real **cross-canvas** search.

## What's new
- **`services/search.ts` → `searchAcrossCanvases(query)`** — `ilike`-matches **metric cards** and **evidence items** by title across *every* canvas. **RLS-scoped**, so results are limited to what the viewer can access; canvas names are batched in for the result subtitles.
- **`QuickSearchCommand`** was a stub ("being rebuilt") — rebuilt it into a real **cmdk** command palette: debounced query, results grouped into **Metrics** / **Evidence**, `shouldFilter={false}` (the DB does the filtering). Selecting a result reuses the existing navigate-to-canvas / evidence handler.
- **AppShell**: the global Search button now opens `QuickSearchCommand` and the advertised **Shift+F** hotkey is wired (ignored while typing). `AdvancedSearchModal` stays for in-canvas advanced search.

## Deliberately out of scope
In-canvas **focus/zoom the node** on result-select — CanvasPage doesn't consume `location.state.focusNode` yet, and I kept CanvasPage untouched so this doesn't disturb the canvas manual testing in flight. Filed as a follow-up. (Navigation to the right canvas already works.)

## Verification
type-check ✓, lint ✓ (0 errors), build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)