### PR TITLE
fix(cvs-269): persist relationship notes (were dropped on save)

### DIFF
--- a/src/shared/lib/supabase/services/relationships.ts
+++ b/src/shared/lib/supabase/services/relationships.ts
@@ -40,6 +40,7 @@ function transformRelationship(
     type: rel.type as any,
     confidence: rel.confidence as any,
     weight: rel.weight || undefined,
+    notes: rel.description || undefined,
     evidence: evidence.map(transformEvidenceItem),
     createdAt: rel.created_at || new Date().toISOString(),
     updatedAt: rel.updated_at || new Date().toISOString(),
@@ -93,6 +94,10 @@ export async function createRelationship(
     console.error('Validation error creating relationship:', error);
     throw error;
   }
+  // Notes → `description` column, set after validation (see updateRelationship).
+  if (relationship.notes !== undefined) {
+    insertData.description = relationship.notes ?? null;
+  }
   const client = resolveClient(authenticatedClient);
 
   const { data, error } = await client
@@ -129,6 +134,10 @@ export async function updateRelationship(
     console.error('Validation error updating relationship:', error);
     throw error;
   }
+  // Relationship notes live in the `description` column (the domain model calls
+  // it `notes`). Set it AFTER validation — the generated strict schema doesn't
+  // know this column (stale Prisma mirror) but Postgres accepts it (cf. CVS-34).
+  if (updates.notes !== undefined) updateData.description = updates.notes ?? null;
   const { data, error } = await client
     .from('relationships')
     .update(updateData)


### PR DESCRIPTION
Closes **CVS-269**. The relationship sheet's **Notes** textarea fed `formData.notes`, but `updateRelationship` only saved type/confidence/weight — so notes were **silently dropped** and never reloaded.

## Fix (no migration)
Notes map to the existing, previously-unused `relationships.description` column:
- `transformRelationship` reads `description` → `notes`.
- `create`/`updateRelationship` write `notes` → `description`, set **after** the strict generated-zod `.parse()` (the Prisma mirror doesn't include the column — same post-validation pattern as evidence `date`/`content` in CVS-34).

## Verification
- `type-check` ✅ · `lint` ✅ (0 new) · **full vitest 314/314** ✅. No DB change.

Note: touches the same three service functions as the open causal PR (#121); whichever merges second needs a trivial rebase (keep both added lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)