### PR TITLE
feat(connectors): normalization runtime — source JSON → canonical (CVS-143)

### DIFF
--- a/docs/data/connector-normalization.md
+++ b/docs/data/connector-normalization.md
@@ -1,0 +1,69 @@
+# Connector normalization (source JSON → canonical records)
+
+The normalization runtime (`src/shared/lib/connectors/normalize/`, CVS-143) turns raw
+source objects into validated **canonical records** (CVS-139). It's the layer that keeps
+third-party object shapes out of the product model — connectors fetch, this normalizes.
+
+Sits between the **fetch runtime** (CVS-142, which pages raw records) and **metric
+binding** (CVS-144, which materializes accepted records into metric values).
+
+## Pipeline
+
+```
+raw source object ──▶ Mapper (source-specific) ──▶ CanonicalDraft[]
+                                                       │  engine stamps envelope + lineage
+                                                       ▼
+                                            validateRecord (CVS-139)
+                                          ┌──────────┴───────────┐
+                                    accepted (deduped)      rejected (payload-free)
+```
+
+- A **`Mapper`** is a source module: `(raw, ctx) => CanonicalDraft[]`. It returns only the
+  schema-specific parts (schema, source_object_id, occurred_at, money, attributes) and may
+  emit **multiple** records from one object (e.g. a WooCommerce order → `commerce_order` +
+  `order_line_item[]` + `customer`).
+- **`normalizeRecords(records, mapper, ctx)`** stamps the shared envelope from the
+  `NormalizationContext` (source, account, workspace, observed_at, lineage), validates every
+  output against its canonical schema, dedupes by `dedupeKey`, and returns a
+  `NormalizationReport`.
+
+## Payload-free by construction
+
+Nothing raw is retained or logged. The `NormalizationReport` carries:
+- `accepted: CanonicalRecord[]` — handed to the binding sink (CVS-144), not logged.
+- `skipped` — in-batch duplicates (same dedupe key).
+- `rejected: { index, schema?, source_object_id?, errors[] }[]` — **source ids + validation
+  error codes only**, never field values. A mapper that throws yields a fixed
+  `mapper_error` message (the thrown text is discarded so it can't echo a payload).
+
+## Plugging into the fetch runtime
+
+`toRecordHandler(mapper, ctx, sink?)` returns the runtime's `RecordHandler`, so a stream run
+normalizes each page as it's fetched and reports `{ accepted, skipped, rejected }` into the
+run summary:
+
+```ts
+import { runStream } from '@/shared/lib/connectors/runtime';
+import { toRecordHandler, getMapper } from '@/shared/lib/connectors/normalize';
+
+const mapper = getMapper('stripe', 'payment_intents')!;
+await runStream(adapter, stream, {
+  /* …credentials, cursorStore, cursorKey… */
+  onRecords: toRecordHandler(mapper, ctx, (records) => bindToMetrics(records)),
+});
+```
+
+## Mappers shipped (Tier-1)
+
+| connector:stream | canonical output |
+| --- | --- |
+| `stripe:payment_intents` | `payment` |
+| `ga4:page_report` | `page_metric` |
+| `ga4:events` | `analytics_event` |
+| `woocommerce:orders` | `commerce_order` + `order_line_item[]` + `customer` |
+| `shopify:orders` | `commerce_order` + `order_line_item[]` |
+| `posthog:events` | `analytics_event` |
+
+Resolve one with `getMapper(connectorId, streamName)`. Money is normalized to **minor units**
+(`money.ts`); naive source timestamps are read as UTC (`dates.ts`). Adding a stream = add a
+mapper + a registry key; the canonical contracts don't change.

--- a/src/shared/lib/connectors/normalize/dates.ts
+++ b/src/shared/lib/connectors/normalize/dates.ts
@@ -1,0 +1,20 @@
+// Date normalization helpers for source mappers (CVS-143). Canonical timestamps must
+// be ISO-8601 with a zone (the envelope validates `.datetime({ offset: true })`), so a
+// naive source datetime is treated as UTC. Bad inputs pass through unchanged and get
+// caught by `validateRecord` (→ a rejection), never silently coerced.
+
+/** Ensure an ISO datetime carries a zone; a bare `YYYY-MM-DDTHH:MM:SS` is read as UTC. */
+export function isoUtc(s: string): string {
+  if (typeof s !== 'string' || s.length === 0) return s;
+  if (s.endsWith('Z') || /[+-]\d\d:\d\d$/.test(s)) return s;
+  // date-only or naive datetime → treat as UTC
+  if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return `${s}T00:00:00Z`;
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/.test(s)) return `${s}Z`;
+  return s; // unrecognized → let validation reject it
+}
+
+/** GA4 `YYYYMMDD` → ISO UTC midnight. Non-matching input passes through for rejection. */
+export function ga4DateToIso(d: string): string {
+  const m = /^(\d{4})(\d{2})(\d{2})$/.exec(d ?? '');
+  return m ? `${m[1]}-${m[2]}-${m[3]}T00:00:00Z` : (d ?? '');
+}

