### PR TITLE
fix(styles): actually import tw-animate-css + fix components.json (v4)

### DIFF
--- a/components.json
+++ b/components.json
@@ -4,8 +4,8 @@
   "rsc": true,
   "tsx": true,
   "tailwind": {
-    "config": "tailwind.config.ts",
-    "css": "src/index.css",
+    "config": "",
+    "css": "src/styles/index.css",
     "baseColor": "slate",
     "cssVariables": true
   },

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,4 +1,8 @@
 @import 'tailwindcss';
+/* v4 successor to tailwindcss-animate — provides animate-in / fade-in / zoom-in /
+   slide-in utilities used by the shadcn dialog/dropdown/popover components. The old
+   tailwindcss-animate plugin lived in tailwind.config.ts, which v4 no longer loads. */
+@import 'tw-animate-css';
 
 /* Import Editor.js styles */
 @import './editor.css';


### PR DESCRIPTION
Follow-up to #124 (which deleted the dead `tailwind.config.ts`). #124's `git add` had aborted on the already-removed path, so these two pieces didn't make it into that commit — this lands them.

- **Import `tw-animate-css`** in `src/styles/index.css` (installed v4 successor to `tailwindcss-animate`). Its `animate-in` / `fade-in` / `zoom-in` / `slide-in` utilities are used by the shadcn dialog/dropdown/popover components but were defined nowhere after the v4 migration → those enter/exit animations were **inert**. Now wired.
- **`components.json`**: `config: ""` (v4 has no JS config, and it pointed at the now-deleted file) + correct css path to `src/styles/index.css`.

## Verification
`npm run build` ✓; built CSS emits the tw-animate utilities (`--tw-enter`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)