### PR TITLE
feat(connectors): fetch runtime — pagination, cursors, rate limits, retries (CVS-142)

### DIFF
--- a/docs/data/connector-runtime.md
+++ b/docs/data/connector-runtime.md
@@ -1,0 +1,57 @@
+# Connector fetch runtime (data layer)
+
+The fetch runtime (`src/shared/lib/connectors/runtime/`, CVS-142) is the shared engine that
+runs one connector **stream** end to end: it paces requests to the source, retries transient
+failures, times out slow pages, walks pagination, advances the persisted **cursor** only
+after a page succeeds, and returns a **payload-free** run summary. Every native connector
+(CVS-146–150) implements a thin adapter and lets the runtime own these mechanics.
+
+It builds on the [manifest registry](./connector-manifests.md) (CVS-140, for rate-limit and
+stream metadata) and feeds the [canonical](./canonical-schemas.md) normalizer (CVS-143).
+Credentials are **injected** — the runtime never reads secrets; the connection/token model
+(CVS-141) resolves them at the connector-MVP layer.
+
+## The adapter
+
+A connector implements one method:
+
+```ts
+interface ConnectorAdapter {
+  connectorId: string;
+  fetchPage(input: FetchPageInput): Promise<FetchPageResult>;
+}
+```
+
+`FetchPageInput` carries the stream, sync mode, injected `credentials`, the incremental
+`cursor` (across runs), the `pageToken` (within a run), and an `AbortSignal`.
+`FetchPageResult` returns the page's raw `records`, an optional `nextPageToken` (absent =
+stream exhausted), and an optional updated `cursor`.
+
+## What the runtime guarantees
+
+`runStream(adapter, manifest, stream, options)`:
+
+- **Pacing** — a `RateLimiter` derived from `manifest.rate_limit` (requests-per-minute for
+  `token_bucket`/`fixed_window`; no delay for `concurrency`/`none`).
+- **Retries** — `withRetry` backs off exponentially with full jitter and honors a source's
+  `Retry-After` on rate-limit errors. Only `transient`/`rate_limit`/`timeout` classes retry;
+  `auth`/`permanent` fail fast (see `errors.ts`).
+- **Timeout** — an optional per-page budget that aborts the adapter's request.
+- **Cursor safety** — the cursor is persisted **only after a page is fetched and handled**,
+  so a run that fails partway is `resumable` from the last good page — no duplicated or
+  skipped records. Cursors are opaque strings stored payload-free (`CursorStore`).
+- **Caps** — `maxRecords` bounds a run (powers the 5–10 record sample preview, decision
+  CVS-137 §8).
+- **Payload-free reporting** — `RunReport` carries counts (`pages`, `fetched`, `skipped`,
+  `rejected`), a stable `error_class`, `resumable`, and timestamps — never a source record
+  or token. Verified by test.
+
+Normalization/validation is **not** here — an optional `onRecords` handler lets the CVS-143
+normalizer plug in and report `skipped`/`rejected`, keeping fetch and normalize separable.
+
+## Testing
+
+`mockConnector.ts` (shipped in `src/`, reused by the CVS-154 QA suite) provides
+`createMockConnector` — pre-defined pages with pagination/cursors and injectable per-page
+transient failures — and `createManualClock`, a deterministic clock whose `sleep` advances
+virtual time instantly so backoff and rate-limit waits are exercised without real delays.

--- a/src/shared/lib/connectors/runtime/clock.ts
+++ b/src/shared/lib/connectors/runtime/clock.ts
@@ -1,0 +1,54 @@
+// Clock + timeout helpers (CVS-142).
+//
+// A single injectable Clock backs every wait in the runtime (retry backoff, rate-limit
+// pacing, per-page timeout) so tests advance time deterministically instead of sleeping.
+import { timeoutError } from './errors';
+import type { Clock } from './types';
+
+/** The real clock: wall time + an abortable setTimeout-based sleep. */
+export const systemClock: Clock = {
+  now: () => Date.now(),
+  sleep: (ms, signal) =>
+    new Promise<void>((resolve, reject) => {
+      if (signal?.aborted) return reject(new DOMException('Aborted', 'AbortError'));
+      const id = setTimeout(resolve, ms);
+      signal?.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(id);
+          reject(new DOMException('Aborted', 'AbortError'));
+        },
+        { once: true }
+      );
+    }),
+};
+
+/**
+ * Race a page fetch against a timeout. On expiry the shared AbortController fires (so the
+ * adapter can cancel its request) and a classified `timeout` error is thrown.
+ */
+export async function withTimeout<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  ms: number | undefined,
+  parent: AbortSignal | undefined,
+  clock: Clock
+): Promise<T> {
+  const controller = new AbortController();
+  const onParentAbort = () => controller.abort();
+  if (parent) {
+    if (parent.aborted) controller.abort();
+    else parent.addEventListener('abort', onParentAbort, { once: true });
+  }
+  try {
+    if (!ms) return await fn(controller.signal);
+    const timeout = clock.sleep(ms, controller.signal).then(() => {
+      throw timeoutError(`Page exceeded ${ms}ms budget`);
+    });
+    // Swallow the abort-driven rejection once the fetch has already won the race.
+    timeout.catch(() => undefined);
+    return await Promise.race([fn(controller.signal), timeout]);
+  } finally {
+    controller.abort();
+    parent?.removeEventListener('abort', onParentAbort);
+  }
+}

