### PR TITLE
feat(connectors): normalization runtime — source JSON → canonical records (CVS-143)

### DIFF
--- a/docs/data/connector-normalization.md
+++ b/docs/data/connector-normalization.md
@@ -1,0 +1,54 @@
+# Connector normalization runtime (data layer)
+
+The normalization runtime (`src/shared/lib/connectors/normalize/`, CVS-143) turns **raw
+source JSON** into **validated canonical records** ([CVS-139](./canonical-schemas.md)). It is
+the core of the product bet: third-party object shapes never leak past this boundary — every
+connector emits the same canonical contracts, so metric logic is written once.
+
+It sits between the [fetch runtime](./connector-runtime.md) (CVS-142, which delivers pages of
+raw records) and metric binding (CVS-144, which consumes canonical records). Validation runs
+**before** any record is returned, so nothing downstream sees an invalid record.
+
+## The seam: mapper → draft → record
+
+A **mapper** is a source-specific function that turns one raw object into zero-or-more
+**drafts** — the source-specific half of a canonical record (schema, source id, timestamps,
+money, attributes). The runtime fills the shared envelope (schema_version, source, account,
+workspace, lineage), validates, and dedupes. Mappers never write envelope boilerplate; the
+runtime never sees a source shape.
+
+```ts
+type SourceMapper = (input: unknown, ctx: NormalizeContext) => CanonicalDraft[];
+```
+
+**One-to-many is first-class:** a WooCommerce/Shopify order maps to a `commerce_order`, one
+`order_line_item` per line, and a `customer` reference — all from one source object.
+
+## What the runtime guarantees
+
+`normalizeBatch(mapper, inputs, ctx, options)` → `{ records, report }`:
+
+- **Validated output** — each assembled record passes CVS-139 `validateRecord` before it is
+  returned; failures become counted rejections, never thrown.
+- **Dedupe** — by canonical `dedupeKey` (`source:account:schema:source_object_id`); a `seen`
+  set can be shared across pages so a live run dedupes across pagination.
+- **Money** — mappers convert major-unit sources (Woo/Shopify) to canonical **minor units**
+  via `toMinor`; Stripe (already minor) passes through.
+- **Payload-free reporting** — a `Rejection` carries the schema, source object id (an id we
+  persist for lineage anyway), a stable `code`, and the field `path` — **never a raw source
+  value**. Messages are built from path + code, so a bad enum value can't leak. Verified by
+  test.
+
+## Mappers
+
+Registered per connector in `registry.ts` (`getMapper(connectorId, stream)`): **stripe**
+(payments), **ga4** (page_metrics, events), **woocommerce** (orders → order+lines+customer),
+**shopify** (orders → order+lines), **posthog** (events). Raw input fixtures live in
+`fixtures.ts` (reused by the CVS-154 QA suite).
+
+## Wiring into a live run
+
+`normalizeAsHandler(mapper, ctx, options, sink)` returns a CVS-142 `RecordHandler`, so a fetch
+run normalizes each page as it arrives — accepted canonical records go to `sink`, and the run
+summary's `skipped`/`rejected` counts come from dedupe/validation here. Fetch and normalize
+stay separable: swap the handler, reuse the runtime.

--- a/src/shared/lib/connectors/normalize/fixtures.ts
+++ b/src/shared/lib/connectors/normalize/fixtures.ts
@@ -1,0 +1,69 @@
+// Raw source fixtures for the normalization runtime (CVS-143).
+//
+// These are RAW third-party shapes (what a connector adapter yields), the input side of the
+// mappers — distinct from the canonical fixtures in ../canonical/fixtures.ts (the output).
+// Reused by the tests and by the connector QA suite (CVS-154).
+
+/** Stripe PaymentIntent-like object (amounts already in minor units, epoch-second created). */
+export const stripePaymentRaw = {
+  id: 'pi_abc',
+  created: 1751545800,
+  currency: 'myr',
+  amount: 12900,
+  status: 'succeeded',
+  customer: 'cus_1',
+  payment_method_type: 'card',
+};
+
+/** GA4 page report row (flattened by the connector). */
+export const ga4PageRaw = {
+  date: '2026-07-01',
+  pagePath: '/pricing',
+  metric: 'screenPageViews',
+  value: 1240,
+  dimensions: { country: 'MY' },
+};
+
+/** GA4 event report row. */
+export const ga4EventRaw = {
+  date: '2026-07-01',
+  eventName: 'signed_up',
+  eventCount: 42,
+  dimensions: { country: 'MY' },
+};
+
+/** WooCommerce order with two line items and customer detail (major-unit money strings). */
+export const wooOrderRaw = {
+  id: 1001,
+  date_created_gmt: '2026-07-03T08:59:00',
+  currency: 'MYR',
+  total: '259.90',
+  status: 'completed',
+  customer_id: 5,
+  billing_email: 'buyer@example.com',
+  customer_name: 'Buyer One',
+  line_items: [
+    { id: 11, product_id: 3, sku: 'TSHIRT-M', name: 'T-Shirt', quantity: 2, total: '89.90' },
+    { id: 12, product_id: 4, sku: 'MUG', name: 'Mug', quantity: 1, total: '170.00' },
+  ],
+};
+
+/** Shopify order (adapter-flattened GraphQL node). */
+export const shopifyOrderRaw = {
+  id: 'gid://shopify/Order/77',
+  created_at: '2026-07-03T08:59:00Z',
+  currency: 'MYR',
+  total_amount: '89.90',
+  status: 'paid',
+  customer_id: 'gid://shopify/Customer/9',
+  line_items: [{ id: 'li_9', product_id: 'prod_3', sku: 'TSHIRT-M', title: 'T-Shirt', quantity: 2, unit_amount: '44.95' }],
+};
+
+/** PostHog event. */
+export const posthogEventRaw = {
+  uuid: 'evt_555',
+  event: 'signed_up',
+  timestamp: '2026-07-03T09:59:00Z',
+  distinct_id: 'user_9',
+  properties: { $session_id: 'sess_2', plan: 'pro' },
+};

