### PR TITLE
feat(connectors): metric binding — canonical records → metric values (CVS-144)

### DIFF
--- a/docs/data/connector-binding.md
+++ b/docs/data/connector-binding.md
@@ -1,0 +1,59 @@
+# Connector metric binding
+
+The binding layer (`src/shared/lib/connectors/binding/`, CVS-144) turns validated
+canonical records (CVS-139/143) into **tracked-metric values** — the bridge from a
+connector stream to Metrimap's existing product model (`metric_values`, catalog, dashboards,
+alerts). It's what the CVS-143 sink feeds.
+
+## Concepts
+
+- **`MetricBinding`** — "aggregate *this connector stream* into *this tracked metric* with
+  *this recipe*": `{ connectorId, stream, canonicalSchema, recipe, targetTrackedMetricId,
+  connectedAccountId? }`.
+- **`MetricRecipe`** — `{ aggregation: 'sum'|'count'|'average', grain: 'day'|'week'|'month',
+  field?, filter? }`. `field` is `amount` (envelope) or `attributes.<key>`; `filter` scopes
+  which records count (e.g. only `succeeded` payments = revenue).
+- **`materialize(records, recipe)`** — pure, deterministic aggregation into sorted
+  `ValuePoint[]` (one value per period). Re-running the same records yields the same points.
+
+## Materialization
+
+`materializeBinding(records, binding, account?)` runs over a whole sync's accepted records
+(aggregates span pages — use `collectRecords()` as the CVS-143 sink, then materialize at the
+end) and returns:
+
+- `status: 'materialized'` + `rows` (ready to upsert), or
+- `status: 'stale' | 'orphaned'` with **no rows** when the backing connection is broken —
+  freshness is derived from `connected_accounts.status` (`error` → stale, `revoked` →
+  orphaned), so a broken source never writes silent zeroes.
+
+Rows carry a compact **source-lineage token** in `metric_values.source`
+(`connector=…;stream=…;recipe=…;schema=payment@1.0.0;account=…`).
+
+## Persistence
+
+`upsertMetricValues(client, rows)` upserts into `metric_values` **idempotent by
+`(tracked_metric_id, period)`** — the same key the MCP push path uses — so re-syncing a
+window replaces rather than double-counts. It runs under the caller's RLS (the user owns
+the target tracked metric); the connector sync (CVS-146+) supplies the client.
+
+## Preview
+
+`previewBinding(sampleRecords, recipe)` computes the would-be points **without persisting** —
+the "sample → map recipe → confirm" preview for source-backed metric creation.
+
+## End-to-end shape (wired at CVS-146+)
+
+```ts
+const { records, sink } = collectRecords();
+await runStream(adapter, stream, { /* … */, onRecords: toRecordHandler(mapper, ctx, sink) });
+const result = materializeBinding(records, binding, account);
+if (result.status === 'materialized') await upsertMetricValues(client, result.rows);
+// else: surface stale/orphaned freshness in the UI instead of writing zeroes
+```
+
+## Not here
+
+Full end-user mapping UI is out of scope (backend contracts + preview only). Ratio/active
+recipes and multi-dimension keys are extension points on `MetricRecipe`; money values
+aggregate in **minor units** (currency display is downstream).

--- a/src/shared/lib/connectors/binding/binding.test.ts
+++ b/src/shared/lib/connectors/binding/binding.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import type { CanonicalRecord } from '../canonical';
+import {
+  collectRecords,
+  freshnessOf,
+  materialize,
+  materializeBinding,
+  periodOf,
+  previewBinding,
+  upsertMetricValues,
+  type MetricBinding,
+} from './index';
+
+const payment = (occurred_at: string, amount: number, status = 'succeeded'): CanonicalRecord =>
+  ({
+    schema: 'payment', schema_version: '1.0.0', source: 'stripe', source_account_id: 'acct',
+    source_object_id: `pi_${occurred_at}_${amount}`, workspace_id: 'ws', observed_at: occurred_at,
+    occurred_at, currency: 'MYR', amount, amount_unit: 'minor', attributes: { status },
+    lineage: { connector_version: 'stripe@1.0.0', normalizer_version: 'payment@1.0.0' },
+  }) as unknown as CanonicalRecord;
+
+const pageMetric = (occurred_at: string, value: number): CanonicalRecord =>
+  ({
+    schema: 'page_metric', schema_version: '1.0.0', source: 'ga4', source_account_id: 'p',
+    source_object_id: `${occurred_at}:${value}`, workspace_id: 'ws', observed_at: occurred_at,
+    occurred_at, attributes: { page_path: '/x', metric: 'sessions', value },
+    lineage: { connector_version: 'ga4@1.0.0', normalizer_version: 'page_metric@1.0.0' },
+  }) as unknown as CanonicalRecord;
+
+describe('materialize (recipe engine)', () => {
+  const recs = [payment('2026-07-01T10:00:00Z', 1000), payment('2026-07-01T18:00:00Z', 500), payment('2026-07-02T09:00:00Z', 250)];
+
+  it('sums by day', () => {
+    expect(materialize(recs, { aggregation: 'sum', grain: 'day', field: 'amount' })).toEqual([
+      { period: '2026-07-01', value: 1500 },
+      { period: '2026-07-02', value: 250 },
+    ]);
+  });
+
+  it('sums by month', () => {
+    expect(materialize(recs, { aggregation: 'sum', grain: 'month', field: 'amount' })).toEqual([{ period: '2026-07', value: 1750 }]);
+  });
+
+  it('counts and averages', () => {
+    expect(materialize(recs, { aggregation: 'count', grain: 'month' })[0]).toEqual({ period: '2026-07', value: 3 });
+    expect(materialize(recs, { aggregation: 'average', grain: 'month', field: 'amount' })[0].value).toBeCloseTo(583.33, 1);
+  });
+
+  it('applies a filter (only succeeded counts as revenue)', () => {
+    const mixed = [payment('2026-07-01T10:00:00Z', 1000), payment('2026-07-01T11:00:00Z', 999, 'failed')];
+    const pts = materialize(mixed, { aggregation: 'sum', grain: 'day', field: 'amount', filter: { path: 'attributes.status', equals: 'succeeded' } });
+    expect(pts).toEqual([{ period: '2026-07-01', value: 1000 }]);
+  });
+});
+
+describe('periodOf', () => {
+  it('buckets day / month / week', () => {
+    expect(periodOf('2026-07-03T08:59:00Z', 'day')).toBe('2026-07-03');
+    expect(periodOf('2026-07-03T08:59:00Z', 'month')).toBe('2026-07');
+    expect(periodOf('2026-07-03T08:59:00Z', 'week')).toBe('2026-W27');
+  });
+});
+
+describe('materializeBinding', () => {
+  const revenueBinding: MetricBinding = {
+    connectorId: 'stripe', stream: 'payment_intents', canonicalSchema: 'payment',
+    recipe: { aggregation: 'sum', grain: 'day', field: 'amount', filter: { path: 'attributes.status', equals: 'succeeded' } },
+    targetTrackedMetricId: 'tm_rev', connectedAccountId: 'ca_1',
+  };
+  const sessionsBinding: MetricBinding = {
+    connectorId: 'ga4', stream: 'page_report', canonicalSchema: 'page_metric',
+    recipe: { aggregation: 'sum', grain: 'day', field: 'attributes.value' },
+    targetTrackedMetricId: 'tm_sessions',
+  };
+
+  it('money-style: Stripe revenue → rows with lineage', () => {
+    const res = materializeBinding([payment('2026-07-01T10:00:00Z', 1200), payment('2026-07-01T12:00:00Z', 800)], revenueBinding);
+    expect(res.status).toBe('materialized');
+    expect(res.rows).toEqual([{ tracked_metric_id: 'tm_rev', period: '2026-07-01', value: 2000, source: expect.stringContaining('connector=stripe') }]);
+    expect(res.rows[0].source).toContain('schema=payment@1.0.0');
+  });
+
+  it('analytics-style: GA4 sessions materialize', () => {
+    const res = materializeBinding([pageMetric('2026-07-01T00:00:00Z', 120), pageMetric('2026-07-02T00:00:00Z', 90)], sessionsBinding);
+    expect(res.rows.map((r) => r.value)).toEqual([120, 90]);
+    expect(res.rows[0].tracked_metric_id).toBe('tm_sessions');
+  });
+
+  it('is idempotent — same records produce identical rows', () => {
+    const recs = [payment('2026-07-01T10:00:00Z', 1200), payment('2026-07-02T10:00:00Z', 300)];
+    expect(materializeBinding(recs, revenueBinding).rows).toEqual(materializeBinding(recs, revenueBinding).rows);
+  });
+
+  it('stale when the connection errored — no zeroes written', () => {
+    const res = materializeBinding([payment('2026-07-01T10:00:00Z', 1200)], revenueBinding, { status: 'error' });
+    expect(res.status).toBe('stale');
+    expect(res.rows).toEqual([]);
+  });
+
+  it('orphaned when the connection was revoked', () => {
+    const res = materializeBinding([payment('2026-07-01T10:00:00Z', 1200)], revenueBinding, { status: 'revoked' });
+    expect(res.status).toBe('orphaned');
+    expect(res.rows).toEqual([]);
+  });
+
+  it('materializes normally for a connected account', () => {
+    expect(materializeBinding([payment('2026-07-01T10:00:00Z', 1200)], revenueBinding, { status: 'connected' }).status).toBe('materialized');
+  });
+});
+
+describe('freshnessOf', () => {
+  it('maps connection status to freshness', () => {
+    expect(freshnessOf('connected')).toBe('fresh');
+    expect(freshnessOf('pending')).toBe('fresh');
+    expect(freshnessOf('error')).toBe('stale');
+    expect(freshnessOf('revoked')).toBe('orphaned');
+  });
+});
+
+describe('previewBinding', () => {
+  it('computes points without persisting', () => {
+    const pts = previewBinding([payment('2026-07-01T10:00:00Z', 1000), payment('2026-07-01T11:00:00Z', 500)], { aggregation: 'sum', grain: 'day', field: 'amount' });
+    expect(pts).toEqual([{ period: '2026-07-01', value: 1500 }]);
+  });
+});
+
+describe('collectRecords', () => {
+  it('accumulates accepted records across pages', () => {
+    const { records, sink } = collectRecords();
+    sink([payment('2026-07-01T10:00:00Z', 100)]);
+    sink([payment('2026-07-02T10:00:00Z', 200)]);
+    expect(records).toHaveLength(2);
+  });
+});
+
+describe('upsertMetricValues', () => {
+  it('upserts idempotently by (tracked_metric_id, period)', async () => {
+    const upsert = vi.fn().mockResolvedValue({ error: null });
+    const client = { from: vi.fn(() => ({ upsert })) } as unknown as SupabaseClient<Database>;
+    const rows = [{ tracked_metric_id: 'tm', period: '2026-07-01', value: 5, source: 's' }];
+    const n = await upsertMetricValues(client, rows);
+    expect(n).toBe(1);
+    expect(client.from).toHaveBeenCalledWith('metric_values');
+    expect(upsert).toHaveBeenCalledWith(rows, { onConflict: 'tracked_metric_id,period' });
+  });
+
+  it('no-ops on empty rows', async () => {
+    const from = vi.fn();
+    const client = { from } as unknown as SupabaseClient<Database>;
+    expect(await upsertMetricValues(client, [])).toBe(0);
+    expect(from).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/lib/connectors/binding/index.ts
+++ b/src/shared/lib/connectors/binding/index.ts
@@ -1,0 +1,13 @@
+// Metric binding (CVS-144): canonical records → tracked-metric values. Aggregation
+// recipes, idempotent materialization with source lineage, connection-derived freshness,
+// preview, and the metric_values upsert sink. See docs/data/connector-binding.md.
+export * from './types';
+export { materialize, periodOf } from './recipe';
+export {
+  materializeBinding,
+  previewBinding,
+  collectRecords,
+  freshnessOf,
+  lineageToken,
+} from './materializeBinding';
+export { upsertMetricValues } from './sink';

--- a/src/shared/lib/connectors/binding/materializeBinding.ts
+++ b/src/shared/lib/connectors/binding/materializeBinding.ts
@@ -1,0 +1,67 @@
+// Binding materialization (CVS-144): records + binding → idempotent metric-value rows,
+// with source lineage and connection-derived freshness. A broken/revoked connection
+// yields a stale/orphaned result — never a silent zero.
+import { CANONICAL_SCHEMA_VERSION, type CanonicalRecord } from '../canonical';
+import type { RecordSink } from '../normalize';
+import { materialize } from './recipe';
+import type { BindingFreshness, MaterializationResult, MetricBinding, MetricRecipe, ValuePoint } from './types';
+
+/** Map a connection status to metric freshness. */
+export function freshnessOf(status: string | undefined): BindingFreshness {
+  if (status === 'revoked') return 'orphaned';
+  if (status === 'error') return 'stale';
+  return 'fresh'; // connected / pending / unknown → treat as fresh
+}
+
+/** Compact, human-scannable source-lineage token stored on each metric value. */
+export function lineageToken(binding: MetricBinding): string {
+  const parts = [
+    `connector=${binding.connectorId}`,
+    `stream=${binding.stream}`,
+    `recipe=${binding.recipe.aggregation}`,
+    `schema=${binding.canonicalSchema}@${CANONICAL_SCHEMA_VERSION}`,
+  ];
+  if (binding.connectedAccountId) parts.push(`account=${binding.connectedAccountId}`);
+  return parts.join(';');
+}
+
+/**
+ * Materialize a binding over the full accepted record set of a run. Idempotent: the
+ * same records always produce the same rows, so upserting by (tracked_metric_id, period)
+ * replaces rather than double-counts. If the backing connection is broken, returns a
+ * `stale`/`orphaned` result with no rows (so a downstream sync never writes zeroes).
+ */
+export function materializeBinding(
+  records: CanonicalRecord[],
+  binding: MetricBinding,
+  account?: { status: string }
+): MaterializationResult {
+  if (account) {
+    const freshness = freshnessOf(account.status);
+    if (freshness !== 'fresh') return { status: freshness, points: [], rows: [] };
+  }
+  const points = materialize(records, binding.recipe);
+  const source = lineageToken(binding);
+  const rows = points.map((p) => ({
+    tracked_metric_id: binding.targetTrackedMetricId,
+    period: p.period,
+    value: p.value,
+    source,
+  }));
+  return { status: 'materialized', points, rows };
+}
+
+/** Compute the value points for a sample without persisting — the source-backed-metric preview. */
+export function previewBinding(records: CanonicalRecord[], recipe: MetricRecipe): ValuePoint[] {
+  return materialize(records, recipe);
+}
+
+/**
+ * A record sink that accumulates a run's accepted records so a binding can materialize
+ * over the whole set at the end (aggregates span pages). Pair with the CVS-143
+ * `toRecordHandler`, then call `materializeBinding(collected.records, binding)`.
+ */
+export function collectRecords(): { records: CanonicalRecord[]; sink: RecordSink } {
+  const records: CanonicalRecord[] = [];
+  return { records, sink: (recs) => { records.push(...recs); } };
+}

--- a/src/shared/lib/connectors/binding/recipe.ts
+++ b/src/shared/lib/connectors/binding/recipe.ts
@@ -1,0 +1,69 @@
+// Aggregation engine (CVS-144): canonical records → value points. Pure + deterministic,
+// so re-running the same records yields the same points (idempotent materialization).
+import type { CanonicalRecord } from '../canonical';
+import type { MetricRecipe, PeriodGrain, RecordFilter, ValuePoint } from './types';
+
+/** ISO week label `YYYY-Www` (UTC), matching the day/month `slice` labels. */
+function isoWeek(d: Date): string {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dayNum = (date.getUTCDay() + 6) % 7; // Mon=0
+  date.setUTCDate(date.getUTCDate() - dayNum + 3); // nearest Thursday
+  const firstThursday = new Date(Date.UTC(date.getUTCFullYear(), 0, 4));
+  const week =
+    1 +
+    Math.round(
+      ((date.getTime() - firstThursday.getTime()) / 86_400_000 - 3 + ((firstThursday.getUTCDay() + 6) % 7)) / 7
+    );
+  return `${date.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+/** Bucket an ISO timestamp into a period label for the grain. */
+export function periodOf(occurredAt: string, grain: PeriodGrain): string {
+  if (grain === 'day') return occurredAt.slice(0, 10);
+  if (grain === 'month') return occurredAt.slice(0, 7);
+  return isoWeek(new Date(occurredAt));
+}
+
+/** Resolve `amount`/`status` (envelope) or `attributes.<key>` on a record. */
+function resolvePath(record: CanonicalRecord, path: string): unknown {
+  if (path.startsWith('attributes.')) {
+    return (record.attributes as Record<string, unknown> | undefined)?.[path.slice('attributes.'.length)];
+  }
+  return (record as unknown as Record<string, unknown>)[path];
+}
+
+function matchesFilter(record: CanonicalRecord, filter: RecordFilter): boolean {
+  return resolvePath(record, filter.path) === filter.equals;
+}
+
+/** Aggregate records into one sorted value point per period. */
+export function materialize(records: CanonicalRecord[], recipe: MetricRecipe): ValuePoint[] {
+  const buckets = new Map<string, { sum: number; count: number }>();
+
+  for (const r of records) {
+    if (recipe.filter && !matchesFilter(r, recipe.filter)) continue;
+    if (!r.occurred_at) continue;
+    const period = periodOf(r.occurred_at, recipe.grain);
+    const b = buckets.get(period) ?? { sum: 0, count: 0 };
+    if (recipe.aggregation !== 'count') {
+      const n = resolvePath(r, recipe.field ?? 'amount');
+      if (typeof n === 'number' && Number.isFinite(n)) b.sum += n;
+    }
+    b.count += 1;
+    buckets.set(period, b);
+  }
+
+  return [...buckets.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([period, b]) => ({
+      period,
+      value:
+        recipe.aggregation === 'count'
+          ? b.count
+          : recipe.aggregation === 'average'
+            ? b.count
+              ? b.sum / b.count
+              : 0
+            : b.sum,
+    }));
+}

--- a/src/shared/lib/connectors/binding/sink.ts
+++ b/src/shared/lib/connectors/binding/sink.ts
@@ -1,0 +1,20 @@
+// Metric-value persistence (CVS-144). Upserts materialized rows into `metric_values`,
+// idempotent by (tracked_metric_id, period) — the same key the MCP push path uses. Runs
+// under the caller's RLS (the user owns the target tracked metric); the connector sync
+// (CVS-146+) supplies the client.
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import type { MetricValueRow } from './types';
+
+/** Upsert materialized metric-value rows. Returns the number of rows written. */
+export async function upsertMetricValues(
+  client: SupabaseClient<Database>,
+  rows: MetricValueRow[]
+): Promise<number> {
+  if (rows.length === 0) return 0;
+  const { error } = await client
+    .from('metric_values')
+    .upsert(rows, { onConflict: 'tracked_metric_id,period' });
+  if (error) throw new Error(error.message);
+  return rows.length;
+}

--- a/src/shared/lib/connectors/binding/types.ts
+++ b/src/shared/lib/connectors/binding/types.ts
@@ -1,0 +1,62 @@
+// Metric-binding contracts (CVS-144): turn canonical records (CVS-139/143) into
+// tracked-metric values. A binding says "aggregate this connector stream's records
+// into this metric with this recipe"; materialization produces idempotent value
+// points with source lineage. See docs/data/connector-binding.md.
+
+/** Time bucket for a metric series. */
+export type PeriodGrain = 'day' | 'week' | 'month';
+
+/** How records collapse into one value per period. */
+export type Aggregation = 'sum' | 'count' | 'average';
+
+/** Match a record field to a value (e.g. only `succeeded` payments count as revenue). */
+export interface RecordFilter {
+  /** `amount` / `status` (envelope) or `attributes.<key>`. */
+  path: string;
+  equals: string | number | boolean;
+}
+
+/** Aggregation recipe: what to compute, over which grain, on which field, filtered how. */
+export interface MetricRecipe {
+  aggregation: Aggregation;
+  grain: PeriodGrain;
+  /** Numeric to aggregate for sum/average: `amount` or `attributes.<key>` (ignored for count). */
+  field?: string;
+  filter?: RecordFilter;
+}
+
+/** A binding from a connector stream to a target tracked metric. */
+export interface MetricBinding {
+  connectorId: string;
+  stream: string;
+  canonicalSchema: string;
+  recipe: MetricRecipe;
+  targetTrackedMetricId: string;
+  /** The connected account backing this binding (drives freshness/stale). */
+  connectedAccountId?: string;
+}
+
+/** One aggregated point of a metric series. */
+export interface ValuePoint {
+  period: string;
+  value: number;
+}
+
+/** A row ready to upsert into `metric_values` (idempotent by tracked_metric_id+period). */
+export interface MetricValueRow {
+  tracked_metric_id: string;
+  period: string;
+  value: number;
+  /** Compact source-lineage token (connector/stream/recipe/normalizer). */
+  source: string;
+}
+
+/** Freshness derived from the backing connection's status — never a silent zero. */
+export type BindingFreshness = 'fresh' | 'stale' | 'orphaned';
+
+export interface MaterializationResult {
+  /** `materialized` = points produced; `stale`/`orphaned` = connection broken, nothing written. */
+  status: 'materialized' | BindingFreshness;
+  points: ValuePoint[];
+  rows: MetricValueRow[];
+}


### PR DESCRIPTION
Builds **CVS-144** — the metric-binding layer. Turns canonical records (CVS-139/143) into tracked-metric values: the bridge from a connector stream to the product model (`metric_values`). Feeds off the CVS-143 sink. **No migration** — reuses `metric_values.source` for lineage; freshness derives from `connected_accounts.status`.

## What
- `materialize(records, recipe)` — deterministic `sum`/`count`/`average` over `day`/`week`/`month`, `field` = `amount` or `attributes.<key>`, optional `filter` → sorted `ValuePoint[]`.
- `materializeBinding(records, binding, account?)` — idempotent `MetricValueRow[]` + source-lineage token. Broken connection (`error`/`revoked`) → `stale`/`orphaned`, **no rows** (never silent zeroes). `previewBinding()` no-persist preview; `collectRecords()` accumulator sink for CVS-143.
- `upsertMetricValues(client, rows)` — idempotent upsert by `(tracked_metric_id, period)`.
- **16 tests** (Stripe revenue + GA4 sessions fixtures, idempotency, stale/orphaned, filter, day/week/month, preview, upsert onConflict); doc `docs/data/connector-binding.md`.

## Acceptance criteria
- [x] Canonical stream → metric values for a target tracked metric
- [x] Idempotent by (metric, period)
- [x] Source lineage + freshness (from connection status)
- [x] Broken/revoked → stale/orphaned, not zeroes
- [x] Analytics-style + money-style fixtures

Pure code — no DB, no secrets. Green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)