--- a/src/shared/lib/connectors/runtime/cursorStore.ts
+++ b/src/shared/lib/connectors/runtime/cursorStore.ts
@@ -1,0 +1,33 @@
+// Cursor persistence (CVS-142).
+//
+// The runtime persists only a small opaque cursor string per (account, connector, stream)
+// — payload-free by construction. The DB-backed implementation lands with the connection
+// model; this in-memory store backs tests and mock/preview runs.
+import type { CursorStore } from './types';
+
+/** Stable cursor key for a stream run. */
+export function cursorKeyFor(accountId: string, connectorId: string, stream: string): string {
+  return `${accountId}:${connectorId}:${stream}`;
+}
+
+/** In-memory cursor store — for tests, sample previews, and single-process runs. */
+export class InMemoryCursorStore implements CursorStore {
+  private readonly cursors = new Map<string, string>();
+
+  constructor(initial?: Record<string, string>) {
+    if (initial) for (const [k, v] of Object.entries(initial)) this.cursors.set(k, v);
+  }
+
+  async read(key: string): Promise<string | undefined> {
+    return this.cursors.get(key);
+  }
+
+  async write(key: string, cursor: string): Promise<void> {
+    this.cursors.set(key, cursor);
+  }
+
+  /** Test/debug helper: snapshot of all persisted cursors. */
+  snapshot(): Record<string, string> {
+    return Object.fromEntries(this.cursors);
+  }
+}

--- a/src/shared/lib/connectors/runtime/errors.ts
+++ b/src/shared/lib/connectors/runtime/errors.ts
@@ -1,0 +1,75 @@
+// Connector fetch error model + classification (CVS-142).
+//
+// Adapters and the runtime speak in a small set of error classes so retry/backoff can
+// decide what is worth retrying (transient/rate-limit/timeout) versus fatal (auth/
+// permanent), and so run summaries can name a stable error class without ever carrying
+// a source payload or secret. See docs/data/connector-runtime.md.
+
+/** Stable, payload-free classes a connector run can fail with. */
+export type ConnectorErrorClass =
+  | 'rate_limit'
+  | 'transient'
+  | 'timeout'
+  | 'auth'
+  | 'permanent';
+
+const RETRYABLE: ReadonlySet<ConnectorErrorClass> = new Set([
+  'rate_limit',
+  'transient',
+  'timeout',
+]);
+
+/** Whether an error class is worth retrying. */
+export function isRetryable(cls: ConnectorErrorClass): boolean {
+  return RETRYABLE.has(cls);
+}
+
+/**
+ * A classified connector failure. Carries only a class, a safe message, and an optional
+ * `retryAfterMs` hint (from a source's Retry-After) — never a payload, token, or URL.
+ */
+export class ConnectorFetchError extends Error {
+  readonly class: ConnectorErrorClass;
+  readonly retryAfterMs?: number;
+
+  constructor(cls: ConnectorErrorClass, message: string, opts: { retryAfterMs?: number } = {}) {
+    super(message);
+    this.name = 'ConnectorFetchError';
+    this.class = cls;
+    this.retryAfterMs = opts.retryAfterMs;
+  }
+
+  get retryable(): boolean {
+    return isRetryable(this.class);
+  }
+}
+
+/** Build a rate-limit error, optionally with the source's Retry-After delay. */
+export function rateLimitError(message = 'Rate limited by source', retryAfterMs?: number): ConnectorFetchError {
+  return new ConnectorFetchError('rate_limit', message, { retryAfterMs });
+}
+
+/** Build a timeout error for a page that exceeded its budget. */
+export function timeoutError(message = 'Request timed out'): ConnectorFetchError {
+  return new ConnectorFetchError('timeout', message);
+}
+
+/**
+ * Coerce an unknown thrown value into a classified error. A raw HTTP status maps to a
+ * class (429 → rate_limit, 5xx/network → transient, 401/403 → auth, other 4xx →
+ * permanent); anything already a ConnectorFetchError passes through unchanged.
+ */
+export function classifyError(err: unknown): ConnectorFetchError {
+  if (err instanceof ConnectorFetchError) return err;
+  const message = err instanceof Error ? err.message : String(err);
+  const status = (err as { status?: number } | null)?.status;
+  if (typeof status === 'number') {
+    if (status === 429) return rateLimitError(message);
+    if (status >= 500) return new ConnectorFetchError('transient', message);
+    if (status === 401 || status === 403) return new ConnectorFetchError('auth', message);
+    if (status >= 400) return new ConnectorFetchError('permanent', message);
+  }
+  // Fetch/network failures surface as TypeError with no status — treat as transient.
+  if (err instanceof TypeError) return new ConnectorFetchError('transient', message);
+  return new ConnectorFetchError('permanent', message);
+}