--- a/src/shared/lib/connectors/normalize/index.ts
+++ b/src/shared/lib/connectors/normalize/index.ts
@@ -1,0 +1,7 @@
+// Normalization runtime (CVS-143): turns raw source objects into validated canonical
+// records (CVS-139) via source-specific mappers, dedupes them, and reports payload-free
+// counts + rejections. Plugs into the fetch runtime (CVS-142) via `normalizeAsHandler`.
+// See docs/data/connector-normalization.md.
+export * from './types';
+export { assembleRecord, normalizeBatch, normalizeAsHandler, type NormalizeOptions } from './normalize';
+export { NORMALIZER_REGISTRY, getMapper, hasMapper } from './registry';

--- a/src/shared/lib/connectors/normalize/mappers/ga4.ts
+++ b/src/shared/lib/connectors/normalize/mappers/ga4.ts
@@ -1,0 +1,56 @@
+// GA4 source mappers (CVS-143).
+//
+// GA4 Data API report rows arrive already flattened into date + dimensions + a metric
+// value. Page rows become `page_metric`; event rows become `analytics_event`. The source
+// object id is synthesized from the row's identifying dimensions so re-fetched rows dedupe.
+import type { CanonicalDraft, SourceMapper } from '../types';
+import { asObject, optNum, optStr, toIso } from './util';
+import { MappingError } from '../types';
+
+/** GA4 page report row → canonical `page_metric`. */
+export const ga4PageMetric: SourceMapper = (input): CanonicalDraft[] => {
+  const obj = asObject(input, 'page_metric');
+  const date = optStr(obj, 'date');
+  const pagePath = optStr(obj, 'pagePath');
+  const metric = optStr(obj, 'metric');
+  if (!date || !pagePath || !metric) {
+    throw new MappingError('missing_source_id', 'GA4 page row needs date, pagePath, and metric', { schema: 'page_metric' });
+  }
+  return [
+    {
+      schema: 'page_metric',
+      source_object_id: `ga4:${date}:${pagePath}:${metric}`,
+      occurred_at: toIso(date, 'date', 'page_metric'),
+      attributes: {
+        page_path: pagePath,
+        metric,
+        value: optNum(obj, 'value'),
+        dimensions: obj.dimensions,
+      },
+    },
+  ];
+};
+
+/** GA4 event report row → canonical `analytics_event`. */
+export const ga4Event: SourceMapper = (input): CanonicalDraft[] => {
+  const obj = asObject(input, 'analytics_event');
+  const date = optStr(obj, 'date');
+  const eventName = optStr(obj, 'eventName');
+  if (!date || !eventName) {
+    throw new MappingError('missing_source_id', 'GA4 event row needs date and eventName', { schema: 'analytics_event' });
+  }
+  return [
+    {
+      schema: 'analytics_event',
+      source_object_id: `ga4:${date}:${eventName}`,
+      occurred_at: toIso(date, 'date', 'analytics_event'),
+      attributes: {
+        event_name: eventName,
+        count: optNum(obj, 'eventCount') ?? 1,
+        properties: obj.dimensions,
+      },
+    },
+  ];
+};
+
+export const GA4_MAPPERS = { page_metrics: ga4PageMetric, events: ga4Event };

--- a/src/shared/lib/connectors/normalize/mappers/posthog.ts
+++ b/src/shared/lib/connectors/normalize/mappers/posthog.ts
@@ -1,0 +1,31 @@
+// PostHog source mappers (CVS-143).
+//
+// PostHog events map directly to `analytics_event`; the event's uuid is the source id and
+// its `properties` bag carries through into canonical attributes.
+import type { CanonicalDraft, SourceMapper } from '../types';
+import { asObject, optNum, optStr, requireId, toIso } from './util';
+
+/** PostHog event → canonical `analytics_event`. */
+export const posthogEvent: SourceMapper = (input): CanonicalDraft[] => {
+  const obj = asObject(input, 'analytics_event');
+  const id = requireId(obj, ['uuid', 'id'], 'analytics_event');
+  return [
+    {
+      schema: 'analytics_event',
+      source_object_id: id,
+      occurred_at: toIso(obj.timestamp, 'timestamp', 'analytics_event'),
+      attributes: {
+        event_name: optStr(obj, 'event'),
+        user_source_id: optStr(obj, 'distinct_id'),
+        session_id:
+          typeof obj.properties === 'object' && obj.properties !== null
+            ? optStr(obj.properties as Record<string, unknown>, '$session_id')
+            : undefined,
+        count: optNum(obj, 'count') ?? 1,
+        properties: obj.properties,
+      },
+    },
+  ];
+};
+
+export const POSTHOG_MAPPERS = { events: posthogEvent };