--- a/src/shared/lib/connectors/normalize/index.ts
+++ b/src/shared/lib/connectors/normalize/index.ts
@@ -1,0 +1,12 @@
+// Normalization runtime (CVS-143): source JSON → validated canonical records (CVS-139),
+// pluggable into the fetch runtime (CVS-142) via toRecordHandler. Import from here.
+// See docs/data/connector-normalization.md.
+export * from './types';
+export * from './dates';
+export * from './normalizeStream';
+export * from './registry';
+export { mapStripePayment } from './mappers/stripe';
+export { mapGa4PageMetric, mapGa4Event } from './mappers/ga4';
+export { mapWooOrder } from './mappers/woocommerce';
+export { mapShopifyOrder } from './mappers/shopify';
+export { mapPosthogEvent } from './mappers/posthog';

--- a/src/shared/lib/connectors/normalize/mappers/ga4.ts
+++ b/src/shared/lib/connectors/normalize/mappers/ga4.ts
@@ -1,0 +1,47 @@
+// GA4 Data API → canonical (CVS-143). Rows are pre-shaped by the connector adapter
+// (CVS-146) into these flat objects before normalization.
+import { ga4DateToIso } from '../dates';
+import type { CanonicalDraft, Mapper } from '../types';
+
+interface Ga4PageRow {
+  date: string; // YYYYMMDD
+  pagePath: string;
+  metric: string; // e.g. 'screenPageViews'
+  value: number;
+  country?: string;
+}
+
+interface Ga4EventRow {
+  date: string; // YYYYMMDD
+  eventName: string;
+  eventCount: number;
+}
+
+export const mapGa4PageMetric: Mapper = (raw): CanonicalDraft[] => {
+  const r = raw as Ga4PageRow;
+  return [
+    {
+      schema: 'page_metric',
+      source_object_id: `${r.date}:${r.pagePath}:${r.metric}`,
+      occurred_at: ga4DateToIso(r.date),
+      attributes: {
+        page_path: r.pagePath,
+        metric: r.metric,
+        value: r.value,
+        dimensions: r.country ? { country: r.country } : undefined,
+      },
+    },
+  ];
+};
+
+export const mapGa4Event: Mapper = (raw): CanonicalDraft[] => {
+  const e = raw as Ga4EventRow;
+  return [
+    {
+      schema: 'analytics_event',
+      source_object_id: `${e.date}:${e.eventName}`,
+      occurred_at: ga4DateToIso(e.date),
+      attributes: { event_name: e.eventName, count: e.eventCount },
+    },
+  ];
+};

--- a/src/shared/lib/connectors/normalize/mappers/posthog.ts
+++ b/src/shared/lib/connectors/normalize/mappers/posthog.ts
@@ -1,0 +1,30 @@
+// PostHog → canonical (CVS-143). Events carry an ISO timestamp and a properties bag.
+import type { CanonicalDraft, Mapper } from '../types';
+
+interface PosthogEvent {
+  id?: string;
+  uuid?: string;
+  event: string;
+  distinct_id?: string;
+  timestamp: string; // ISO-8601
+  properties?: Record<string, unknown>;
+}
+
+export const mapPosthogEvent: Mapper = (raw): CanonicalDraft[] => {
+  const e = raw as PosthogEvent;
+  const sessionId = e.properties?.['$session_id'];
+  return [
+    {
+      schema: 'analytics_event',
+      source_object_id: e.uuid ?? e.id ?? '',
+      occurred_at: e.timestamp,
+      attributes: {
+        event_name: e.event,
+        user_source_id: e.distinct_id,
+        session_id: typeof sessionId === 'string' ? sessionId : undefined,
+        count: 1,
+        properties: e.properties,
+      },
+    },
+  ];
+};