--- a/src/shared/lib/connectors/runtime/index.ts
+++ b/src/shared/lib/connectors/runtime/index.ts
@@ -1,0 +1,11 @@
+// Connector fetch runtime (CVS-142): the shared engine that runs a connector stream —
+// pagination, cursors, rate limits, retries, timeouts — and returns a payload-free run
+// report. Adapters implement `ConnectorAdapter`; credentials are injected (CVS-141).
+// See docs/data/connector-runtime.md.
+export * from './errors';
+export * from './types';
+export { systemClock, withTimeout } from './clock';
+export { createRateLimiter, type RateLimiter } from './rateLimiter';
+export { DEFAULT_RETRY, backoffDelay, withRetry } from './retry';
+export { InMemoryCursorStore, cursorKeyFor } from './cursorStore';
+export { runStream } from './runStream';

--- a/src/shared/lib/connectors/runtime/mockConnector.ts
+++ b/src/shared/lib/connectors/runtime/mockConnector.ts
@@ -1,0 +1,90 @@
+// Mock connector + manual clock for exercising the fetch runtime (CVS-142).
+//
+// Kept in src (not a .test file) so the connector QA fixture suite (CVS-154) can reuse it.
+// The mock serves pre-defined pages with pagination + cursors and can inject transient
+// failures on a given page to prove retries and resumed runs, all without a real network.
+import { ConnectorFetchError } from './errors';
+import type { Clock, ConnectorAdapter, FetchPageInput, FetchPageResult } from './types';
+
+export interface MockPage {
+  records: unknown[];
+  cursor?: string;
+}
+
+export interface MockStreamConfig {
+  pages: MockPage[];
+  /** Inject failures on a 0-based page index: throw `error` for the first `times` attempts. */
+  failures?: Record<number, { error: ConnectorFetchError; times: number }>;
+}
+
+export interface MockCall {
+  stream: string;
+  cursor?: string;
+  pageIndex: number;
+}
+
+export interface MockConnector {
+  adapter: ConnectorAdapter;
+  calls: MockCall[];
+}
+
+/**
+ * Build a mock adapter. `streams` maps a stream name to its ordered pages; the runtime
+ * walks them via an integer page token. Records every fetch in `calls` for assertions.
+ */
+export function createMockConnector(
+  connectorId: string,
+  streams: Record<string, MockStreamConfig>
+): MockConnector {
+  const calls: MockCall[] = [];
+  const attempts = new Map<string, number>();
+
+  const adapter: ConnectorAdapter = {
+    connectorId,
+    async fetchPage(input: FetchPageInput): Promise<FetchPageResult> {
+      const cfg = streams[input.stream.name];
+      if (!cfg) throw new ConnectorFetchError('permanent', `No mock stream "${input.stream.name}"`);
+
+      const pageIndex = input.pageToken ? Number(input.pageToken) : 0;
+      calls.push({ stream: input.stream.name, cursor: input.cursor, pageIndex });
+
+      const failure = cfg.failures?.[pageIndex];
+      if (failure) {
+        const key = `${input.stream.name}:${pageIndex}`;
+        const soFar = attempts.get(key) ?? 0;
+        if (soFar < failure.times) {
+          attempts.set(key, soFar + 1);
+          throw failure.error;
+        }
+      }
+
+      const page = cfg.pages[pageIndex];
+      if (!page) throw new ConnectorFetchError('permanent', `Mock page ${pageIndex} out of range`);
+
+      const hasNext = pageIndex + 1 < cfg.pages.length;
+      return {
+        records: page.records,
+        cursor: page.cursor,
+        nextPageToken: hasNext ? String(pageIndex + 1) : undefined,
+      };
+    },
+  };
+
+  return { adapter, calls };
+}
+
+/**
+ * A deterministic clock: `sleep` resolves immediately but advances virtual time, so
+ * backoff and rate-limit waits are instant yet `now()` still moves forward. Do not set a
+ * per-page timeout with this clock unless you are testing the timeout itself.
+ */
+export function createManualClock(start = 0): Clock & { total: () => number } {
+  let t = start;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+    total: () => t,
+  };
+}