--- a/src/shared/lib/connectors/normalize/mappers/shopify.ts
+++ b/src/shared/lib/connectors/normalize/mappers/shopify.ts
@@ -1,0 +1,62 @@
+// Shopify source mappers (CVS-143).
+//
+// Assumes the connector adapter (CVS-149) has already flattened the GraphQL Admin order
+// node into plain fields (ids, ISO timestamps, major-unit money strings, a line_items
+// array). A Shopify order is one-to-many: order + line items, mirroring WooCommerce.
+import { toMinor } from '../../canonical';
+import type { CanonicalDraft, SourceMapper } from '../types';
+import { asObject, optNum, optStr, requireId, toIso } from './util';
+
+/** Shopify order → commerce_order + order_line_item[]. */
+export const shopifyOrder: SourceMapper = (input): CanonicalDraft[] => {
+  const obj = asObject(input, 'commerce_order');
+  const orderId = requireId(obj, ['id'], 'commerce_order');
+  const currency = optStr(obj, 'currency');
+  const occurred = toIso(obj.created_at ?? obj.createdAt, 'created_at', 'commerce_order');
+  const total = optNum(obj, 'total_amount') ?? optNum(obj, 'total_price');
+  const lines = Array.isArray(obj.line_items) ? obj.line_items : [];
+
+  const drafts: CanonicalDraft[] = [
+    {
+      schema: 'commerce_order',
+      source_object_id: orderId,
+      occurred_at: occurred,
+      currency,
+      amount: total !== undefined && currency ? toMinor(total, currency) : undefined,
+      amount_unit: 'minor',
+      attributes: {
+        status: obj.status ?? obj.displayFulfillmentStatus,
+        customer_source_id: optStr(obj, 'customer_id'),
+        line_item_count: lines.length,
+      },
+    },
+  ];
+
+  for (const raw of lines) {
+    const line = asObject(raw, 'order_line_item');
+    const lineId = requireId(line, ['id'], 'order_line_item');
+    const qty = optNum(line, 'quantity') ?? 1;
+    const unit = optNum(line, 'unit_amount') ?? optNum(line, 'unit_price');
+    const unitMinor = unit !== undefined && currency ? toMinor(unit, currency) : undefined;
+    drafts.push({
+      schema: 'order_line_item',
+      source_object_id: lineId,
+      occurred_at: occurred,
+      currency,
+      amount: unitMinor !== undefined ? unitMinor * qty : undefined,
+      amount_unit: 'minor',
+      attributes: {
+        order_source_id: orderId,
+        product_source_id: optStr(line, 'product_id'),
+        sku: optStr(line, 'sku'),
+        title: optStr(line, 'title'),
+        quantity: qty,
+        unit_amount: unitMinor,
+      },
+    });
+  }
+
+  return drafts;
+};
+
+export const SHOPIFY_MAPPERS = { orders: shopifyOrder };

--- a/src/shared/lib/connectors/normalize/mappers/stripe.ts
+++ b/src/shared/lib/connectors/normalize/mappers/stripe.ts
@@ -1,0 +1,30 @@
+// Stripe source mappers (CVS-143).
+//
+// Stripe amounts are already in minor units and timestamps are epoch seconds, so mapping
+// is mostly a rename into the canonical `payment` shape. Semantic checks (status enum,
+// integer-minor amount) are enforced by the canonical schema, not here.
+import type { CanonicalDraft, SourceMapper } from '../types';
+import { asObject, optStr, optNum, requireId, toIso } from './util';
+
+/** Stripe PaymentIntent/Charge → canonical `payment`. */
+export const stripePayment: SourceMapper = (input): CanonicalDraft[] => {
+  const obj = asObject(input, 'payment');
+  const id = requireId(obj, ['id'], 'payment');
+  return [
+    {
+      schema: 'payment',
+      source_object_id: id,
+      occurred_at: toIso(obj.created, 'created', 'payment'),
+      currency: typeof obj.currency === 'string' ? obj.currency.toUpperCase() : undefined,
+      amount: optNum(obj, 'amount'),
+      amount_unit: 'minor',
+      attributes: {
+        status: obj.status,
+        customer_source_id: optStr(obj, 'customer'),
+        payment_method: optStr(obj, 'payment_method_type') ?? optStr(obj, 'payment_method'),
+      },
+    },
+  ];
+};
+
+export const STRIPE_MAPPERS = { payments: stripePayment };