--- a/src/shared/lib/connectors/normalize/mappers/shopify.ts
+++ b/src/shared/lib/connectors/normalize/mappers/shopify.ts
@@ -1,0 +1,85 @@
+// Shopify GraphQL Admin → canonical (CVS-143). Money is major-unit decimal strings
+// in `shopMoney`. One order → order + line items.
+import { toMinor } from '../../canonical';
+import { isoUtc } from '../dates';
+import type { CanonicalDraft, Mapper } from '../types';
+
+interface ShopifyMoney {
+  amount: string;
+  currencyCode: string;
+}
+
+interface ShopifyLineItem {
+  id: string;
+  sku?: string;
+  title?: string;
+  quantity: number;
+  originalTotalSet?: { shopMoney: ShopifyMoney };
+}
+
+interface ShopifyOrder {
+  id: string; // gid://shopify/Order/123
+  displayFinancialStatus?: string;
+  processedAt?: string;
+  createdAt?: string;
+  totalPriceSet?: { shopMoney: ShopifyMoney };
+  customer?: { id: string } | null;
+  lineItems?: { nodes: ShopifyLineItem[] };
+}
+
+const STATUS: Record<string, string> = {
+  PAID: 'paid',
+  PARTIALLY_PAID: 'paid',
+  PENDING: 'pending',
+  AUTHORIZED: 'pending',
+  REFUNDED: 'refunded',
+  PARTIALLY_REFUNDED: 'refunded',
+  VOIDED: 'canceled',
+};
+
+export const mapShopifyOrder: Mapper = (raw): CanonicalDraft[] => {
+  const o = raw as ShopifyOrder;
+  const money = o.totalPriceSet?.shopMoney;
+  const currency = (money?.currencyCode ?? '').toUpperCase();
+  const cur = currency || 'USD';
+  const occurred_at = isoUtc(o.processedAt ?? o.createdAt ?? '');
+  const items = o.lineItems?.nodes ?? [];
+
+  const drafts: CanonicalDraft[] = [
+    {
+      schema: 'commerce_order',
+      source_object_id: o.id,
+      occurred_at,
+      currency,
+      amount: toMinor(Number(money?.amount ?? 0), cur),
+      amount_unit: 'minor',
+      attributes: {
+        status: o.displayFinancialStatus ? (STATUS[o.displayFinancialStatus] ?? o.displayFinancialStatus.toLowerCase()) : 'pending',
+        customer_source_id: o.customer?.id ?? undefined,
+        line_item_count: items.length,
+      },
+    },
+  ];
+
+  for (const li of items) {
+    const m = li.originalTotalSet?.shopMoney;
+    const liCur = (m?.currencyCode ?? currency).toUpperCase() || 'USD';
+    drafts.push({
+      schema: 'order_line_item',
+      source_object_id: `${o.id}:${li.id}`,
+      occurred_at,
+      currency: (m?.currencyCode ?? currency).toUpperCase() || undefined,
+      amount: m ? toMinor(Number(m.amount ?? 0), liCur) : undefined,
+      amount_unit: m ? 'minor' : undefined,
+      attributes: {
+        order_source_id: o.id,
+        sku: li.sku,
+        title: li.title,
+        quantity: li.quantity,
+        unit_amount: m && li.quantity ? toMinor(Number(m.amount ?? 0) / li.quantity, liCur) : undefined,
+      },
+    });
+  }
+
+  return drafts;
+};

--- a/src/shared/lib/connectors/normalize/mappers/stripe.ts
+++ b/src/shared/lib/connectors/normalize/mappers/stripe.ts
@@ -1,0 +1,42 @@
+// Stripe → canonical (CVS-143). Stripe amounts are already in minor units.
+import type { CanonicalDraft, Mapper } from '../types';
+
+interface StripePaymentIntent {
+  id: string;
+  amount: number;
+  currency: string;
+  status: string;
+  created: number; // unix seconds
+  customer?: string | null;
+  payment_method_types?: string[];
+}
+
+// Stripe PaymentIntent status → canonical payment status (unknown passes through → rejected).
+const STATUS: Record<string, string> = {
+  succeeded: 'succeeded',
+  canceled: 'canceled',
+  processing: 'pending',
+  requires_payment_method: 'pending',
+  requires_confirmation: 'pending',
+  requires_action: 'pending',
+  requires_capture: 'pending',
+};
+
+export const mapStripePayment: Mapper = (raw): CanonicalDraft[] => {
+  const pi = raw as StripePaymentIntent;
+  return [
+    {
+      schema: 'payment',
+      source_object_id: pi.id,
+      occurred_at: new Date((pi.created ?? 0) * 1000).toISOString(),
+      currency: (pi.currency ?? '').toUpperCase(),
+      amount: pi.amount,
+      amount_unit: 'minor',
+      attributes: {
+        status: STATUS[pi.status] ?? pi.status,
+        customer_source_id: pi.customer ?? undefined,
+        payment_method: pi.payment_method_types?.[0],
+      },
+    },
+  ];
+};