--- a/src/shared/lib/connectors/runtime/rateLimiter.ts
+++ b/src/shared/lib/connectors/runtime/rateLimiter.ts
@@ -1,0 +1,33 @@
+// Manifest-driven rate limiter (CVS-142).
+//
+// Paces requests according to a connector manifest's `rate_limit` block so the runtime
+// respects source quotas without each adapter reimplementing throttling. `token_bucket`
+// and `fixed_window` pace by requests-per-minute; `concurrency`/`none` add no delay
+// (single-stream runs are already sequential). Waits go through the injected Clock.
+import type { RateLimitStrategy } from '../manifests';
+import type { Clock } from './types';
+
+export interface RateLimiter {
+  /** Wait until the next request is allowed. */
+  acquire(signal?: AbortSignal): Promise<void>;
+}
+
+/** Build a limiter for a manifest's rate-limit strategy. */
+export function createRateLimiter(rate: RateLimitStrategy, clock: Clock): RateLimiter {
+  const rpm = rate.requests_per_minute;
+  const paces = (rate.strategy === 'token_bucket' || rate.strategy === 'fixed_window') && !!rpm;
+  if (!paces || !rpm) {
+    return { acquire: async () => undefined };
+  }
+  const minIntervalMs = Math.ceil(60_000 / rpm);
+  let nextAllowedAt = 0;
+  return {
+    async acquire(signal) {
+      const now = clock.now();
+      const wait = Math.max(0, nextAllowedAt - now);
+      // Reserve this slot before awaiting so concurrent acquires queue behind it.
+      nextAllowedAt = Math.max(now, nextAllowedAt) + minIntervalMs;
+      if (wait > 0) await clock.sleep(wait, signal);
+    },
+  };
+}

--- a/src/shared/lib/connectors/runtime/retry.ts
+++ b/src/shared/lib/connectors/runtime/retry.ts
@@ -1,0 +1,50 @@
+// Retry with exponential backoff + jitter (CVS-142).
+//
+// Retries only retryable classes (transient/rate_limit/timeout); auth/permanent fail
+// fast. A source's Retry-After hint (on a rate_limit error) overrides the computed delay
+// so we back off exactly as long as asked. All waits go through the injected Clock.
+import { classifyError, ConnectorFetchError } from './errors';
+import type { Clock, RetryPolicy } from './types';
+
+export const DEFAULT_RETRY: RetryPolicy = {
+  maxAttempts: 4,
+  baseDelayMs: 500,
+  maxDelayMs: 30_000,
+};
+
+/** Exponential backoff for attempt `n` (0-based), full-jitter, capped at maxDelayMs. */
+export function backoffDelay(n: number, policy: RetryPolicy, rand: () => number): number {
+  const ceiling = Math.min(policy.maxDelayMs, policy.baseDelayMs * 2 ** n);
+  return Math.floor(rand() * ceiling);
+}
+
+/**
+ * Run `fn`, retrying retryable failures up to `policy.maxAttempts`. Returns the first
+ * success; rethrows the last classified error when attempts are exhausted or the error
+ * is not retryable. Never swallows — the caller decides how a terminal failure is
+ * reported. `signal` aborts both the work and the backoff wait.
+ */
+export async function withRetry<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  policy: RetryPolicy,
+  clock: Clock,
+  signal?: AbortSignal
+): Promise<T> {
+  const rand = policy.jitter ?? Math.random;
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn(signal ?? new AbortController().signal);
+    } catch (raw) {
+      const err = classifyError(raw);
+      attempt += 1;
+      if (!err.retryable || attempt >= policy.maxAttempts) throw err;
+      const wait = retryAfter(err) ?? backoffDelay(attempt - 1, policy, rand);
+      await clock.sleep(wait, signal);
+    }
+  }
+}
+
+function retryAfter(err: ConnectorFetchError): number | undefined {
+  return err.class === 'rate_limit' ? err.retryAfterMs : undefined;
+}