--- a/src/shared/lib/connectors/normalize/mappers/util.ts
+++ b/src/shared/lib/connectors/normalize/mappers/util.ts
@@ -1,0 +1,55 @@
+// Shared helpers for source mappers (CVS-143).
+//
+// Small, defensive accessors so each mapper reads raw source JSON safely and fails with a
+// structured MappingError (never a raw value) when a source object is unmappable. Semantic
+// validation (enums, required attributes, money rules) is left to the canonical schemas.
+import { MappingError } from '../types';
+
+/** Narrow an unknown source object to a record, or reject it structurally. */
+export function asObject(input: unknown, schema?: string): Record<string, unknown> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new MappingError('not_an_object', 'Source object is not a JSON object', { schema });
+  }
+  return input as Record<string, unknown>;
+}
+
+/** Optional string (also coerces a number id to string); undefined when absent. */
+export function optStr(obj: Record<string, unknown>, key: string): string | undefined {
+  const v = obj[key];
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' && Number.isFinite(v)) return String(v);
+  return undefined;
+}
+
+/** Optional finite number, parsing numeric strings; undefined when absent/unparseable. */
+export function optNum(obj: Record<string, unknown>, key: string): number | undefined {
+  const v = obj[key];
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string' && v.trim() !== '' && Number.isFinite(Number(v))) return Number(v);
+  return undefined;
+}
+
+/**
+ * Resolve a source object id from the first present key. A missing id is fatal — without
+ * it there is no lineage or dedupe — so it rejects with a dedicated code.
+ */
+export function requireId(obj: Record<string, unknown>, keys: string[], schema?: string): string {
+  for (const k of keys) {
+    const v = optStr(obj, k);
+    if (v) return v;
+  }
+  throw new MappingError('missing_source_id', `Missing source id (${keys.join('/')})`, { path: keys[0], schema });
+}
+
+/** Normalize an epoch (s or ms) or ISO string to an ISO-8601 timestamp, or reject it. */
+export function toIso(value: unknown, path: string, schema?: string): string {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const ms = value < 1e12 ? value * 1000 : value;
+    const d = new Date(ms);
+    if (!Number.isNaN(d.getTime())) return d.toISOString();
+  } else if (typeof value === 'string' && value.trim() !== '') {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d.toISOString();
+  }
+  throw new MappingError('invalid_timestamp', `Missing or invalid timestamp at ${path}`, { path, schema });
+}

--- a/src/shared/lib/connectors/normalize/mappers/woocommerce.ts
+++ b/src/shared/lib/connectors/normalize/mappers/woocommerce.ts
@@ -1,0 +1,75 @@
+// WooCommerce source mappers (CVS-143).
+//
+// A Woo order is one-to-many: it produces a `commerce_order`, one `order_line_item` per
+// line, and a `customer` reference when the order carries customer detail. Woo money is in
+// major units (decimal strings) so it is converted to canonical minor units per currency.
+import { toMinor } from '../../canonical';
+import type { CanonicalDraft, SourceMapper } from '../types';
+import { asObject, optNum, optStr, requireId, toIso } from './util';
+
+/** WooCommerce order → commerce_order + order_line_item[] + optional customer. */
+export const wooOrder: SourceMapper = (input): CanonicalDraft[] => {
+  const obj = asObject(input, 'commerce_order');
+  const orderId = requireId(obj, ['id'], 'commerce_order');
+  const currency = optStr(obj, 'currency');
+  const occurred = toIso(obj.date_created_gmt ?? obj.date_created, 'date_created_gmt', 'commerce_order');
+  const total = optNum(obj, 'total');
+  const customerId = optStr(obj, 'customer_id');
+  const lines = Array.isArray(obj.line_items) ? obj.line_items : [];
+
+  const drafts: CanonicalDraft[] = [
+    {
+      schema: 'commerce_order',
+      source_object_id: orderId,
+      occurred_at: occurred,
+      currency,
+      amount: total !== undefined && currency ? toMinor(total, currency) : undefined,
+      amount_unit: 'minor',
+      attributes: {
+        status: obj.status,
+        customer_source_id: customerId,
+        line_item_count: lines.length,
+      },
+    },
+  ];
+
+  for (const raw of lines) {
+    const line = asObject(raw, 'order_line_item');
+    const lineId = requireId(line, ['id'], 'order_line_item');
+    const qty = optNum(line, 'quantity') ?? 1;
+    const lineTotal = optNum(line, 'total');
+    const lineMinor = lineTotal !== undefined && currency ? toMinor(lineTotal, currency) : undefined;
+    drafts.push({
+      schema: 'order_line_item',
+      source_object_id: lineId,
+      occurred_at: occurred,
+      currency,
+      amount: lineMinor,
+      amount_unit: 'minor',
+      attributes: {
+        order_source_id: orderId,
+        product_source_id: optStr(line, 'product_id'),
+        sku: optStr(line, 'sku'),
+        title: optStr(line, 'name'),
+        quantity: qty,
+        unit_amount: lineMinor !== undefined && qty > 0 ? Math.round(lineMinor / qty) : undefined,
+      },
+    });
+  }
+
+  if (customerId) {
+    drafts.push({
+      schema: 'customer',
+      source_object_id: customerId,
+      occurred_at: occurred,
+      attributes: {
+        email: optStr(obj, 'billing_email'),
+        name: optStr(obj, 'customer_name'),
+      },
+    });
+  }
+
+  return drafts;
+};
+
+export const WOOCOMMERCE_MAPPERS = { orders: wooOrder };