--- a/src/shared/lib/connectors/normalize/mappers/woocommerce.ts
+++ b/src/shared/lib/connectors/normalize/mappers/woocommerce.ts
@@ -1,0 +1,90 @@
+// WooCommerce → canonical (CVS-143). One order → order + line items + customer
+// (the one-to-many case). Woo amounts are major-unit decimal strings.
+import { toMinor } from '../../canonical';
+import { isoUtc } from '../dates';
+import type { CanonicalDraft, Mapper } from '../types';
+
+interface WooLineItem {
+  id: number;
+  product_id?: number;
+  sku?: string;
+  name?: string;
+  quantity: number;
+  total: string; // major units, line total
+}
+
+interface WooOrder {
+  id: number;
+  status: string;
+  total: string; // major units, order total
+  currency: string;
+  date_created: string;
+  customer_id?: number;
+  billing?: { email?: string };
+  line_items?: WooLineItem[];
+}
+
+const STATUS: Record<string, string> = {
+  pending: 'pending',
+  processing: 'paid',
+  'on-hold': 'pending',
+  completed: 'completed',
+  cancelled: 'canceled',
+  refunded: 'refunded',
+  failed: 'canceled',
+};
+
+export const mapWooOrder: Mapper = (raw): CanonicalDraft[] => {
+  const o = raw as WooOrder;
+  const currency = (o.currency ?? '').toUpperCase();
+  const cur = currency || 'USD'; // for the minor-unit math only; the draft keeps `currency`
+  const occurred_at = isoUtc(o.date_created ?? '');
+  const items = o.line_items ?? [];
+
+  const drafts: CanonicalDraft[] = [
+    {
+      schema: 'commerce_order',
+      source_object_id: String(o.id),
+      occurred_at,
+      currency,
+      amount: toMinor(Number(o.total ?? 0), cur),
+      amount_unit: 'minor',
+      attributes: {
+        status: STATUS[o.status] ?? o.status,
+        customer_source_id: o.customer_id ? String(o.customer_id) : undefined,
+        line_item_count: items.length,
+      },
+    },
+  ];
+
+  for (const li of items) {
+    const qty = li.quantity;
+    drafts.push({
+      schema: 'order_line_item',
+      source_object_id: `${o.id}:${li.id}`,
+      occurred_at,
+      currency,
+      amount: toMinor(Number(li.total ?? 0), cur),
+      amount_unit: 'minor',
+      attributes: {
+        order_source_id: String(o.id),
+        product_source_id: li.product_id != null ? String(li.product_id) : undefined,
+        sku: li.sku,
+        title: li.name,
+        quantity: qty,
+        unit_amount: qty ? toMinor(Number(li.total ?? 0) / qty, cur) : undefined,
+      },
+    });
+  }
+
+  if (o.customer_id) {
+    drafts.push({
+      schema: 'customer',
+      source_object_id: String(o.customer_id),
+      occurred_at,
+      attributes: { email: o.billing?.email },
+    });
+  }
+
+  return drafts;
+};