--- a/src/shared/lib/connectors/runtime/runStream.ts
+++ b/src/shared/lib/connectors/runtime/runStream.ts
@@ -1,0 +1,123 @@
+// Stream run loop (CVS-142).
+//
+// Drives one connector stream end to end: paces requests by the manifest rate limit,
+// retries transient failures with backoff, times out slow pages, walks pagination, and
+// advances the persisted cursor ONLY after a page succeeds — so a run that fails partway
+// resumes from the last good page without duplicating or skipping records. Produces a
+// payload-free RunReport. See docs/data/connector-runtime.md.
+import type { ConnectorManifest, StreamManifest } from '../manifests';
+import { classifyError } from './errors';
+import { systemClock, withTimeout } from './clock';
+import { createRateLimiter } from './rateLimiter';
+import { DEFAULT_RETRY, withRetry } from './retry';
+import type {
+  ConnectorAdapter,
+  PageOutcome,
+  RetryPolicy,
+  RunReport,
+  RunStreamOptions,
+} from './types';
+
+const NO_OP_OUTCOME = (records: unknown[]): PageOutcome => ({ accepted: records.length, skipped: 0, rejected: 0 });
+
+/**
+ * Fetch one stream to completion (or to `maxRecords`), returning a structured summary.
+ * Never throws for source/transport failures — a terminal error is captured in the report
+ * as a stable `error_class` so Connected Accounts and debug surfaces can render it.
+ */
+export async function runStream(
+  adapter: ConnectorAdapter,
+  manifest: ConnectorManifest,
+  stream: StreamManifest,
+  options: RunStreamOptions
+): Promise<RunReport> {
+  const clock = options.clock ?? systemClock;
+  const retry: RetryPolicy = { ...DEFAULT_RETRY, ...options.retry };
+  const limiter = createRateLimiter(manifest.rate_limit, clock);
+  const handle = options.onRecords ?? NO_OP_OUTCOME;
+  const startedAt = clock.now();
+
+  let cursor = await options.cursorStore.read(options.cursorKey);
+  let cursorPersisted = false;
+  let pageToken: string | undefined;
+  let pages = 0;
+  let fetched = 0;
+  let skipped = 0;
+  let rejected = 0;
+  let errorClass: RunReport['error_class'];
+  let errorMessage: string | undefined;
+
+  try {
+    for (;;) {
+      await limiter.acquire(options.signal);
+
+      const currentCursor = cursor;
+      const currentToken = pageToken;
+      const page = await withRetry(
+        (signal) =>
+          withTimeout(
+            (inner) =>
+              adapter.fetchPage({
+                stream,
+                syncMode: options.syncMode,
+                credentials: options.credentials,
+                cursor: currentCursor,
+                pageToken: currentToken,
+                signal: inner,
+              }),
+            options.pageTimeoutMs,
+            signal,
+            clock
+          ),
+        retry,
+        clock,
+        options.signal
+      );
+
+      pages += 1;
+
+      let records = page.records;
+      if (options.maxRecords !== undefined) {
+        const room = options.maxRecords - fetched;
+        if (records.length > room) records = records.slice(0, Math.max(0, room));
+      }
+
+      const outcome = await handle(records);
+      fetched += records.length;
+      skipped += outcome.skipped ?? 0;
+      rejected += outcome.rejected ?? 0;
+
+      // Advance the cursor only now that the page has been fetched and handled.
+      if (page.cursor !== undefined) {
+        cursor = page.cursor;
+        await options.cursorStore.write(options.cursorKey, page.cursor);
+        cursorPersisted = true;
+      }
+
+      pageToken = page.nextPageToken;
+      const hitCap = options.maxRecords !== undefined && fetched >= options.maxRecords;
+      if (!pageToken || hitCap) break;
+    }
+  } catch (raw) {
+    const err = classifyError(raw);
+    errorClass = err.class;
+    errorMessage = err.message;
+  }
+
+  const finishedAt = clock.now();
+  return {
+    connector_id: adapter.connectorId,
+    stream: stream.name,
+    sync_mode: options.syncMode,
+    pages,
+    fetched,
+    skipped,
+    rejected,
+    cursor: cursorPersisted ? cursor : undefined,
+    error_class: errorClass,
+    error_message: errorMessage,
+    resumable: errorClass !== undefined && cursorPersisted,
+    started_at: new Date(startedAt).toISOString(),
+    finished_at: new Date(finishedAt).toISOString(),
+  };
+}

