### PR TITLE
feat(dashboard): route server state through TanStack Query (CVS-70, phase 1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,8 +36,19 @@ import AppShell from './shared/components/layout/AppShell';
 // Auth Pages
 import SignInPage from './features/auth/pages/SignInPage';
 
-// Create a client
-const queryClient = new QueryClient();
+// Server-state defaults (CVS-70): keep data cached across navigations so revisits are
+// instant (stale-while-revalidate) instead of refetching from a spinner. Client/UI state
+// stays in Zustand — this only governs TanStack Query's server cache.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000, // 30s: treat data as fresh, serve from cache without refetch
+      gcTime: 5 * 60_000, // keep unused cache 5min for instant back-navigation
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});
 
 export default function App() {
   return (

--- a/src/features/dashboard/hooks/useDashboardData.ts
+++ b/src/features/dashboard/hooks/useDashboardData.ts
@@ -1,0 +1,71 @@
+// Dashboard server-state hooks (CVS-70).
+//
+// Wraps the existing Supabase services in TanStack Query so revisiting the dashboard shows
+// cached data immediately (stale-while-revalidate) instead of refetching from a spinner.
+// Components consume these hooks; they never fetch Supabase directly. Client/UI state stays
+// in Zustand — this is only the server-state layer.
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/shared/queries/keys';
+import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
+import { listWidgets } from '@/shared/lib/supabase/services/dashboards';
+import {
+  getMetricValuesByMetricIds,
+  listTrackedMetrics,
+} from '@/shared/lib/supabase/services/trackedMetrics';
+import { getProjectById } from '@/shared/lib/supabase/services/projects';
+import { getCanvasNodesByProject } from '@/shared/lib/supabase/services/canvasNodes';
+import { listContractsWithLinksForProject } from '@/shared/lib/supabase/services/strategyImpact';
+import type { ImpactContract, MetricLink } from '@/features/strategy/impact/types';
+import type { CanvasNode, GroupNode, MetricCard, MetricValue } from '@/shared/types';
+import type { DashboardWidget } from '@/features/dashboard/types';
+
+/** The full bundle the dashboard needs for one canvas, fetched in one query. */
+export interface DashboardData {
+  widgets: DashboardWidget[];
+  trackedNames: Record<string, string>;
+  cards: MetricCard[];
+  groups: GroupNode[];
+  chartNodes: CanvasNode[];
+  impactEntries: Array<{ contract: ImpactContract; links: MetricLink[] }>;
+}
+
+/**
+ * Load the dashboard bundle for a canvas. Cached under a per-canvas key, so navigating away
+ * and back is instant while a background refetch keeps it fresh. Individual sub-fetches
+ * degrade gracefully (a failed project/nodes/impact load yields empty, matching the prior
+ * hand-rolled behavior) rather than failing the whole dashboard.
+ */
+export function useDashboardData(canvasId: string | undefined) {
+  const client = useClerkSupabase();
+  return useQuery({
+    queryKey: queryKeys.dashboard.data(canvasId ?? ''),
+    enabled: Boolean(client && canvasId),
+    queryFn: async (): Promise<DashboardData> => {
+      const [widgets, metrics, project, nodes, impact] = await Promise.all([
+        listWidgets(canvasId!, client!),
+        listTrackedMetrics(client!),
+        getProjectById(canvasId!, client!).catch(() => null),
+        getCanvasNodesByProject(canvasId!, client!).catch(() => [] as CanvasNode[]),
+        listContractsWithLinksForProject(canvasId!, client!).catch(() => []),
+      ]);
+      return {
+        widgets,
+        trackedNames: Object.fromEntries(metrics.map((m) => [m.id, m.name])),
+        cards: project?.nodes ?? [],
+        groups: project?.groups ?? [],
+        chartNodes: nodes.filter((n) => n.nodeType === 'chartNode'),
+        impactEntries: impact,
+      };
+    },
+  });
+}
+
+/** Shared series for the tracked metrics referenced by the dashboard's widgets/impact. */
+export function useTrackedMetricValues(ids: string[]) {
+  const client = useClerkSupabase();
+  return useQuery({
+    queryKey: queryKeys.metricValues.byIds(ids),
+    enabled: Boolean(client) && ids.length > 0,
+    queryFn: (): Promise<Record<string, MetricValue[]>> => getMetricValuesByMetricIds(ids, client!),
+  });
+}

--- a/src/features/dashboard/pages/DashboardPage.tsx
+++ b/src/features/dashboard/pages/DashboardPage.tsx
@@ -1,23 +1,22 @@
 import { useCanvasStore } from '@/lib/stores';
 import { Button } from '@/shared/components/ui/button';
 import { Card } from '@/shared/components/ui/card';
+import { Skeleton } from '@/shared/components/ui/skeleton';
 import { usePageHeader } from '@/shared/hooks/usePageHeader';
 import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
 import { useVisibilityStore } from '@/shared/stores/useVisibilityStore';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/shared/queries/keys';
 import {
-  getMetricValuesByMetricIds,
-  listTrackedMetrics,
-} from '@/shared/lib/supabase/services/trackedMetrics';
+  useDashboardData,
+  useTrackedMetricValues,
+} from '@/features/dashboard/hooks/useDashboardData';
 import {
   createWidget,
   deleteWidget,
-  listWidgets,
   updateLayouts,
   updateWidget,
 } from '@/shared/lib/supabase/services/dashboards';
-import { getProjectById } from '@/shared/lib/supabase/services/projects';
-import { getCanvasNodesByProject } from '@/shared/lib/supabase/services/canvasNodes';
-import { listContractsWithLinksForProject } from '@/shared/lib/supabase/services/strategyImpact';
 import {
   linkedStrategyForWidget,
   type WidgetStrategyLink,
@@ -59,7 +58,6 @@ import {
   Eye,
   LayoutGrid,
   Lock,
-  Loader2,
   Pencil,
   Plus,
 } from 'lucide-react';
@@ -76,25 +74,43 @@ const ROW_HEIGHT = 40;
 
 const CUSTOM_VIEW = '__custom__';
 
+// Stable empty defaults so derived useMemos don't churn on every render while the query
+// resolves (a fresh `[]`/`{}` each render would defeat memoization).
+const EMPTY_NAMES: Record<string, string> = {};
+const EMPTY_CARDS: MetricCard[] = [];
+const EMPTY_GROUPS: GroupNode[] = [];
+const EMPTY_NODES: CanvasNode[] = [];
+const EMPTY_IMPACT: Array<{ contract: ImpactContract; links: MetricLink[] }> = [];
+const EMPTY_VALUES: Record<string, MetricValue[]> = {};
+
 export default function DashboardPage() {
   const { canvasId } = useParams();
   const navigate = useNavigate();
   const client = useClerkSupabase();
   const storeCanvas = useCanvasStore((s) => s.canvas);
+  const queryClient = useQueryClient();
 
-  const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
-  const [trackedNames, setTrackedNames] = useState<Record<string, string>>({});
-  const [trackedValues, setTrackedValues] = useState<
-    Record<string, MetricValue[]>
-  >({});
+  // Server state via TanStack Query (CVS-70): cached + stale-while-revalidate, so
+  // revisiting the dashboard is instant instead of refetching behind a spinner.
+  const { data: dashboardData, isLoading } = useDashboardData(canvasId);
+  const trackedNames = dashboardData?.trackedNames ?? EMPTY_NAMES;
   // Persisted nodes + groups for this canvas (drives the group dashboards).
-  const [loadedCards, setLoadedCards] = useState<MetricCard[]>([]);
-  const [loadedGroups, setLoadedGroups] = useState<GroupNode[]>([]);
-  const [chartNodes, setChartNodes] = useState<CanvasNode[]>([]);
-  const [impactEntries, setImpactEntries] = useState<
-    Array<{ contract: ImpactContract; links: MetricLink[] }>
-  >([]);
-  const [loading, setLoading] = useState(true);
+  const loadedCards = dashboardData?.cards ?? EMPTY_CARDS;
+  const loadedGroups = dashboardData?.groups ?? EMPTY_GROUPS;
+  const chartNodes = dashboardData?.chartNodes ?? EMPTY_NODES;
+  const impactEntries = dashboardData?.impactEntries ?? EMPTY_IMPACT;
+
+  // Widgets stay in local state so drag/resize/create/remove feel instant; seeded from the
+  // query and re-seeded whenever a mutation invalidates and the bundle refetches.
+  const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
+  useEffect(() => {
+    if (dashboardData) setWidgets(dashboardData.widgets);
+  }, [dashboardData]);
+
+  const invalidateDashboard = () => {
+    if (canvasId) void queryClient.invalidateQueries({ queryKey: queryKeys.dashboard.data(canvasId) });
+  };
+
   const [editMode, setEditMode] = useState(false);
   const [configOpen, setConfigOpen] = useState(false);
   const [editing, setEditing] = useState<DashboardWidget | null>(null);
@@ -135,40 +151,6 @@ export default function DashboardPage() {
     [storeMatches, storeCanvas?.groups, loadedGroups]
   );
 
-  // Load widgets + the catalog (names) + the project (nodes/groups) for this canvas.
-  useEffect(() => {
-    if (!client || !canvasId) return;
-    setLoading(true);
-    Promise.all([
-      listWidgets(canvasId, client),
-      listTrackedMetrics(client),
-      getProjectById(canvasId, client).catch(() => null),
-      getCanvasNodesByProject(canvasId, client).catch(
-        () => [] as CanvasNode[]
-      ),
-      listContractsWithLinksForProject(canvasId, client).catch(() => []),
-    ])
-      .then(([w, metrics, project, nodes, impact]) => {
-        setWidgets(w);
-        setTrackedNames(
-          Object.fromEntries(metrics.map((m) => [m.id, m.name]))
-        );
-        setLoadedCards(project?.nodes ?? []);
-        setLoadedGroups(project?.groups ?? []);
-        setChartNodes(nodes.filter((n) => n.nodeType === 'chartNode'));
-        setImpactEntries(impact);
-      })
-      .catch(() => {
-        setWidgets([]);
-        setTrackedNames({});
-        setLoadedCards([]);
-        setLoadedGroups([]);
-        setChartNodes([]);
-        setImpactEntries([]);
-      })
-      .finally(() => setLoading(false));
-  }, [client, canvasId]);
-
   // Default to the first group's dashboard when groups exist, else Custom.
   useEffect(() => {
     if (groups.length > 0) {
@@ -198,15 +180,7 @@ export default function DashboardPage() {
     return Array.from(ids);
   }, [widgets, impactEntries]);
 
-  useEffect(() => {
-    if (!client || referencedTrackedIds.length === 0) {
-      setTrackedValues({});
-      return;
-    }
-    getMetricValuesByMetricIds(referencedTrackedIds, client)
-      .then(setTrackedValues)
-      .catch(() => setTrackedValues({}));
-  }, [client, referencedTrackedIds]);
+  const { data: trackedValues = EMPTY_VALUES } = useTrackedMetricValues(referencedTrackedIds);
 
   const sources: WidgetDataSources = useMemo(
     () => ({ cards: visibleCards, trackedValues, trackedNames }),
@@ -343,6 +317,7 @@ export default function DashboardPage() {
         );
         setWidgets((prev) => [...prev, created]);
       }
+      invalidateDashboard();
     } catch {
       toast.error('Failed to save widget');
     }
@@ -354,6 +329,7 @@ export default function DashboardPage() {
     setWidgets((w) => w.filter((x) => x.id !== id));
     try {
       await deleteWidget(id, client);
+      invalidateDashboard();
     } catch {
       setWidgets(prev);
       toast.error('Failed to remove widget');
@@ -374,6 +350,7 @@ export default function DashboardPage() {
         client
       );
       setWidgets((prev) => [...prev, created]);
+      invalidateDashboard();
       toast.success('Chart added to dashboard');
     } catch {
       toast.error('Failed to import chart');
@@ -439,10 +416,12 @@ export default function DashboardPage() {
     deps: [editMode, isCustom, chartNodes, widgets],
   });
 
-  if (loading) {
+  if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      <div className="grid grid-cols-1 gap-4 p-6 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-40 w-full rounded-xl" />
+        ))}
       </div>
     );
   }

--- a/src/shared/queries/keys.test.ts
+++ b/src/shared/queries/keys.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { queryKeys } from './keys';
+
+describe('queryKeys', () => {
+  it('scopes the dashboard bundle by canvas id under the dashboard namespace', () => {
+    expect(queryKeys.dashboard.data('c1')).toEqual(['dashboard', 'data', 'c1']);
+    // Nested under `dashboard.all` so a broad invalidation clears it.
+    expect(queryKeys.dashboard.data('c1').slice(0, 1)).toEqual(queryKeys.dashboard.all);
+  });
+
+  it('makes metric-value keys order-independent so [a,b] and [b,a] share a cache entry', () => {
+    expect(queryKeys.metricValues.byIds(['b', 'a'])).toEqual(queryKeys.metricValues.byIds(['a', 'b']));
+    expect(queryKeys.metricValues.byIds(['a', 'b'])).toEqual(['metricValues', ['a', 'b']]);
+  });
+
+  it('does not mutate the caller-supplied id array', () => {
+    const ids = ['z', 'a'];
+    queryKeys.metricValues.byIds(ids);
+    expect(ids).toEqual(['z', 'a']);
+  });
+});

--- a/src/shared/queries/keys.ts
+++ b/src/shared/queries/keys.ts
@@ -1,0 +1,19 @@
+// Typed query-key factory for TanStack Query (CVS-70).
+//
+// One place that owns every server-state cache key, so invalidation and prefetch are
+// type-safe and consistent instead of stringly-typed per call site. Keys are hierarchical
+// — invalidating a broader key (e.g. `dashboard.all`) clears everything nested under it.
+// As pages migrate off hand-rolled fetching, add their keys here rather than inline.
+
+export const queryKeys = {
+  dashboard: {
+    all: ['dashboard'] as const,
+    /** The full dashboard bundle (widgets + catalog names + project + charts + impact). */
+    data: (canvasId: string) => ['dashboard', 'data', canvasId] as const,
+  },
+  metricValues: {
+    all: ['metricValues'] as const,
+    /** Shared series for a set of tracked-metric ids (order-independent). */
+    byIds: (ids: readonly string[]) => ['metricValues', [...ids].sort()] as const,
+  },
+} as const;


### PR DESCRIPTION
Part of CVS-70 — **phase 1: the DashboardPage proof point** (the issue's "do first" slice). Not the full migration.

## What this does
Routes the dashboard's **server state** through TanStack Query so revisiting a canvas dashboard is instant (cached, stale-while-revalidate) instead of refetching behind a spinner. Client/UI state stays in Zustand.

- **`src/shared/queries/keys.ts`** — typed, hierarchical query-key factory (+ unit tests).
- **`src/features/dashboard/hooks/useDashboardData.ts`** — `useDashboardData` (the whole bundle in one query) + `useTrackedMetricValues`, wrapping the existing Supabase services. Components no longer fetch in `useEffect`.
- **`DashboardPage`** — two hand-rolled `useEffect` fetchers replaced by the hooks; full-screen spinner → skeleton; widget create/update/delete/import invalidate the bundle so the cache stays correct. Widgets keep local state for instant drag/create feedback, seeded from the query.
- **`App.tsx`** — `QueryClient` defaults: `staleTime` 30s, `gcTime` 5m, `refetchOnWindowFocus` off, `retry` 1.

## Scope / follow-up
This is the foundation + one page. The remaining pages (canvas, assets, strategy, relationship, embed, chart-node-settings) and **optimistic mutations with rollback** are follow-up slices, so the issue stays In Progress after this merges.

## Verification
type-check, lint, and the full Vitest suite pass via Husky. **Visual/perceived-perf behavior needs the owner's manual test** (navigate away from a dashboard and back → instant, no spinner; widget add/remove persists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)