--- a/src/shared/lib/connectors/normalize/normalize.test.ts
+++ b/src/shared/lib/connectors/normalize/normalize.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import type { CanonicalRecord } from '../canonical';
+import {
+  getMapper,
+  mapGa4Event,
+  mapGa4PageMetric,
+  mapPosthogEvent,
+  mapShopifyOrder,
+  mapStripePayment,
+  mapWooOrder,
+  normalizeRecords,
+  toRecordHandler,
+  type NormalizationContext,
+} from './index';
+
+const ctx = (over: Partial<NormalizationContext> = {}): NormalizationContext => ({
+  source: 'stripe',
+  sourceAccountId: 'acct_1',
+  workspaceId: 'ws_1',
+  connectorVersion: 'stripe@1.0.0',
+  observedAt: '2026-07-06T00:00:00Z',
+  ...over,
+});
+
+const stripePI = {
+  id: 'pi_1', amount: 12900, currency: 'myr', status: 'succeeded',
+  created: 1751539800, customer: 'cus_1', payment_method_types: ['card'],
+};
+
+describe('mappers — happy paths validate into canonical records', () => {
+  it('stripe payment', () => {
+    const r = normalizeRecords([stripePI], mapStripePayment, ctx());
+    expect(r.acceptedCount).toBe(1);
+    expect(r.rejectedCount).toBe(0);
+    expect(r.accepted[0].schema).toBe('payment');
+    expect(r.accepted[0].amount).toBe(12900);
+    expect(r.accepted[0].source).toBe('stripe');
+    expect(r.accepted[0].lineage.normalizer_version).toBe('payment@1.0.0');
+  });
+
+  it('ga4 page metric + event', () => {
+    const pm = normalizeRecords(
+      [{ date: '20260701', pagePath: '/pricing', metric: 'screenPageViews', value: 1240, country: 'MY' }],
+      mapGa4PageMetric, ctx({ source: 'ga4', connectorVersion: 'ga4@1.0.0' })
+    );
+    expect(pm.accepted[0].schema).toBe('page_metric');
+    expect(pm.accepted[0].occurred_at).toBe('2026-07-01T00:00:00Z');
+
+    const ev = normalizeRecords(
+      [{ date: '20260701', eventName: 'sign_up', eventCount: 42 }],
+      mapGa4Event, ctx({ source: 'ga4', connectorVersion: 'ga4@1.0.0' })
+    );
+    expect(ev.accepted[0].schema).toBe('analytics_event');
+  });
+
+  it('shopify order → order + line item', () => {
+    const raw = {
+      id: 'gid://shopify/Order/123', displayFinancialStatus: 'PAID', processedAt: '2026-07-03T09:00:00Z',
+      totalPriceSet: { shopMoney: { amount: '89.90', currencyCode: 'MYR' } },
+      customer: { id: 'gid://shopify/Customer/9' },
+      lineItems: { nodes: [{ id: 'li_1', sku: 'S', title: 'Shirt', quantity: 2, originalTotalSet: { shopMoney: { amount: '89.90', currencyCode: 'MYR' } } }] },
+    };
+    const r = normalizeRecords([raw], mapShopifyOrder, ctx({ source: 'shopify', connectorVersion: 'shopify@1.0.0' }));
+    expect(r.rejectedCount).toBe(0);
+    expect(r.accepted.map((x) => x.schema)).toEqual(['commerce_order', 'order_line_item']);
+    expect(r.accepted[0].amount).toBe(8990);
+  });
+
+  it('posthog event', () => {
+    const raw = { uuid: 'evt_1', event: 'signed_up', distinct_id: 'user_9', timestamp: '2026-07-03T10:00:00Z', properties: { $session_id: 'sess_2', plan: 'pro' } };
+    const r = normalizeRecords([raw], mapPosthogEvent, ctx({ source: 'posthog', connectorVersion: 'posthog@1.0.0' }));
+    expect(r.accepted[0].schema).toBe('analytics_event');
+    if (r.accepted[0].schema === 'analytics_event') expect(r.accepted[0].attributes.session_id).toBe('sess_2');
+  });
+});
+
+describe('one-to-many: WooCommerce order → order + line items + customer', () => {
+  const wooOrder = {
+    id: 1001, status: 'completed', total: '259.90', currency: 'myr', date_created: '2026-07-03T08:59:00',
+    customer_id: 5, billing: { email: 'a@b.com' },
+    line_items: [
+      { id: 11, product_id: 3, sku: 'X', name: 'T', quantity: 2, total: '179.80' },
+      { id: 12, product_id: 4, sku: 'Y', name: 'U', quantity: 1, total: '80.10' },
+    ],
+  };
+
+  it('emits 4 canonical records from 1 source object', () => {
+    const r = normalizeRecords([wooOrder], mapWooOrder, ctx({ source: 'woocommerce', connectorVersion: 'woocommerce@1.0.0' }));
+    expect(r.rejectedCount).toBe(0);
+    expect(r.accepted.map((x) => x.schema)).toEqual(['commerce_order', 'order_line_item', 'order_line_item', 'customer']);
+    const order = r.accepted[0];
+    expect(order.amount).toBe(25990);
+    if (order.schema === 'commerce_order') expect(order.attributes.line_item_count).toBe(2);
+  });
+});
+
+describe('dedupe (warning path): in-batch duplicates are skipped, not rejected', () => {
+  it('skips the second identical record', () => {
+    const r = normalizeRecords([stripePI, { ...stripePI }], mapStripePayment, ctx());
+    expect(r.acceptedCount).toBe(1);
+    expect(r.skipped).toBe(1);
+    expect(r.rejectedCount).toBe(0);
+  });
+});
+
+describe('rejections (payload-free)', () => {
+  it('missing currency on a money-required schema', () => {
+    const r = normalizeRecords([{ id: 'pi_x', amount: 100, status: 'succeeded', created: 1751539800 }], mapStripePayment, ctx());
+    expect(r.acceptedCount).toBe(0);
+    expect(r.rejected[0].source_object_id).toBe('pi_x');
+    expect(r.rejected[0].errors.length).toBeGreaterThan(0);
+  });
+
+  it('invalid timestamp', () => {
+    const r = normalizeRecords([{ date: 'notadate', pagePath: '/x', metric: 'm', value: 1 }], mapGa4PageMetric, ctx({ source: 'ga4' }));
+    expect(r.acceptedCount).toBe(0);
+    expect(r.rejected[0].errors.some((e) => e.path === 'occurred_at')).toBe(true);
+  });
+
+  it('missing source id', () => {
+    const r = normalizeRecords([{ event: 'x', timestamp: '2026-07-03T10:00:00Z' }], mapPosthogEvent, ctx({ source: 'posthog' }));
+    expect(r.acceptedCount).toBe(0);
+    expect(r.rejected[0].errors.some((e) => e.path === 'source_object_id')).toBe(true);
+  });
+
+  it('unsupported status', () => {
+    const r = normalizeRecords([{ id: 'pi_z', amount: 100, currency: 'MYR', status: 'flurgle', created: 1751539800 }], mapStripePayment, ctx());
+    expect(r.acceptedCount).toBe(0);
+    expect(r.rejected[0].errors.some((e) => e.path.startsWith('attributes.status'))).toBe(true);
+  });
+
+  it('a throwing mapper is a rejection with a generic (payload-free) message', () => {
+    const boom = () => { throw new Error('raw secret 4242424242424242'); };
+    const r = normalizeRecords([{}], boom, ctx());
+    expect(r.rejectedCount).toBe(1);
+    expect(r.rejected[0].errors[0].code).toBe('mapper_error');
+    expect(r.rejected[0].errors[0].message).not.toContain('4242');
+  });
+});
+
+describe('toRecordHandler — plugs into the fetch runtime', () => {
+  it('returns a PageOutcome and sends accepted records to the sink', async () => {
+    const sink: CanonicalRecord[] = [];
+    const handler = toRecordHandler(mapStripePayment, ctx(), (recs) => { sink.push(...recs); });
+    const outcome = await handler([stripePI, { ...stripePI }, { id: 'pi_bad', amount: 1, status: 'succeeded', created: 1 }]);
+    expect(outcome).toEqual({ accepted: 1, skipped: 1, rejected: 1 });
+    expect(sink).toHaveLength(1);
+    expect(sink[0].schema).toBe('payment');
+  });
+});
+
+describe('getMapper', () => {
+  it('resolves registered connector:stream keys', () => {
+    expect(getMapper('stripe', 'payment_intents')).toBe(mapStripePayment);
+    expect(getMapper('woocommerce', 'orders')).toBe(mapWooOrder);
+    expect(getMapper('nope', 'nope')).toBeUndefined();
+  });
+});