--- a/src/shared/lib/connectors/normalize/normalize.test.ts
+++ b/src/shared/lib/connectors/normalize/normalize.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { validateRecord, type CanonicalRecord } from '../canonical';
+import { runStream, InMemoryCursorStore, cursorKeyFor } from '../runtime';
+import { createMockConnector, createManualClock } from '../runtime/mockConnector';
+import { getConnector } from '../manifests';
+import {
+  NORMALIZER_REGISTRY,
+  getMapper,
+  hasMapper,
+  normalizeBatch,
+  normalizeAsHandler,
+  type NormalizeContext,
+} from './index';
+import {
+  ga4EventRaw,
+  ga4PageRaw,
+  posthogEventRaw,
+  shopifyOrderRaw,
+  stripePaymentRaw,
+  wooOrderRaw,
+} from './fixtures';
+
+function ctx(over: Partial<NormalizeContext> = {}): NormalizeContext {
+  return {
+    source: 'stripe',
+    source_account_id: 'acct_1',
+    workspace_id: 'ws_1',
+    connector_version: 'stripe@1.0.0',
+    normalizer_version: 'payment@1.0.0',
+    observed_at: '2026-07-03T12:31:00Z',
+    ...over,
+  };
+}
+
+describe('mapper registry', () => {
+  const table = [
+    { connector: 'stripe', stream: 'payments', raw: stripePaymentRaw, schemas: ['payment'] },
+    { connector: 'ga4', stream: 'page_metrics', raw: ga4PageRaw, schemas: ['page_metric'] },
+    { connector: 'ga4', stream: 'events', raw: ga4EventRaw, schemas: ['analytics_event'] },
+    { connector: 'woocommerce', stream: 'orders', raw: wooOrderRaw, schemas: ['commerce_order', 'order_line_item', 'order_line_item', 'customer'] },
+    { connector: 'shopify', stream: 'orders', raw: shopifyOrderRaw, schemas: ['commerce_order', 'order_line_item'] },
+    { connector: 'posthog', stream: 'events', raw: posthogEventRaw, schemas: ['analytics_event'] },
+  ];
+
+  for (const { connector, stream, raw, schemas } of table) {
+    it(`${connector}/${stream} maps to valid canonical ${[...new Set(schemas)].join('+')}`, () => {
+      const mapper = getMapper(connector, stream);
+      expect(mapper).toBeDefined();
+      const { records, report } = normalizeBatch(mapper!, [raw], ctx({ source: connector }), { source: connector, stream });
+      expect(report.rejected).toBe(0);
+      expect(records.map((r) => r.schema)).toEqual(schemas);
+      // Every emitted record independently validates against the canonical schema.
+      for (const r of records) expect(validateRecord(r).ok).toBe(true);
+    });
+  }
+
+  it('registers a mapper for every Tier-1 connector in the manifest registry', () => {
+    for (const id of Object.keys(NORMALIZER_REGISTRY)) expect(getConnector(id)).toBeDefined();
+    expect(hasMapper('stripe', 'payments')).toBe(true);
+    expect(hasMapper('stripe', 'nope')).toBe(false);
+  });
+});
+
+describe('one-to-many + money', () => {
+  it('expands a WooCommerce order into order + line items + customer with minor-unit money', () => {
+    const { records, report } = normalizeBatch(getMapper('woocommerce', 'orders')!, [wooOrderRaw], ctx({ source: 'woocommerce' }), {
+      source: 'woocommerce',
+      stream: 'orders',
+    });
+    expect(report.produced).toBe(4);
+    expect(report.accepted).toBe(4);
+    const order = records.find((r) => r.schema === 'commerce_order');
+    expect(order?.amount).toBe(25990); // "259.90" MYR → minor units
+    expect(order?.amount_unit).toBe('minor');
+    const lineItems = records.filter((r) => r.schema === 'order_line_item');
+    expect(lineItems).toHaveLength(2);
+    expect((order?.attributes as { line_item_count: number }).line_item_count).toBe(2);
+  });
+});
+
+describe('dedupe', () => {
+  it('drops a repeated source object as a duplicate', () => {
+    const { records, report } = normalizeBatch(
+      getMapper('stripe', 'payments')!,
+      [stripePaymentRaw, stripePaymentRaw],
+      ctx(),
+      { source: 'stripe', stream: 'payments' }
+    );
+    expect(report.produced).toBe(2);
+    expect(report.accepted).toBe(1);
+    expect(report.duplicates).toBe(1);
+    expect(records).toHaveLength(1);
+  });
+});
+
+describe('rejection paths (payload-free)', () => {
+  const run = (raw: unknown, source = 'stripe', stream = 'payments') =>
+    normalizeBatch(getMapper(source, stream)!, [raw], ctx({ source }), { source, stream });
+
+  it('rejects a missing source id', () => {
+    const { report } = run({ ...stripePaymentRaw, id: undefined });
+    expect(report.accepted).toBe(0);
+    expect(report.rejections[0].code).toBe('missing_source_id');
+  });
+
+  it('rejects an invalid timestamp', () => {
+    const { report } = run({ ...stripePaymentRaw, created: 'not-a-date' });
+    expect(report.rejections[0].code).toBe('invalid_timestamp');
+  });
+
+  it('rejects missing currency on a money-required schema', () => {
+    const { report } = run({ ...wooOrderRaw, currency: undefined }, 'woocommerce', 'orders');
+    expect(report.rejections.some((r) => r.path === 'currency')).toBe(true);
+  });
+
+  it('rejects an unsupported status without leaking the raw value', () => {
+    const { report } = run({ ...stripePaymentRaw, status: 'SENSITIVE_STATUS' });
+    expect(report.accepted).toBe(0);
+    expect(report.rejections.some((r) => r.path?.includes('status'))).toBe(true);
+    expect(JSON.stringify(report)).not.toContain('SENSITIVE_STATUS');
+  });
+});
+
+describe('normalizeAsHandler — wired into the fetch runtime (CVS-142)', () => {
+  it('normalizes each page of a mock run and dedupes across pages', async () => {
+    const manifest = getConnector('stripe')!;
+    const stream = manifest.streams.find((s) => s.name === 'payments')!;
+    const p2 = { ...stripePaymentRaw, id: 'pi_def', created: 1751632200 };
+    const { adapter } = createMockConnector('stripe', {
+      payments: {
+        pages: [
+          { records: [stripePaymentRaw, p2], cursor: 'c1' },
+          { records: [p2], cursor: 'c2' }, // p2 repeats → duplicate across pages
+        ],
+      },
+    });
+
+    const collected: CanonicalRecord[] = [];
+    const handler = normalizeAsHandler(
+      getMapper('stripe', 'payments')!,
+      ctx(),
+      { source: 'stripe', stream: 'payments' },
+      (recs) => collected.push(...recs)
+    );
+
+    const report = await runStream(adapter, manifest, stream, {
+      credentials: {},
+      syncMode: 'incremental',
+      cursorStore: new InMemoryCursorStore(),
+      cursorKey: cursorKeyFor('acct_1', 'stripe', 'payments'),
+      clock: createManualClock(),
+      onRecords: handler,
+    });
+
+    expect(report.fetched).toBe(3); // 2 + 1 records seen
+    expect(report.skipped).toBe(1); // the cross-page duplicate
+    expect(report.error_class).toBeUndefined();
+    expect(collected.map((r) => r.source_object_id).sort()).toEqual(['pi_abc', 'pi_def']);
+  });
+});