--- a/src/shared/lib/connectors/runtime/runtime.test.ts
+++ b/src/shared/lib/connectors/runtime/runtime.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import type { ConnectorManifest, RateLimitStrategy, StreamManifest } from '../manifests';
+import { runStream, InMemoryCursorStore, cursorKeyFor, ConnectorFetchError, backoffDelay, DEFAULT_RETRY } from './index';
+import { createManualClock, createMockConnector } from './mockConnector';
+import type { RunStreamOptions } from './types';
+
+const stream: StreamManifest = {
+  name: 'payments',
+  display_name: 'Payments',
+  canonical_schema: 'payment',
+  supported_sync_modes: ['full_refresh', 'incremental'],
+};
+
+function manifestWith(rate: RateLimitStrategy): ConnectorManifest {
+  return {
+    id: 'mock',
+    display_name: 'Mock',
+    category: 'payments',
+    status: 'mvp',
+    auth: { type: 'none' },
+    history_modes: ['metric_materialization'],
+    default_history_mode: 'metric_materialization',
+    storage_policy: 'metric_materialization',
+    stores_raw_payloads: false,
+    normalizer_version: '1.0.0',
+    rate_limit: rate,
+    streams: [stream],
+  };
+}
+
+const NO_RATE: RateLimitStrategy = { strategy: 'none' };
+const KEY = cursorKeyFor('acct', 'mock', 'payments');
+
+function baseOptions(over: Partial<RunStreamOptions> = {}): RunStreamOptions {
+  return {
+    credentials: {},
+    syncMode: 'incremental',
+    cursorStore: new InMemoryCursorStore(),
+    cursorKey: KEY,
+    clock: createManualClock(),
+    ...over,
+  };
+}
+
+describe('runStream — pagination + cursor', () => {
+  it('walks every page, collects records, and persists the last cursor', async () => {
+    const { adapter, calls } = createMockConnector('mock', {
+      payments: {
+        pages: [
+          { records: [1, 2], cursor: 'c1' },
+          { records: [3, 4], cursor: 'c2' },
+          { records: [5], cursor: 'c3' },
+        ],
+      },
+    });
+    const store = new InMemoryCursorStore();
+    const report = await runStream(adapter, manifestWith(NO_RATE), stream, baseOptions({ cursorStore: store }));
+
+    expect(report.pages).toBe(3);
+    expect(report.fetched).toBe(5);
+    expect(report.error_class).toBeUndefined();
+    expect(report.cursor).toBe('c3');
+    expect(store.snapshot()[KEY]).toBe('c3');
+    expect(calls.map((c) => c.pageIndex)).toEqual([0, 1, 2]);
+  });
+
+  it('caps at maxRecords and stops early', async () => {
+    const { adapter } = createMockConnector('mock', {
+      payments: { pages: [{ records: [1, 2, 3, 4, 5] }, { records: [6, 7, 8, 9, 10] }, { records: [11] }] },
+    });
+    const report = await runStream(adapter, manifestWith(NO_RATE), stream, baseOptions({ maxRecords: 7 }));
+    expect(report.fetched).toBe(7);
+    expect(report.pages).toBe(2);
+  });
+
+  it('aggregates skipped/rejected from the record handler', async () => {
+    const { adapter } = createMockConnector('mock', { payments: { pages: [{ records: [1, 2, 3, 4] }] } });
+    const report = await runStream(
+      adapter,
+      manifestWith(NO_RATE),
+      stream,
+      baseOptions({ onRecords: (r) => ({ accepted: r.length - 2, skipped: 1, rejected: 1 }) })
+    );
+    expect(report.fetched).toBe(4);
+    expect(report.skipped).toBe(1);
+    expect(report.rejected).toBe(1);
+  });
+});
+
+describe('runStream — retries + failures', () => {
+  it('retries transient failures then succeeds', async () => {
+    const { adapter, calls } = createMockConnector('mock', {
+      payments: {
+        pages: [{ records: [1], cursor: 'c1' }],
+        failures: { 0: { error: new ConnectorFetchError('transient', 'blip'), times: 2 } },
+      },
+    });
+    const report = await runStream(adapter, manifestWith(NO_RATE), stream, baseOptions());
+    expect(report.error_class).toBeUndefined();
+    expect(report.fetched).toBe(1);
+    expect(calls).toHaveLength(3); // 2 failed attempts + 1 success
+  });
+
+  it('gives up after maxAttempts and reports the error class', async () => {
+    const { adapter } = createMockConnector('mock', {
+      payments: { pages: [{ records: [1] }], failures: { 0: { error: new ConnectorFetchError('transient', 'down'), times: 99 } } },
+    });
+    const report = await runStream(adapter, manifestWith(NO_RATE), stream, baseOptions());
+    expect(report.error_class).toBe('transient');
+    expect(report.fetched).toBe(0);
+  });
+
+  it('fails fast on a non-retryable (auth) error', async () => {
+    const { adapter, calls } = createMockConnector('mock', {
+      payments: { pages: [{ records: [1] }], failures: { 0: { error: new ConnectorFetchError('auth', 'bad key'), times: 5 } } },
+    });
+    const report = await runStream(adapter, manifestWith(NO_RATE), stream, baseOptions());
+    expect(report.error_class).toBe('auth');
+    expect(calls).toHaveLength(1);
+  });
+
+  it('persists the last good cursor and marks the run resumable when it fails partway', async () => {
+    const { adapter } = createMockConnector('mock', {
+      payments: {
+        pages: [{ records: [1], cursor: 'c1' }, { records: [2], cursor: 'c2' }],
+        failures: { 1: { error: new ConnectorFetchError('permanent', 'boom'), times: 99 } },
+      },
+    });
+    const store = new InMemoryCursorStore();
+    const report = await runStream(adapter, manifestWith(NO_RATE), stream, baseOptions({ cursorStore: store }));
+    expect(report.error_class).toBe('permanent');
+    expect(report.resumable).toBe(true);
+    expect(report.cursor).toBe('c1');
+    expect(store.snapshot()[KEY]).toBe('c1');
+
+    // A resumed run reads that cursor and hands it to the adapter's first call.
+    const { adapter: adapter2, calls: calls2 } = createMockConnector('mock', {
+      payments: { pages: [{ records: [2], cursor: 'c2' }] },
+    });
+    await runStream(adapter2, manifestWith(NO_RATE), stream, baseOptions({ cursorStore: store }));
+    expect(calls2[0].cursor).toBe('c1');
+  });
+});
+
+describe('runStream — rate limiting + timeout', () => {
+  it('paces requests by the manifest requests_per_minute', async () => {
+    const clock = createManualClock();
+    const { adapter } = createMockConnector('mock', {
+      payments: { pages: [{ records: [1] }, { records: [2] }, { records: [3] }] },
+    });
+    // 60 rpm → one request/second; 3 pages → two 1s waits.
+    await runStream(adapter, manifestWith({ strategy: 'token_bucket', requests_per_minute: 60 }), stream, baseOptions({ clock }));
+    expect(clock.total()).toBe(2000);
+  });
+
+  it('adds no delay for a "none" rate strategy', async () => {
+    const clock = createManualClock();
+    const { adapter } = createMockConnector('mock', { payments: { pages: [{ records: [1] }, { records: [2] }] } });
+    await runStream(adapter, manifestWith(NO_RATE), stream, baseOptions({ clock }));
+    expect(clock.total()).toBe(0);
+  });
+
+  it('times out a page that never resolves', async () => {
+    const adapter = { connectorId: 'mock', fetchPage: () => new Promise<never>(() => {}) };
+    const report = await runStream(adapter, manifestWith(NO_RATE), stream, baseOptions({ pageTimeoutMs: 1000 }));
+    expect(report.error_class).toBe('timeout');
+    expect(report.pages).toBe(0);
+  });
+});
+
+describe('runStream — payload-free reporting', () => {
+  it('never leaks source records or secrets into the report', async () => {
+    const { adapter } = createMockConnector('mock', {
+      payments: { pages: [{ records: [{ pan: 'SENTINEL-4242', note: 'SECRET-TOKEN' }], cursor: 'c1' }] },
+    });
+    const report = await runStream(adapter, manifestWith(NO_RATE), stream, baseOptions({ credentials: { api_key: 'SECRET-TOKEN' } }));
+    const serialized = JSON.stringify(report);
+    expect(serialized).not.toContain('SENTINEL-4242');
+    expect(serialized).not.toContain('SECRET-TOKEN');
+    expect(report.fetched).toBe(1);
+  });
+});
+
+describe('backoffDelay', () => {
+  it('grows exponentially and is capped', () => {
+    const policy = { ...DEFAULT_RETRY, baseDelayMs: 100, maxDelayMs: 1000 };
+    expect(backoffDelay(0, policy, () => 0.999)).toBeLessThan(100);
+    expect(backoffDelay(2, policy, () => 0.999)).toBeLessThan(400);
+    expect(backoffDelay(10, policy, () => 0.999)).toBeLessThanOrEqual(1000);
+  });
+});