--- a/src/shared/lib/connectors/normalize/normalizeStream.ts
+++ b/src/shared/lib/connectors/normalize/normalizeStream.ts
@@ -1,0 +1,94 @@
+// Normalization engine (CVS-143): run a mapper over a page of source records, stamp
+// the canonical envelope, validate against CVS-139, dedupe, and report — payload-free.
+// `toRecordHandler` adapts it to the CVS-142 fetch runtime's `onRecords` seam.
+import {
+  CANONICAL_SCHEMA_VERSION,
+  dedupeKey,
+  validateRecord,
+  type CanonicalRecord,
+} from '../canonical';
+import type { PageOutcome, RecordHandler } from '../runtime';
+import type { CanonicalDraft, Mapper, NormalizationContext, NormalizationReport, RejectedRecord } from './types';
+
+/** Stamp the shared envelope + lineage onto a schema-specific draft. */
+function assemble(draft: CanonicalDraft, ctx: NormalizationContext): Record<string, unknown> {
+  return {
+    schema: draft.schema,
+    schema_version: CANONICAL_SCHEMA_VERSION,
+    source: ctx.source,
+    source_account_id: ctx.sourceAccountId,
+    source_object_id: draft.source_object_id,
+    workspace_id: ctx.workspaceId,
+    observed_at: ctx.observedAt,
+    occurred_at: draft.occurred_at,
+    ...(draft.currency !== undefined ? { currency: draft.currency } : {}),
+    ...(draft.amount !== undefined ? { amount: draft.amount } : {}),
+    ...(draft.amount_unit !== undefined ? { amount_unit: draft.amount_unit } : {}),
+    attributes: draft.attributes,
+    lineage: {
+      connector_version: ctx.connectorVersion,
+      ...(ctx.cursor !== undefined ? { cursor: ctx.cursor } : {}),
+      normalizer_version: draft.normalizer_version ?? `${draft.schema}@${CANONICAL_SCHEMA_VERSION}`,
+    },
+  };
+}
+
+/**
+ * Normalize a page of raw source records into validated canonical records. Every
+ * output is validated (CVS-139) before it's accepted; a record that fails — or a
+ * mapper that throws — becomes a payload-free rejection (source ids + error codes,
+ * never raw data). In-batch duplicates (same dedupeKey) are skipped, not rejected.
+ */
+export function normalizeRecords(
+  records: unknown[],
+  mapper: Mapper,
+  ctx: NormalizationContext
+): NormalizationReport {
+  const accepted: CanonicalRecord[] = [];
+  const rejected: RejectedRecord[] = [];
+  const seen = new Set<string>();
+  let skipped = 0;
+
+  records.forEach((raw, index) => {
+    let drafts: CanonicalDraft[];
+    try {
+      drafts = mapper(raw, ctx);
+    } catch {
+      // Never surface the thrown message — it could echo raw payload data.
+      rejected.push({ index, errors: [{ path: '$', code: 'mapper_error', message: 'normalizer failed to map source record' }] });
+      return;
+    }
+    for (const draft of drafts) {
+      const res = validateRecord(assemble(draft, ctx));
+      if (!res.ok) {
+        rejected.push({ index, schema: draft.schema, source_object_id: draft.source_object_id, errors: res.errors });
+        continue;
+      }
+      const key = dedupeKey(res.record);
+      if (seen.has(key)) {
+        skipped++;
+        continue;
+      }
+      seen.add(key);
+      accepted.push(res.record);
+    }
+  });
+
+  return { accepted, acceptedCount: accepted.length, skipped, rejected, rejectedCount: rejected.length };
+}
+
+/** Sink for accepted records (the CVS-144 metric-binding layer implements this). */
+export type RecordSink = (records: CanonicalRecord[]) => void | Promise<void>;
+
+/**
+ * Adapt a mapper into the fetch runtime's `onRecords` handler: each page is normalized,
+ * accepted records go to the sink, and the runtime gets payload-free accepted/skipped/
+ * rejected counts for its run report.
+ */
+export function toRecordHandler(mapper: Mapper, ctx: NormalizationContext, sink?: RecordSink): RecordHandler {
+  return async (records: unknown[]): Promise<PageOutcome> => {
+    const report = normalizeRecords(records, mapper, ctx);
+    if (sink && report.accepted.length) await sink(report.accepted);
+    return { accepted: report.acceptedCount, skipped: report.skipped, rejected: report.rejectedCount };
+  };
+}