--- a/src/shared/lib/connectors/normalize/normalize.ts
+++ b/src/shared/lib/connectors/normalize/normalize.ts
@@ -1,0 +1,151 @@
+// Normalization runtime (CVS-143).
+//
+// Turns raw source objects into validated canonical records: run a source-specific mapper,
+// fill the shared envelope, validate against the CVS-139 schemas, dedupe by source id, and
+// report counts + payload-free rejections. Validation happens BEFORE any record is returned,
+// so nothing downstream (metric binding, CVS-144) ever sees an invalid record.
+import {
+  CANONICAL_SCHEMA_VERSION,
+  dedupeKey,
+  validateRecord,
+  type CanonicalRecord,
+} from '../canonical';
+import type { PageOutcome, RecordHandler } from '../runtime';
+import {
+  MappingError,
+  type CanonicalDraft,
+  type NormalizeContext,
+  type NormalizeReport,
+  type NormalizeResult,
+  type Rejection,
+  type SourceMapper,
+} from './types';
+
+/** Fill the shared envelope around a mapper's draft (CVS-139 envelope contract). */
+export function assembleRecord(draft: CanonicalDraft, ctx: NormalizeContext, nowIso: string): unknown {
+  return {
+    schema: draft.schema,
+    schema_version: CANONICAL_SCHEMA_VERSION,
+    source: ctx.source,
+    source_account_id: ctx.source_account_id,
+    source_object_id: draft.source_object_id,
+    workspace_id: ctx.workspace_id,
+    observed_at: draft.observed_at ?? ctx.observed_at ?? nowIso,
+    occurred_at: draft.occurred_at,
+    ...(draft.currency !== undefined ? { currency: draft.currency } : {}),
+    ...(draft.amount !== undefined ? { amount: draft.amount } : {}),
+    ...(draft.amount_unit !== undefined ? { amount_unit: draft.amount_unit } : {}),
+    attributes: draft.attributes,
+    lineage: {
+      connector_version: ctx.connector_version,
+      normalizer_version: ctx.normalizer_version,
+      ...(ctx.cursor !== undefined ? { cursor: ctx.cursor } : {}),
+    },
+  };
+}
+
+function rejectionFromMappingError(err: MappingError): Rejection {
+  return {
+    schema: err.schema,
+    source_object_id: err.sourceObjectId,
+    code: err.code,
+    path: err.path,
+    message: err.path ? `${err.path}: ${err.code}` : err.code,
+  };
+}
+
+export interface NormalizeOptions {
+  source: string;
+  stream: string;
+  /** Injected clock for deterministic timestamps in tests; defaults to Date.now. */
+  now?: () => number;
+  /** Dedupe keys already seen in a prior page/run, so cross-page dedupe holds. */
+  seen?: Set<string>;
+}
+
+/**
+ * Normalize a batch of raw source objects for one stream. Returns the accepted canonical
+ * records and a payload-free report. Never throws for bad input — a mapper failure or a
+ * validation failure becomes a counted rejection.
+ */
+export function normalizeBatch(
+  mapper: SourceMapper,
+  inputs: readonly unknown[],
+  ctx: NormalizeContext,
+  options: NormalizeOptions
+): NormalizeResult {
+  const nowIso = new Date(options.now?.() ?? Date.now()).toISOString();
+  const seen = options.seen ?? new Set<string>();
+  const records: CanonicalRecord[] = [];
+  const rejections: Rejection[] = [];
+  let produced = 0;
+  let duplicates = 0;
+
+  for (const input of inputs) {
+    let drafts: CanonicalDraft[];
+    try {
+      drafts = mapper(input, ctx);
+    } catch (err) {
+      if (err instanceof MappingError) {
+        rejections.push(rejectionFromMappingError(err));
+        continue;
+      }
+      rejections.push({ code: 'mapper_error', message: 'mapper_error' });
+      continue;
+    }
+
+    for (const draft of drafts) {
+      produced += 1;
+      const candidate = assembleRecord(draft, ctx, nowIso);
+      const result = validateRecord(candidate);
+      if (!result.ok) {
+        rejections.push({
+          schema: draft.schema,
+          source_object_id: draft.source_object_id,
+          code: result.errors[0]?.code ?? 'invalid',
+          path: result.errors[0]?.path,
+          message: `${draft.schema}: ${result.errors.map((e) => `${e.path}:${e.code}`).join(', ')}`,
+        });
+        continue;
+      }
+      const key = dedupeKey(result.record);
+      if (seen.has(key)) {
+        duplicates += 1;
+        continue;
+      }
+      seen.add(key);
+      records.push(result.record);
+    }
+  }
+
+  const report: NormalizeReport = {
+    source: options.source,
+    stream: options.stream,
+    processed: inputs.length,
+    produced,
+    accepted: records.length,
+    rejected: rejections.length,
+    duplicates,
+    rejections,
+  };
+  return { records, report };
+}
+
+/**
+ * Adapt a mapper into a CVS-142 `RecordHandler` so a live fetch run normalizes each page
+ * as it arrives. Accepted records are pushed to `sink`; the run summary's skipped/rejected
+ * counts come from dedupe/validation here. A shared `seen` set dedupes across pages.
+ */
+export function normalizeAsHandler(
+  mapper: SourceMapper,
+  ctx: NormalizeContext,
+  options: NormalizeOptions,
+  sink: (records: CanonicalRecord[]) => void
+): RecordHandler {
+  const seen = options.seen ?? new Set<string>();
+  return (pageRecords: unknown[]): PageOutcome => {
+    const { records, report } = normalizeBatch(mapper, pageRecords, ctx, { ...options, seen });
+    if (records.length) sink(records);
+    return { accepted: report.accepted, skipped: report.duplicates, rejected: report.rejected };
+  };
+}