--- a/src/shared/lib/connectors/runtime/types.ts
+++ b/src/shared/lib/connectors/runtime/types.ts
@@ -1,0 +1,114 @@
+// Fetch-runtime contracts (CVS-142).
+//
+// The adapter interface a connector implements, the page/run shapes the runtime drives,
+// the payload-free run report it produces, and the small injectable seams (clock, cursor
+// store) that keep the runtime deterministic in tests. Credentials are *injected* — the
+// runtime never reads secrets itself; the connection/token model (CVS-141) resolves them
+// at the connector-MVP layer (CVS-146+). See docs/data/connector-runtime.md.
+import type { StreamManifest, SyncMode } from '../manifests';
+import type { ConnectorErrorClass } from './errors';
+
+/** Opaque, already-resolved credentials handed to an adapter — never persisted or logged. */
+export type ConnectorCredentials = Readonly<Record<string, string>>;
+
+/** Everything an adapter needs to fetch one page of one stream. */
+export interface FetchPageInput {
+  stream: StreamManifest;
+  syncMode: SyncMode;
+  credentials: ConnectorCredentials;
+  /** Incremental cursor carried across runs (from the cursor store). */
+  cursor?: string;
+  /** Pagination token within the current run (from the previous page). */
+  pageToken?: string;
+  /** Aborted when the run is cancelled or a page times out. */
+  signal: AbortSignal;
+}
+
+/** One page of source records plus how to continue. */
+export interface FetchPageResult {
+  /** Raw source records for this page — normalization/validation is CVS-143, not here. */
+  records: unknown[];
+  /** Token for the next page in this run; absent/undefined means the stream is exhausted. */
+  nextPageToken?: string;
+  /** Updated incremental cursor after this page; the runtime persists it on success. */
+  cursor?: string;
+}
+
+/** A connector's fetch surface. One method — the runtime owns the loop, retries, and pacing. */
+export interface ConnectorAdapter {
+  connectorId: string;
+  fetchPage(input: FetchPageInput): Promise<FetchPageResult>;
+}
+
+/**
+ * Per-page disposition reported by an optional record handler (e.g. the CVS-143
+ * normalizer). Lets the run summary carry accepted/skipped/rejected without the fetch
+ * runtime knowing anything about canonical validation.
+ */
+export interface PageOutcome {
+  accepted: number;
+  skipped?: number;
+  rejected?: number;
+}
+
+/** Handles the records of a page and reports how many were accepted/skipped/rejected. */
+export type RecordHandler = (records: unknown[]) => PageOutcome | Promise<PageOutcome>;
+
+/** Injectable clock so retry/backoff and rate-limit waits are deterministic in tests. */
+export interface Clock {
+  now(): number;
+  sleep(ms: number, signal?: AbortSignal): Promise<void>;
+}
+
+/** Payload-free cursor persistence. Real impl is DB-backed (payload-free) at a later step. */
+export interface CursorStore {
+  read(key: string): Promise<string | undefined>;
+  write(key: string, cursor: string): Promise<void>;
+}
+
+/** Backoff policy for retryable failures. */
+export interface RetryPolicy {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  /** Deterministic jitter in [0,1) — defaults to Math.random; injected in tests. */
+  jitter?: () => number;
+}
+
+export interface RunStreamOptions {
+  credentials: ConnectorCredentials;
+  syncMode: SyncMode;
+  cursorStore: CursorStore;
+  /** Stable key the cursor persists under, e.g. `${accountId}:${connector}:${stream}`. */
+  cursorKey: string;
+  /** Cap on records fetched this run — powers sample-preview mode (decision CVS-137 §8). */
+  maxRecords?: number;
+  /** Per-page timeout; omit to disable. */
+  pageTimeoutMs?: number;
+  retry?: Partial<RetryPolicy>;
+  clock?: Clock;
+  signal?: AbortSignal;
+  /** Optional per-page record handler (normalization plugs in here). */
+  onRecords?: RecordHandler;
+}
+
+/** Structured, payload-free summary of a single stream run. */
+export interface RunReport {
+  connector_id: string;
+  stream: string;
+  sync_mode: SyncMode;
+  pages: number;
+  fetched: number;
+  skipped: number;
+  rejected: number;
+  /** Cursor persisted at the end of the run (undefined if none advanced). */
+  cursor?: string;
+  /** Set when the run ended on a failure; the class is stable and payload-free. */
+  error_class?: ConnectorErrorClass;
+  /** Safe, source-agnostic error message (never a payload/token). */
+  error_message?: string;
+  /** True when the run stopped early on failure but a resumable cursor was persisted. */
+  resumable: boolean;
+  started_at: string;
+  finished_at: string;
+}