--- a/src/shared/lib/connectors/normalize/registry.ts
+++ b/src/shared/lib/connectors/normalize/registry.ts
@@ -1,0 +1,25 @@
+// Mapper registry (CVS-143): resolve a source-specific normalizer for a connector
+// stream. Keys are `${connectorId}:${streamName}`, aligned with the CVS-140 manifest
+// stream names; connectors (CVS-146+) resolve their mapper via getMapper.
+import { mapGa4Event, mapGa4PageMetric } from './mappers/ga4';
+import { mapPosthogEvent } from './mappers/posthog';
+import { mapShopifyOrder } from './mappers/shopify';
+import { mapStripePayment } from './mappers/stripe';
+import { mapWooOrder } from './mappers/woocommerce';
+import type { Mapper } from './types';
+
+export const MAPPERS: Record<string, Mapper> = {
+  'stripe:payment_intents': mapStripePayment,
+  'ga4:page_report': mapGa4PageMetric,
+  'ga4:events': mapGa4Event,
+  'woocommerce:orders': mapWooOrder,
+  'shopify:orders': mapShopifyOrder,
+  'posthog:events': mapPosthogEvent,
+};
+
+export const MAPPER_KEYS = Object.keys(MAPPERS);
+
+/** Resolve the mapper for a connector stream, or undefined if none is registered. */
+export function getMapper(connectorId: string, streamName: string): Mapper | undefined {
+  return MAPPERS[`${connectorId}:${streamName}`];
+}