--- a/src/shared/lib/connectors/normalize/registry.ts
+++ b/src/shared/lib/connectors/normalize/registry.ts
@@ -1,0 +1,30 @@
+// Normalizer registry (CVS-143).
+//
+// Maps (connectorId, streamName) → the source-specific mapper, so the runtime can resolve
+// the right normalizer for a connector run without hard-coding per-source branches. Each
+// mapper module lives under ./mappers and emits the shared canonical contracts.
+import type { ConnectorMappers, SourceMapper } from './types';
+import { STRIPE_MAPPERS } from './mappers/stripe';
+import { GA4_MAPPERS } from './mappers/ga4';
+import { WOOCOMMERCE_MAPPERS } from './mappers/woocommerce';
+import { SHOPIFY_MAPPERS } from './mappers/shopify';
+import { POSTHOG_MAPPERS } from './mappers/posthog';
+
+/** connectorId → { streamName → mapper }. Mirrors the manifest ids from CVS-140. */
+export const NORMALIZER_REGISTRY: Record<string, ConnectorMappers> = {
+  stripe: STRIPE_MAPPERS,
+  ga4: GA4_MAPPERS,
+  woocommerce: WOOCOMMERCE_MAPPERS,
+  shopify: SHOPIFY_MAPPERS,
+  posthog: POSTHOG_MAPPERS,
+};
+
+/** Resolve the mapper for a connector stream, or undefined if none is registered. */
+export function getMapper(connectorId: string, stream: string): SourceMapper | undefined {
+  return NORMALIZER_REGISTRY[connectorId]?.[stream];
+}
+
+/** Whether a connector stream has a normalizer. */
+export function hasMapper(connectorId: string, stream: string): boolean {
+  return Boolean(getMapper(connectorId, stream));
+}