### PR DESCRIPTION
Closes CVS-142. *Canonical schemas & native connectors* → milestone 2 (Connector runtime).

## What this adds
`src/shared/lib/connectors/runtime/` — the shared engine every native connector (CVS-146–150) runs on. A connector implements one method (`fetchPage`); the runtime owns pagination, pacing, retries, timeouts, cursor safety, and reporting.

- **`runStream(adapter, manifest, stream, options)`** — the loop.
- **`rateLimiter.ts`** — pacing derived from `manifest.rate_limit` (requests/min for token_bucket/fixed_window; none for concurrency/none).
- **`retry.ts`** — exponential backoff + full jitter, honors `Retry-After`; only transient/rate_limit/timeout retry, auth/permanent fail fast.
- **`errors.ts`** — `ConnectorFetchError` + `classifyError` (HTTP status → stable class).
- **`clock.ts`** — injectable clock + per-page `withTimeout`.
- **`cursorStore.ts`** — payload-free `CursorStore` + in-memory impl.
- **`mockConnector.ts`** — reusable mock connector + deterministic clock (also for the CVS-154 QA suite).
- **`docs/data/connector-runtime.md`**.

## Design notes
- **Decoupled from secrets.** Credentials are *injected* (`ConnectorCredentials`); the runtime never reads them. CVS-141's `readAccountSecret` wires in at the connector-MVP layer — so this builds cleanly on `main` rather than stacking on the owner-gated #120.
- **Cursor advances only after a page is fetched + handled** → a run that fails partway is `resumable` from the last good page (no dupes/skips). Proven by test.
- **Payload-free `RunReport`** — counts + stable `error_class`, never a record or token (asserted).
- Normalization stays separate: an optional `onRecords` handler lets the CVS-143 normalizer plug in.

## Acceptance criteria
- [x] Runs a mock connector stream with pagination + cursor persistence
- [x] Cursor advances only after a successful page/run (+ resume test)
- [x] Rate-limit + retry configurable by manifest
- [x] Run summaries contain no payloads or secrets
- [x] Failures are structured (`error_class`) for Connected Accounts / debug surfaces

## Verification
12 runtime tests (pagination, caps, retries + exhaustion, fail-fast, resume, rate-limit pacing, timeout, payload-free) + full suite, type-check, lint pass via Husky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)