--- a/src/shared/lib/connectors/normalize/types.ts
+++ b/src/shared/lib/connectors/normalize/types.ts
@@ -1,0 +1,50 @@
+// Normalization contracts (CVS-143): source JSON → canonical records.
+//
+// A `Mapper` is a source-specific module that turns one raw source object into 0..N
+// canonical *drafts* (the schema-specific parts). The engine (normalizeStream.ts)
+// stamps the shared envelope from `NormalizationContext`, validates against CVS-139,
+// dedupes, and produces a payload-free report. See docs/data/connector-normalization.md.
+import type { CanonicalRecord } from '../canonical';
+
+/** Envelope context the engine stamps onto every draft (from the connector run). */
+export interface NormalizationContext {
+  source: string; // connector id, e.g. 'stripe'
+  sourceAccountId: string;
+  workspaceId: string;
+  connectorVersion: string; // e.g. 'stripe@1.0.0'
+  observedAt: string; // ISO — when Metrimap fetched
+  cursor?: string; // carried into lineage
+}
+
+/** The schema-specific part a mapper produces; the engine adds the envelope + lineage. */
+export interface CanonicalDraft {
+  schema: string;
+  source_object_id: string;
+  occurred_at: string;
+  currency?: string;
+  amount?: number;
+  amount_unit?: 'minor' | 'major';
+  attributes: Record<string, unknown>;
+  /** Override the default `<schema>@<version>` normalizer tag when useful. */
+  normalizer_version?: string;
+}
+
+/** A source-specific normalizer: one raw object → 0..N canonical drafts. */
+export type Mapper = (raw: unknown, ctx: NormalizationContext) => CanonicalDraft[];
+
+/** A payload-free record of why one input was rejected — ids + validation errors only. */
+export interface RejectedRecord {
+  index: number; // position in the input page
+  schema?: string;
+  source_object_id?: string;
+  errors: { path: string; code: string; message: string }[];
+}
+
+/** The outcome of normalizing a page: the accepted records + payload-free counts/reasons. */
+export interface NormalizationReport {
+  accepted: CanonicalRecord[];
+  acceptedCount: number;
+  skipped: number; // in-batch duplicates (same dedupeKey)
+  rejected: RejectedRecord[];
+  rejectedCount: number;
+}


### PR DESCRIPTION
Builds **CVS-143** — the normalization runtime. Milestone 2 of the connectors lane. Turns raw source objects into validated canonical records (CVS-139), keeping third-party shapes out of the product model. Plugs into the fetch runtime (CVS-142) via its `onRecords` seam.

## What
- **`normalizeRecords(records, mapper, ctx)`** — maps → stamps the shared envelope + lineage → validates every output (CVS-139) → dedupes → returns a **payload-free** `NormalizationReport` (accepted / skipped-duplicates / rejected).
- **`toRecordHandler(mapper, ctx, sink?)`** — adapts it to the runtime's `RecordHandler`, so each page normalizes as it's fetched and reports `{accepted, skipped, rejected}` into the run summary. The `sink` is where CVS-144 (metric binding) plugs in.
- **6 mappers** — `stripe:payment_intents`, `ga4:page_report`, `ga4:events`, `woocommerce:orders`, `shopify:orders`, `posthog:events`. WooCommerce proves **one-to-many** (order → `commerce_order` + `order_line_item[]` + `customer`). Money → minor units; naive timestamps read as UTC.
- **Payload-free rejections** — source ids + validation error codes only; a throwing mapper yields a fixed message (never echoes raw data, verified in a test).
- `getMapper(connector, stream)`; **13 tests** (happy / one-to-many / dedupe / 4 negative paths incl. missing currency, invalid timestamp, missing source id, unsupported status / runtime-handler); doc `docs/data/connector-normalization.md`.

## Acceptance criteria
- [x] Validates output before returning records
- [x] Rejected records counted + explained without leaking raw data
- [x] Source-specific modules emitting shared canonical contracts
- [x] One-to-many supported + tested
- [x] Tests cover happy / warning (dedupe-skip) / rejection paths + negative cases

type-check + lint (0 warnings) + tests green. Pure code — no DB, no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)