### PR TITLE
feat(cvs-264): causal validation/refutation state

### DIFF
--- a/src/features/canvas/components/edges/DynamicEdge.tsx
+++ b/src/features/canvas/components/edges/DynamicEdge.tsx
@@ -22,6 +22,7 @@ import EnhancedEdgeButton, {
   useEdgeActions,
 } from './shared/EnhancedEdgeButton';
 import {
+  getCausalStatusMeta,
   getRelationshipEdgeStyle,
   getRelationshipStroke,
   getRelationshipTypeMeta,
@@ -160,11 +161,27 @@ export default function DynamicEdge({
   );
   const confidenceConfig = getConfidenceConfig(relationship.confidence);
   // CVS-165: the drawn line encodes direction/strength/confidence.
-  const edgeStyle = getRelationshipEdgeStyle(
+  const baseEdgeStyle = getRelationshipEdgeStyle(
     relationship.type,
     relationship.weight,
     relationship.confidence
   );
+  // Causal validation state (CVS-264): a refuted causal claim must NOT look like
+  // a healthy one — warn it red + dashed regardless of its weight.
+  const causal =
+    relationship.type === 'Causal'
+      ? getCausalStatusMeta(relationship.causalMetadata?.status)
+      : null;
+  const edgeStyle = causal?.warn
+    ? {
+        ...baseEdgeStyle,
+        stroke: '#dc2626',
+        strokeDasharray: '6,4',
+        opacity: Math.min(baseEdgeStyle.opacity, 0.75),
+        tone: 'negative' as const,
+        loose: true,
+      }
+    : baseEdgeStyle;
 
   // Debug logging for edge styling updates - REMOVED to reduce console noise
 
@@ -339,6 +356,17 @@ export default function DynamicEdge({
             >
               {relationship.confidence}
             </Badge>
+            {causal && relationship.causalMetadata?.status && (
+              <Badge
+                variant="outline"
+                className={cn(
+                  'text-xs font-normal backdrop-blur-sm',
+                  causal.badge
+                )}
+              >
+                {causal.label}
+              </Badge>
+            )}
             {relationship.evidence.length > 0 && (
               <Badge variant="secondary" className="text-xs">
                 {relationship.evidence.length} evidence
@@ -360,6 +388,7 @@ export default function DynamicEdge({
           confidence={relationship.confidence}
           selected={selected}
           isHovered={isHovered}
+          warn={!!causal?.warn}
           onOpenSettings={() => {
             if (isRelationshipSheetOpen && onSwitchToRelationship) {
               onSwitchToRelationship(relationship.id);

--- a/src/features/canvas/components/edges/shared/EnhancedEdgeButton.tsx
+++ b/src/features/canvas/components/edges/shared/EnhancedEdgeButton.tsx
@@ -70,6 +70,8 @@ interface EnhancedEdgeButtonProps {
   // Visual state
   selected?: boolean;
   isHovered?: boolean;
+  /** Force the warning look (red + dashed) — e.g. a refuted causal link. */
+  warn?: boolean;
   
   // Actions
   onOpenSettings?: () => void;
@@ -142,6 +144,7 @@ export default function EnhancedEdgeButton({
   weight,
   selected = false,
   isHovered = false,
+  warn = false,
   onOpenSettings,
   onView,
   onEdit,
@@ -165,10 +168,11 @@ export default function EnhancedEdgeButton({
     edgeType === 'relationshipEdge'
       ? getRelationshipEdgeStyle(relationshipType, weight)
       : null;
+  const effectiveTone = warn ? 'negative' : (relStyle?.tone ?? 'neutral');
   const pill = relStyle
-    ? TONE_PILL[relStyle.tone] ?? TONE_PILL.neutral
+    ? TONE_PILL[effectiveTone] ?? TONE_PILL.neutral
     : { bg: config.bgColor, border: config.borderColor, text: config.color };
-  const loose = relStyle?.loose ?? false;
+  const loose = warn || (relStyle?.loose ?? false);
 
   // Actions for the toolbar
   const actions = [

--- a/src/features/canvas/components/panels/relationship-panel/RelationshipSheet.tsx
+++ b/src/features/canvas/components/panels/relationship-panel/RelationshipSheet.tsx
@@ -47,10 +47,12 @@ import {
 } from '@/shared/lib/supabase/services/changelog';
 
 import type {
+  CausalStatus,
   ConfidenceLevel,
   Relationship,
   RelationshipType,
 } from '@/shared/types';
+import { CAUSAL_STATUS_LIST } from '@/features/canvas/constants/relationshipTypeMeta';
 import {
   getEvidenceTypeIcon,
   getTypeColor,
@@ -190,6 +192,11 @@ export default function RelationshipSheet({
     },
   ]);
 
+  // Causal validation status (persisted in relationship.causalMetadata).
+  const [causalStatus, setCausalStatus] = useState<CausalStatus>(
+    relationship?.causalMetadata?.status ?? 'unvalidated'
+  );
+
   // Worker hook for statistical analysis
   const { analyzeCorrelation, isLoading: isWorkerLoading } = useWorker();
 
@@ -230,6 +237,19 @@ export default function RelationshipSheet({
         evidence: relationship.evidence || [],
         notes: relationship.notes || '',
       });
+
+      // Hydrate causal validation state from the persisted metadata (the static
+      // labels/descriptions stay local; only checked/notes + status persist).
+      const saved = relationship.causalMetadata;
+      setCausalStatus(saved?.status ?? 'unvalidated');
+      setCausalChecklist((prev) =>
+        prev.map((item) => {
+          const hit = saved?.checklist?.find((c) => c.id === item.id);
+          return hit
+            ? { ...item, checked: !!hit.checked, notes: hit.notes ?? '' }
+            : { ...item, checked: false, notes: '' };
+        })
+      );
     }
   }, [relationship]);
 
@@ -340,16 +360,17 @@ export default function RelationshipSheet({
     field: 'checked' | 'notes',
     value: boolean | string
   ) => {
-    setCausalChecklist((prev) => {
-      const updated = prev.map((item) =>
+    setCausalChecklist((prev) =>
+      prev.map((item) =>
         item.id === id ? { ...item, [field]: value } : item
-      );
+      )
+    );
+    setIsModified(true);
+  };
 
-      // Note: causalChecklist is not part of the Relationship type,
-      // but we store it locally for UI state management
-
-      return updated;
-    });
+  const handleCausalStatusChange = (status: CausalStatus) => {
+    setCausalStatus(status);
+    setIsModified(true);
   };
 
   // Calculate checklist progress
@@ -383,9 +404,21 @@ export default function RelationshipSheet({
           };
         }
 
-        // Save the relationship
+        // Save the relationship (causal validation state rides along for Causal).
         await persistEdgeUpdate(relationshipId, {
           ...formData,
+          ...(formData.type === 'Causal'
+            ? {
+                causalMetadata: {
+                  status: causalStatus,
+                  checklist: causalChecklist.map((i) => ({
+                    id: i.id,
+                    checked: i.checked,
+                    notes: i.notes,
+                  })),
+                },
+              }
+            : {}),
           updatedAt: new Date().toISOString(),
         });
 
@@ -1361,6 +1394,35 @@ export default function RelationshipSheet({
                   <p className="text-sm text-gray-600">
                     Systematic validation of causal claims based on established
                     criteria
+                  </p>
+                </div>
+
+                {/* Validation status — surfaces on the edge (CVS-264) */}
+                <div>
+                  <p className="mb-2 text-sm font-medium text-gray-700">
+                    Validation status
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {CAUSAL_STATUS_LIST.map((s) => (
+                      <button
+                        key={s.status}
+                        type="button"
+                        onClick={() => handleCausalStatusChange(s.status)}
+                        className={`rounded-full border px-3 py-1 text-sm transition-colors ${
+                          causalStatus === s.status
+                            ? `${s.badge} font-medium`
+                            : 'border-gray-200 text-gray-500 hover:bg-gray-50'
+                        }`}
+                      >
+                        {s.label}
+                      </button>
+                    ))}
+                  </div>
+                  <p className="mt-2 text-xs text-gray-500">
+                    Correlation isn't causation — work the checklist below, then
+                    mark this claim <strong>validated</strong> or{' '}
+                    <strong>refuted</strong>. A refuted causal link is flagged on
+                    the canvas.
                   </p>
                 </div>
 

--- a/src/features/canvas/constants/relationshipTypeMeta.test.ts
+++ b/src/features/canvas/constants/relationshipTypeMeta.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getCausalStatusMeta,
   getRelationshipEdgeStyle,
   getRelationshipStroke,
 } from './relationshipTypeMeta';
@@ -77,5 +78,31 @@ describe('getRelationshipStroke (delegates to edge style)', () => {
     expect(getRelationshipStroke('Causal', -80)).toBe('#dc2626');
     expect(getRelationshipStroke('Probabilistic', 5)).toBe('#d97706');
     expect(getRelationshipStroke('Deterministic', 80)).toBe('#6b7280');
+  });
+});
+
+// CVS-264 — causal validation/refutation state.
+describe('getCausalStatusMeta', () => {
+  it('refuted warns (negative tone) so it never looks healthy', () => {
+    const m = getCausalStatusMeta('refuted');
+    expect(m.warn).toBe(true);
+    expect(m.tone).toBe('negative');
+    expect(m.color).toBe('#dc2626');
+  });
+
+  it('validated is positive and does not warn', () => {
+    const m = getCausalStatusMeta('validated');
+    expect(m.tone).toBe('positive');
+    expect(m.warn).toBe(false);
+  });
+
+  it('validating reads amber/weak', () => {
+    expect(getCausalStatusMeta('validating').tone).toBe('weak');
+  });
+
+  it('undefined / unknown defaults to unvalidated (neutral, no warn)', () => {
+    expect(getCausalStatusMeta(undefined).status).toBe('unvalidated');
+    expect(getCausalStatusMeta('bogus').tone).toBe('neutral');
+    expect(getCausalStatusMeta('bogus').warn).toBe(false);
   });
 });

--- a/src/features/canvas/constants/relationshipTypeMeta.ts
+++ b/src/features/canvas/constants/relationshipTypeMeta.ts
@@ -20,7 +20,11 @@ import {
   Zap,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import type { ConfidenceLevel, RelationshipType } from '@/shared/types';
+import type {
+  CausalStatus,
+  ConfidenceLevel,
+  RelationshipType,
+} from '@/shared/types';
 
 export type RelationshipLayer = 'component' | 'influence';
 
@@ -330,3 +334,69 @@ export function getRelationshipWeightLabel(
   // Truthy check matches prior edge behavior (weight 0 falls back to default).
   return weight ? `${weight}` : meta.defaultWeightLabel;
 }
+
+// --- Causal validation state (CVS-165 / CVS-264) --------------------------
+
+export interface CausalStatusMeta {
+  status: CausalStatus;
+  label: string;
+  tone: RelationshipTone;
+  /** Hex colour for a status dot/badge. */
+  color: string;
+  /** Tailwind classes for a small status badge. */
+  badge: string;
+  /** True when this status should visually WARN (a refuted causal claim). */
+  warn: boolean;
+}
+
+const CAUSAL_STATUS_META: Record<CausalStatus, CausalStatusMeta> = {
+  validated: {
+    status: 'validated',
+    label: 'Validated',
+    tone: 'positive',
+    color: EDGE_COLORS.positiveStrong,
+    badge: 'bg-green-50 text-green-700 border-green-300',
+    warn: false,
+  },
+  refuted: {
+    status: 'refuted',
+    label: 'Refuted',
+    tone: 'negative',
+    color: EDGE_COLORS.negative,
+    badge: 'bg-red-50 text-red-700 border-red-300',
+    warn: true,
+  },
+  validating: {
+    status: 'validating',
+    label: 'Validating',
+    tone: 'weak',
+    color: EDGE_COLORS.weak,
+    badge: 'bg-amber-50 text-amber-700 border-amber-300',
+    warn: false,
+  },
+  unvalidated: {
+    status: 'unvalidated',
+    label: 'Unvalidated',
+    tone: 'neutral',
+    color: EDGE_COLORS.neutral,
+    badge: 'bg-gray-50 text-gray-600 border-gray-300',
+    warn: false,
+  },
+};
+
+/** Visual meta for a causal relationship's validation status (defaults to unvalidated). */
+export function getCausalStatusMeta(
+  status?: CausalStatus | string
+): CausalStatusMeta {
+  return (
+    CAUSAL_STATUS_META[status as CausalStatus] ??
+    CAUSAL_STATUS_META.unvalidated
+  );
+}
+
+export const CAUSAL_STATUS_LIST: CausalStatusMeta[] = [
+  CAUSAL_STATUS_META.unvalidated,
+  CAUSAL_STATUS_META.validating,
+  CAUSAL_STATUS_META.validated,
+  CAUSAL_STATUS_META.refuted,
+];

--- a/src/shared/lib/supabase/services/relationships.ts
+++ b/src/shared/lib/supabase/services/relationships.ts
@@ -42,6 +42,7 @@ function transformRelationship(
     weight: rel.weight || undefined,
     notes: rel.description || undefined,
     evidence: evidence.map(transformEvidenceItem),
+    causalMetadata: (rel.causal_metadata as Relationship['causalMetadata']) ?? undefined,
     createdAt: rel.created_at || new Date().toISOString(),
     updatedAt: rel.updated_at || new Date().toISOString(),
   };
@@ -76,6 +77,7 @@ function transformToInsert(
     type: rel.type,
     confidence: rel.confidence,
     weight: rel.weight,
+    causal_metadata: (rel.causalMetadata ?? null) as Json,
     created_by: userId,
   };
 }
@@ -126,6 +128,8 @@ export async function updateRelationship(
   if (updates.confidence !== undefined)
     updateData.confidence = updates.confidence;
   if (updates.weight !== undefined) updateData.weight = updates.weight;
+  if (updates.causalMetadata !== undefined)
+    updateData.causal_metadata = (updates.causalMetadata ?? null) as Json;
 
   const client = resolveClient(authenticatedClient);
   try {

--- a/src/shared/lib/supabase/types.ts
+++ b/src/shared/lib/supabase/types.ts
@@ -1473,6 +1473,7 @@ export type Database = {
           type: string
           confidence: string
           weight: number | null
+          causal_metadata: Json | null
           description: string | null
           project_id: string
           created_at: string | null
@@ -1487,6 +1488,7 @@ export type Database = {
           type: string
           confidence: string
           weight?: number | null
+          causal_metadata?: Json | null
           description?: string | null
           project_id: string
           created_at?: string | null
@@ -1501,6 +1503,7 @@ export type Database = {
           type?: string
           confidence?: string
           weight?: number | null
+          causal_metadata?: Json | null
           description?: string | null
           project_id?: string
           created_at?: string | null

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -161,12 +161,33 @@ export interface Relationship {
   evidence: EvidenceItem[];
   notes?: string;
 
+  // Causal validation (only meaningful for type === 'Causal'): the checklist +
+  // its validated/refuted status, persisted so it surfaces on the edge (CVS-165).
+  causalMetadata?: CausalMetadata;
+
   // History for influence drift analysis
   history?: RelationshipHistoryEntry[];
 
   // Metadata
   createdAt: string;
   updatedAt: string;
+}
+
+export type CausalStatus =
+  | 'unvalidated'
+  | 'validating'
+  | 'validated'
+  | 'refuted';
+
+export interface CausalChecklistItem {
+  id: string;
+  checked: boolean;
+  notes?: string;
+}
+
+export interface CausalMetadata {
+  status: CausalStatus;
+  checklist: CausalChecklistItem[];
 }
 
 export interface RelationshipHistoryEntry {

--- a/supabase/migrations/20260715120000_relationship_causal_metadata.sql
+++ b/supabase/migrations/20260715120000_relationship_causal_metadata.sql
@@ -1,0 +1,11 @@
+-- =====================================================================
+-- CAUSAL VALIDATION STATE — persist a causal relationship's validation checklist
+-- and its validated/refuted status so it survives reload and can surface on the
+-- edge (last CVS-165 AC). Stored as jsonb: { status, checklist:[{id,checked,notes}] }.
+-- =====================================================================
+BEGIN;
+
+ALTER TABLE public.relationships
+  ADD COLUMN IF NOT EXISTS causal_metadata jsonb;
+
+COMMIT;


### PR DESCRIPTION
Closes **CVS-264** — the **last open CVS-165 acceptance criterion**: "causal relationships require explicit support and surface validation/refutation state."

## What
- **DB:** `relationships.causal_metadata jsonb` (`{ status, checklist:[{id,checked,notes}] }`).
- **Model:** `CausalStatus` (unvalidated / validating / validated / refuted) + `Relationship.causalMetadata`; pure **`getCausalStatusMeta`** (label / tone / badge / warn) with unit tests.
- **Persist:** `transformRelationship` / `transformToInsert` / `updateRelationship` round-trip it. The sheet's **Causal Checklist** now loads checked/notes + a **status selector** and saves them (was local-only, reset on reload).
- **Surface on edge:** a status badge in the hover detail; a **refuted** causal link **warns** — red dashed dim line + red/dashed centre pill (`warn` prop on `EnhancedEdgeButton`) so it never looks like a healthy causal link. Non-causal edges are untouched.

## Verification
- `type-check` ✅ · `lint` ✅ (0 new) · **full vitest 276/276** ✅ (+4 causal-status tests).

## ⚠️ Merge order
**Apply `20260715120000_relationship_causal_metadata.sql` to prod first**, then merge — the app writes `causal_metadata` on save, so the column must exist. (Not self-applied/merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)