--- a/src/shared/lib/connectors/normalize/types.ts
+++ b/src/shared/lib/connectors/normalize/types.ts
@@ -1,0 +1,96 @@
+// Normalization contracts (CVS-143).
+//
+// A source-specific mapper turns ONE raw source object into zero-or-more canonical
+// *drafts* (the source-specific bits); the runtime fills the shared envelope, validates
+// against the CVS-139 schemas, dedupes, and produces a payload-free report. Mappers never
+// see the envelope boilerplate and the runtime never sees source shapes — the seam is the
+// draft. See docs/data/connector-normalization.md.
+import type { AmountUnit, CanonicalRecord } from '../canonical';
+
+/** Run-level context the runtime injects into every canonical record's envelope. */
+export interface NormalizeContext {
+  /** Connector id, e.g. "stripe" — becomes the record `source`. */
+  source: string;
+  source_account_id: string;
+  workspace_id: string;
+  /** Lineage: the connector + normalizer versions that produced the record. */
+  connector_version: string;
+  normalizer_version: string;
+  /** Lineage cursor for the page this object came from. */
+  cursor?: string;
+  /** When the run observed the data; defaults to now at assembly time. */
+  observed_at?: string;
+}
+
+/**
+ * The source-specific half of a canonical record. The mapper supplies the schema, the
+ * source object id, timestamps, money, and typed attributes; the runtime supplies the
+ * rest of the envelope (schema_version, source, account, workspace, lineage).
+ */
+export interface CanonicalDraft {
+  schema: string;
+  source_object_id: string;
+  occurred_at: string;
+  observed_at?: string;
+  currency?: string;
+  amount?: number;
+  amount_unit?: AmountUnit;
+  attributes: Record<string, unknown>;
+}
+
+/** Maps one raw source object to zero-or-more drafts (one-to-many is supported). */
+export type SourceMapper = (input: unknown, ctx: NormalizeContext) => CanonicalDraft[];
+
+/** A registered mapper module for one connector, keyed by stream name. */
+export type ConnectorMappers = Record<string, SourceMapper>;
+
+/**
+ * A payload-free explanation of why a record was dropped. Carries the schema, the source
+ * object id (an id we persist for lineage anyway), a stable code, and the field path —
+ * never a raw source value.
+ */
+export interface Rejection {
+  schema?: string;
+  source_object_id?: string;
+  code: string;
+  path?: string;
+  message: string;
+}
+
+/** Payload-free summary of a normalization pass. Counts + rejections, never raw data. */
+export interface NormalizeReport {
+  source: string;
+  stream: string;
+  /** Raw source objects processed. */
+  processed: number;
+  /** Canonical drafts produced by the mapper(s). */
+  produced: number;
+  accepted: number;
+  rejected: number;
+  /** Drafts dropped as duplicates of an already-accepted dedupe key. */
+  duplicates: number;
+  rejections: Rejection[];
+}
+
+/** The output of normalizing a batch: the accepted canonical records + a report. */
+export interface NormalizeResult {
+  records: CanonicalRecord[];
+  report: NormalizeReport;
+}
+
+/** Thrown by a mapper when a source object cannot be mapped at all (e.g. no id). */
+export class MappingError extends Error {
+  readonly code: string;
+  readonly path?: string;
+  readonly schema?: string;
+  readonly sourceObjectId?: string;
+
+  constructor(code: string, message: string, opts: { path?: string; schema?: string; sourceObjectId?: string } = {}) {
+    super(message);
+    this.name = 'MappingError';
+    this.code = code;
+    this.path = opts.path;
+    this.schema = opts.schema;
+    this.sourceObjectId = opts.sourceObjectId;
+  }
+}


### PR DESCRIPTION
Closes CVS-143. *Canonical schemas & native connectors* → milestone 2 (Connector runtime).

## What this adds
`src/shared/lib/connectors/normalize/` — turns raw source JSON into validated canonical records (CVS-139). This is the product's core boundary: third-party shapes never leak past it.

- **`types.ts`** — the `SourceMapper` / `CanonicalDraft` seam + `MappingError` + payload-free `Rejection`/`NormalizeReport`.
- **`normalize.ts`** — `normalizeBatch` (assemble envelope → validate → dedupe → report) and `normalizeAsHandler` (wires into CVS-142's `onRecords`).
- **`registry.ts`** — `getMapper(connectorId, stream)`.
- **`mappers/`** — Stripe (payments), GA4 (page_metrics + events), WooCommerce (orders → order+lines+customer), Shopify (orders → order+lines), PostHog (events), with a defensive accessor util and major→minor money conversion.
- **`fixtures.ts`** — raw source inputs (reused by CVS-154). **`docs/data/connector-normalization.md`**.

## Acceptance criteria
- [x] Validates output before returning records
- [x] Rejections counted + explained by path/code, **no raw source data** (asserted: a bad enum value never appears in the report)
- [x] Source-specific mappers, shared canonical contracts
- [x] One-to-many supported + tested (Woo order → 4 records)
- [x] Happy / warning / rejection paths covered (missing id, invalid timestamp, missing currency, unsupported status)

## Notes
- Builds on `main` (CVS-139 + CVS-142 both merged). Fetch and normalize stay separable — `normalizeAsHandler` plugs a mapper into a live fetch run and dedupes across pages.
- Does **not** bind records to metrics or persist values — that's CVS-144.

## Verification
14 tests (per-mapper happy paths, one-to-many, dedupe, 4 rejection paths, payload-free, + CVS-142 integration) + full suite, type-check, lint pass via Husky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)