### PR TITLE
chore(e2e): verify canvas UI locally via production Clerk + real data

### DIFF
--- a/e2e/canvas.spec.ts
+++ b/e2e/canvas.spec.ts
@@ -1,0 +1,41 @@
+import { clerk, setupClerkTestingToken } from '@clerk/testing/playwright';
+import { test } from '@playwright/test';
+
+const EMAIL = process.env.E2E_TEST_EMAIL;
+const PASSWORD = process.env.E2E_TEST_PASSWORD;
+
+// Activate the signed-in user's first org (the app is orgs-only) so their
+// canvases load. Call after clerk.signIn.
+export async function activateOrg(page: import('@playwright/test').Page) {
+  await page.evaluate(async () => {
+    const c = (window as { Clerk?: any }).Clerk;
+    if (!c?.user || c.organization) return;
+    const m = await c.user.getOrganizationMemberships();
+    const org = (m?.data ?? m)?.[0]?.organization;
+    if (org) await c.setActive({ organization: org.id });
+  });
+}
+
+// Open a real canvas and capture the toolbar filter popover (real data).
+test('canvas + filter popover', async ({ page }) => {
+  test.skip(!process.env.CLERK_SECRET_KEY || !EMAIL || !PASSWORD, 'creds');
+  await setupClerkTestingToken({ page });
+  await page.goto('/');
+  await clerk.signIn({
+    page,
+    signInParams: { strategy: 'password', identifier: EMAIL!, password: PASSWORD! },
+  });
+  await activateOrg(page);
+  await page.goto('/');
+  await page.waitForTimeout(3500);
+  await page.getByText('Canvas Preview').first().click().catch(() => {});
+  await page.waitForURL(/\/canvas\/[^/]+$/, { timeout: 25000 }).catch(() => {});
+  await page.waitForTimeout(5000);
+  await page.screenshot({ path: 'e2e/screenshots/canvas.png' });
+  const fb = page.locator('button[title="Filter & date"]').first();
+  if (await fb.isVisible().catch(() => false)) {
+    await fb.click();
+    await page.waitForTimeout(900);
+    await page.screenshot({ path: 'e2e/screenshots/filter.png' });
+  }
+});

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -1,5 +1,6 @@
 import { clerk, setupClerkTestingToken } from '@clerk/testing/playwright';
 import { test } from '@playwright/test';
+import { activateOrg } from './canvas.spec';
 
 const EMAIL = process.env.E2E_TEST_EMAIL;
 const PASSWORD = process.env.E2E_TEST_PASSWORD;
@@ -24,6 +25,7 @@ test('capture workspace routes', async ({ page }) => {
     page,
     signInParams: { strategy: 'password', identifier: EMAIL!, password: PASSWORD! },
   });
+  await activateOrg(page);
 
   for (const r of ROUTES) {
     await page.goto(r.path);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,10 +17,12 @@ try {
 // (pk_live) are domain-locked to canvasm.app and refuse localhost, and Web
 // Crypto needs a secure context — localhost qualifies, dev.canvasm.app:3000 (http)
 // does not. So point clerkSetup + the app at the dev instance on localhost.
-const E2E_PK = process.env.E2E_CLERK_PUBLISHABLE_KEY;
-const E2E_SK = process.env.E2E_CLERK_SECRET_KEY;
-process.env.CLERK_PUBLISHABLE_KEY = E2E_PK || process.env.VITE_CLERK_PUBLISHABLE_KEY;
-if (E2E_SK) process.env.CLERK_SECRET_KEY = E2E_SK;
+// Use PRODUCTION Clerk (pk_live/sk_live): Supabase trusts its JWTs, and we added
+// https://dev.canvasm.app:3000 to the prod instance's allowed_origins so it loads
+// locally over HTTPS. The app uses its own .env pk_live (no override).
+process.env.CLERK_PUBLISHABLE_KEY = process.env.VITE_CLERK_PUBLISHABLE_KEY;
+// CLERK_SECRET_KEY stays the sk_live loaded from .env above.
+const E2E_PK: string | undefined = undefined;
 
 export default defineConfig({
   testDir: './e2e',


### PR DESCRIPTION
Switches the screenshot harness to **production Clerk** (Supabase trusts its JWTs; dev-instance JWTs get PGRST301). pk_live loads locally because `https://dev.canvasm.app:3000` was added to the prod instance's `allowed_origins` (additive). Signs in the test user, activates their org, opens a real canvas, and screenshots canvas surfaces. Verified the CVS-163 filter popover on a real canvas before merge. Removes need for the dev instance. (Reminder in the commit: pull the allowed_origin when the lane's done.)