### PR TITLE
feat(connectors): observability — run health + audit (CVS-145)

### DIFF
--- a/docs/data/connector-observability.md
+++ b/docs/data/connector-observability.md
@@ -1,0 +1,61 @@
+# Connector observability (run health + audit)
+
+Payload-free observability for native connectors (`src/shared/lib/connectors/observability/`,
+CVS-145): records what each sync did — counts, cursor movement, error classes — and derives
+an operator-facing health state, **without ever storing tokens or raw source payloads**.
+
+Migration: `supabase/migrations/20260706130000_connector_runs.sql` (owner-applies, like CVS-141).
+
+## The audit table (`connector_runs`)
+
+Workspace-scoped, **append-only** (RLS: select + insert; no update/delete → immutable log).
+Columns are payload-free by construction — counts (`pages`/`fetched`/`accepted`/`skipped`/
+`rejected`/`materialized`), a `cursor` token, an `error_class`, a **redacted** `error_message`,
+timings, and an `event` (`run_finished`/`run_failed` or connection lifecycle events). There is
+deliberately **no** column for request bodies, tokens, or record contents.
+
+## Recording
+
+The CVS-142 `RunReport` is already payload-free; `recordRun(client, report, meta)` maps it to a
+row and persists it. `runRowFromReport` computes `accepted` (`fetched − skipped − rejected`) and
+`duration_ms`, and runs the message through `safeMessage` (redacts token-like runs +
+`sk_`/`pk_`/`Bearer`/JWT prefixes, truncates to 300 chars) as defense-in-depth.
+
+```ts
+await recordRun(client, runReport, { connectedAccountId, workspaceId, materialized });
+await recordConnectionEvent(client, { connectorId, connectedAccountId, event: 'connection_refreshed' });
+```
+
+`recordConnectionEvent` logs lifecycle events (connected / refreshed / revoked / disconnected /
+auth_failed) — `auth_failed` is recorded as `status: error`.
+
+## Reading + health
+
+- `listRuns(client, { connectedAccountId?, connectorId?, limit })` — recent rows (safe columns),
+  newest first, for the admin/debug panel.
+- `latestRun(client, accountId, stream?)` — the most recent run event.
+- `deriveHealth(latestRun, { connectionStatus, nowMs?, staleAfterMs? })` — pure. Connection state
+  wins for hard stops (`revoked` → `needs_reconnect`, `paused` → `paused`); otherwise the last
+  run decides:
+
+  | last run | → health |
+  | --- | --- |
+  | error, `error_class: auth` | `needs_reconnect` |
+  | error, `error_class: rate_limit` | `rate_limited` |
+  | error/partial, other class | `failing` |
+  | success, fresh | `healthy` |
+  | success, older than `staleAfterMs` (default 24h) | `stale` |
+  | no runs yet | `stale` (or `needs_reconnect` if the connection errored) |
+
+This is the status Connected Accounts (CVS-90) and the admin panel surface.
+
+## Retry safety
+
+Retrying a failed run is safe: the fetch runtime only advances the cursor after a page is
+fetched **and** handled (CVS-142), and metric binding upserts idempotently by
+`(tracked_metric_id, period)` (CVS-144) — so a re-run neither skips data nor double-counts.
+
+## Not here
+
+No admin UI (backend contract only) and no full connection-event stream beyond the events above —
+those render in the CVS-90 settings surface + a later admin/debug panel.

--- a/src/shared/lib/connectors/observability/health.ts
+++ b/src/shared/lib/connectors/observability/health.ts
@@ -1,0 +1,44 @@
+// Health derivation (CVS-145): map the latest run + connection status to an
+// operator-facing health state. Pure + injectable clock so it's deterministic in tests.
+import type { ConnectorHealth, ConnectorRunRow } from './types';
+
+export interface HealthOpts {
+  /** connected_accounts.status: 'connected' | 'pending' | 'error' | 'revoked' | 'paused'. */
+  connectionStatus?: string;
+  nowMs?: number;
+  /** A successful run older than this is 'stale'. Default 24h. */
+  staleAfterMs?: number;
+}
+
+/**
+ * Derive health from the most recent run and the connection state. Connection state
+ * wins for hard-stops (revoked → needs_reconnect, paused → paused); otherwise the last
+ * run's outcome + error class decides, with a staleness fallback.
+ */
+export function deriveHealth(latest: ConnectorRunRow | undefined, opts: HealthOpts = {}): ConnectorHealth {
+  if (opts.connectionStatus === 'revoked') return 'needs_reconnect';
+  if (opts.connectionStatus === 'paused') return 'paused';
+
+  if (!latest) {
+    // no runs yet: a broken connection needs attention, otherwise it's simply stale.
+    return opts.connectionStatus === 'error' ? 'needs_reconnect' : 'stale';
+  }
+
+  if (latest.status === 'error' || latest.status === 'partial') {
+    switch (latest.error_class) {
+      case 'auth':
+        return 'needs_reconnect';
+      case 'rate_limit':
+        return 'rate_limited';
+      default:
+        return 'failing'; // transient / timeout / permanent / unknown
+    }
+  }
+
+  // success — check freshness
+  const now = opts.nowMs ?? Date.now();
+  const staleAfter = opts.staleAfterMs ?? 24 * 60 * 60 * 1000;
+  const finishedMs = latest.finished_at ? Date.parse(latest.finished_at) : NaN;
+  if (!Number.isNaN(finishedMs) && now - finishedMs > staleAfter) return 'stale';
+  return 'healthy';
+}

--- a/src/shared/lib/connectors/observability/index.ts
+++ b/src/shared/lib/connectors/observability/index.ts
@@ -1,0 +1,14 @@
+// Connector observability (CVS-145): payload-free run/audit records + health derivation.
+// Records the CVS-142 RunReport (already payload-free) into `connector_runs` and derives
+// operator health from recent runs + connection state. See docs/data/connector-observability.md.
+export * from './types';
+export * from './health';
+export {
+  safeMessage,
+  statusFromReport,
+  runRowFromReport,
+  recordRun,
+  recordConnectionEvent,
+  listRuns,
+  latestRun,
+} from './observability';

--- a/src/shared/lib/connectors/observability/observability.test.ts
+++ b/src/shared/lib/connectors/observability/observability.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import type { RunReport } from '../runtime';
+import {
+  deriveHealth,
+  recordConnectionEvent,
+  recordRun,
+  runRowFromReport,
+  safeMessage,
+  statusFromReport,
+  type ConnectorRunRow,
+} from './index';
+
+const okReport: RunReport = {
+  connector_id: 'stripe', stream: 'payment_intents', sync_mode: 'incremental',
+  pages: 3, fetched: 100, skipped: 5, rejected: 2, cursor: 'created:123',
+  resumable: true, started_at: '2026-07-06T00:00:00Z', finished_at: '2026-07-06T00:00:05Z',
+};
+
+describe('safeMessage — redaction', () => {
+  it('redacts token-like runs and key prefixes', () => {
+    expect(safeMessage('auth failed for sk_live_ABCDEFGHIJKLMNOPQR')).not.toContain('sk_live_ABCDEFGHIJKLMNOPQR');
+    expect(safeMessage('cursor eyJhbGciOiJIUzI1NiJ9.payloadpayloadpayloadpayload')).toContain('[redacted]');
+  });
+  it('passes short safe messages through and truncates long ones', () => {
+    expect(safeMessage('rate limited by source')).toBe('rate limited by source');
+    expect(safeMessage(null)).toBeNull();
+    expect((safeMessage('x'.repeat(500)) ?? '').length).toBeLessThanOrEqual(300);
+  });
+});
+
+describe('statusFromReport', () => {
+  it('success / partial / error', () => {
+    expect(statusFromReport(okReport)).toBe('success');
+    expect(statusFromReport({ ...okReport, error_class: 'auth', pages: 2 })).toBe('partial');
+    expect(statusFromReport({ ...okReport, error_class: 'auth', pages: 0 })).toBe('error');
+  });
+});
+
+describe('runRowFromReport', () => {
+  it('maps a payload-free report to a row (computes accepted + duration, redacts message)', () => {
+    const row = runRowFromReport({ ...okReport, error_class: 'auth', error_message: 'bad token sk_live_ABCDEFGHIJKLMNOPQR' }, { connectedAccountId: 'ca_1', materialized: 7 });
+    expect(row.connector_id).toBe('stripe');
+    expect(row.accepted).toBe(93); // 100 - 5 - 2
+    expect(row.materialized).toBe(7);
+    expect(row.duration_ms).toBe(5000);
+    expect(row.event).toBe('run_failed');
+    expect(row.error_message).not.toContain('sk_live_ABCDEFGHIJKLMNOPQR');
+    expect(row.connected_account_id).toBe('ca_1');
+  });
+
+  it('a clean run is run_finished / success', () => {
+    const row = runRowFromReport(okReport);
+    expect(row.event).toBe('run_finished');
+    expect(row.status).toBe('success');
+  });
+});
+
+describe('deriveHealth', () => {
+  const base: ConnectorRunRow = { connector_id: 'stripe', event: 'run_finished', status: 'success', pages: 1, fetched: 1, accepted: 1, skipped: 0, rejected: 0, materialized: 1, resumable: false, finished_at: '2026-07-06T00:00:00Z' };
+  const now = Date.parse('2026-07-06T01:00:00Z');
+
+  it('connection state wins for hard stops', () => {
+    expect(deriveHealth(base, { connectionStatus: 'revoked' })).toBe('needs_reconnect');
+    expect(deriveHealth(base, { connectionStatus: 'paused' })).toBe('paused');
+  });
+  it('no runs yet', () => {
+    expect(deriveHealth(undefined, {})).toBe('stale');
+    expect(deriveHealth(undefined, { connectionStatus: 'error' })).toBe('needs_reconnect');
+  });
+  it('maps error classes', () => {
+    expect(deriveHealth({ ...base, status: 'error', error_class: 'auth' }, { nowMs: now })).toBe('needs_reconnect');
+    expect(deriveHealth({ ...base, status: 'error', error_class: 'rate_limit' }, { nowMs: now })).toBe('rate_limited');
+    expect(deriveHealth({ ...base, status: 'error', error_class: 'transient' }, { nowMs: now })).toBe('failing');
+    expect(deriveHealth({ ...base, status: 'partial', error_class: 'timeout' }, { nowMs: now })).toBe('failing');
+  });
+  it('healthy when fresh, stale when old', () => {
+    expect(deriveHealth(base, { nowMs: now })).toBe('healthy'); // 1h old, default 24h window
+    expect(deriveHealth(base, { nowMs: now, staleAfterMs: 30 * 60 * 1000 })).toBe('stale'); // 1h > 30m
+  });
+});
+
+describe('persistence (mocked client)', () => {
+  const mockClient = () => {
+    const insert = vi.fn().mockResolvedValue({ error: null });
+    const client = { from: vi.fn(() => ({ insert })) } as unknown as SupabaseClient<Database>;
+    return { client, insert };
+  };
+
+  it('recordRun inserts a row with workspace_id', async () => {
+    const { client, insert } = mockClient();
+    await recordRun(client, okReport, { workspaceId: 'ws_1', connectedAccountId: 'ca_1' });
+    expect(client.from).toHaveBeenCalledWith('connector_runs');
+    const arg = insert.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.workspace_id).toBe('ws_1');
+    expect(arg.connector_id).toBe('stripe');
+    expect(arg.event).toBe('run_finished');
+  });
+
+  it('recordConnectionEvent marks auth_failed as error', async () => {
+    const { client, insert } = mockClient();
+    await recordConnectionEvent(client, { connectorId: 'ga4', connectedAccountId: 'ca_2', event: 'auth_failed' });
+    const arg = insert.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.event).toBe('auth_failed');
+    expect(arg.status).toBe('error');
+  });
+});

--- a/src/shared/lib/connectors/observability/observability.ts
+++ b/src/shared/lib/connectors/observability/observability.ts
@@ -1,0 +1,122 @@
+// Connector observability service (CVS-145): record payload-free run/connection audit
+// rows and read them back safely. The CVS-142 RunReport is already payload-free; this
+// maps it to a row, redacts the message as defense-in-depth, and persists it. Takes any
+// RLS-scoped or service-role client (the connector sync supplies one, CVS-146+).
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import type { RunReport } from '../runtime';
+import type { ConnectorEvent, ConnectorRunRow, RunRecordMeta, RunStatus } from './types';
+
+/** Redact token-like runs + truncate, so a message can never leak a secret or payload. */
+export function safeMessage(msg?: string | null): string | null {
+  if (!msg) return null;
+  let s = String(msg);
+  s = s.replace(/\b(?:sk|pk|mk|rk|Bearer|ey)[A-Za-z0-9._-]{8,}/gi, '[redacted]');
+  s = s.replace(/[A-Za-z0-9_-]{40,}/g, '[redacted]');
+  return s.length > 300 ? `${s.slice(0, 297)}…` : s;
+}
+
+/** A run with an error that still made progress is `partial`; one that never started is `error`. */
+export function statusFromReport(report: RunReport): RunStatus {
+  if (!report.error_class) return 'success';
+  return report.pages > 0 ? 'partial' : 'error';
+}
+
+function durationMs(start?: string, end?: string): number | null {
+  if (!start || !end) return null;
+  const d = Date.parse(end) - Date.parse(start);
+  return Number.isFinite(d) ? d : null;
+}
+
+/** Map a payload-free RunReport (+ downstream counts) to a connector_runs row. */
+export function runRowFromReport(report: RunReport, meta: RunRecordMeta = {}): ConnectorRunRow {
+  return {
+    connected_account_id: meta.connectedAccountId ?? null,
+    connector_id: report.connector_id,
+    stream: report.stream,
+    event: report.error_class ? 'run_failed' : 'run_finished',
+    status: statusFromReport(report),
+    sync_mode: report.sync_mode,
+    pages: report.pages,
+    fetched: report.fetched,
+    accepted: meta.accepted ?? Math.max(0, report.fetched - report.skipped - report.rejected),
+    skipped: report.skipped,
+    rejected: report.rejected,
+    materialized: meta.materialized ?? 0,
+    cursor: report.cursor ?? null,
+    error_class: report.error_class ?? null,
+    error_message: safeMessage(report.error_message),
+    resumable: report.resumable,
+    duration_ms: durationMs(report.started_at, report.finished_at),
+    started_at: report.started_at,
+    finished_at: report.finished_at,
+  };
+}
+
+type Client = SupabaseClient<Database>;
+
+function withWorkspace(row: ConnectorRunRow, workspaceId?: string): Record<string, unknown> {
+  return workspaceId ? { ...row, workspace_id: workspaceId } : { ...row };
+}
+
+/** Persist a completed stream run as an audit row. */
+export async function recordRun(client: Client, report: RunReport, meta: RunRecordMeta = {}): Promise<void> {
+  const { error } = await client
+    .from('connector_runs')
+    .insert(withWorkspace(runRowFromReport(report, meta), meta.workspaceId) as never);
+  if (error) throw new Error(error.message);
+}
+
+/** Persist a connection lifecycle event (connected/refreshed/revoked/disconnected/auth_failed). */
+export async function recordConnectionEvent(
+  client: Client,
+  input: { connectorId: string; connectedAccountId?: string; event: ConnectorEvent; errorClass?: string; workspaceId?: string }
+): Promise<void> {
+  const row: ConnectorRunRow = {
+    connected_account_id: input.connectedAccountId ?? null,
+    connector_id: input.connectorId,
+    stream: null,
+    event: input.event,
+    status: input.event === 'auth_failed' ? 'error' : 'success',
+    pages: 0, fetched: 0, accepted: 0, skipped: 0, rejected: 0, materialized: 0,
+    resumable: false,
+    error_class: input.errorClass ?? null,
+  };
+  const { error } = await client.from('connector_runs').insert(withWorkspace(row, input.workspaceId) as never);
+  if (error) throw new Error(error.message);
+}
+
+const SAFE_COLUMNS =
+  'connected_account_id, connector_id, stream, event, status, sync_mode, pages, fetched, accepted, skipped, rejected, materialized, cursor, error_class, error_message, resumable, duration_ms, started_at, finished_at, created_at';
+
+/** Recent audit rows (safe columns), newest first — powers the admin/debug panel. */
+export async function listRuns(
+  client: Client,
+  filters: { connectedAccountId?: string; connectorId?: string; limit?: number } = {}
+): Promise<ConnectorRunRow[]> {
+  let q = client.from('connector_runs').select(SAFE_COLUMNS).order('created_at', { ascending: false }).limit(filters.limit ?? 50);
+  if (filters.connectedAccountId) q = q.eq('connected_account_id', filters.connectedAccountId);
+  if (filters.connectorId) q = q.eq('connector_id', filters.connectorId);
+  const { data, error } = await q;
+  if (error) throw new Error(error.message);
+  return (data ?? []) as unknown as ConnectorRunRow[];
+}
+
+/** The most recent run for a connection+stream — feeds `deriveHealth`. */
+export async function latestRun(
+  client: Client,
+  connectedAccountId: string,
+  stream?: string
+): Promise<ConnectorRunRow | undefined> {
+  let q = client
+    .from('connector_runs')
+    .select(SAFE_COLUMNS)
+    .eq('connected_account_id', connectedAccountId)
+    .in('event', ['run_finished', 'run_failed'])
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (stream) q = q.eq('stream', stream);
+  const { data, error } = await q;
+  if (error) throw new Error(error.message);
+  return (data?.[0] as unknown as ConnectorRunRow) ?? undefined;
+}

--- a/src/shared/lib/connectors/observability/types.ts
+++ b/src/shared/lib/connectors/observability/types.ts
@@ -1,0 +1,57 @@
+// Connector observability contracts (CVS-145): payload-free run/audit records + the
+// health state derived from them. Nothing here can carry a token, payload, or request
+// body — only counts, cursor tokens, error classes, and safe messages.
+import type { ConnectorErrorClass } from '../runtime';
+
+export type RunStatus = 'running' | 'success' | 'error' | 'partial';
+
+/** Distinguishes a stream-run audit row from a connection lifecycle event. */
+export type ConnectorEvent =
+  | 'run_started'
+  | 'run_finished'
+  | 'run_failed'
+  | 'connection_connected'
+  | 'connection_refreshed'
+  | 'connection_revoked'
+  | 'connection_disconnected'
+  | 'auth_failed';
+
+/** Operator-facing health of a connection/stream, derived from recent runs + status. */
+export type ConnectorHealth =
+  | 'healthy'
+  | 'needs_reconnect'
+  | 'rate_limited'
+  | 'stale'
+  | 'failing'
+  | 'paused';
+
+/** A row written to / read from `connector_runs` (payload-free by construction). */
+export interface ConnectorRunRow {
+  connected_account_id?: string | null;
+  connector_id: string;
+  stream?: string | null;
+  event: ConnectorEvent;
+  status: RunStatus;
+  sync_mode?: string | null;
+  pages: number;
+  fetched: number;
+  accepted: number;
+  skipped: number;
+  rejected: number;
+  materialized: number;
+  cursor?: string | null;
+  error_class?: ConnectorErrorClass | string | null;
+  error_message?: string | null;
+  resumable: boolean;
+  duration_ms?: number | null;
+  started_at?: string | null;
+  finished_at?: string | null;
+}
+
+/** Extra context the runtime's RunReport doesn't carry (workspace, account, downstream counts). */
+export interface RunRecordMeta {
+  connectedAccountId?: string;
+  workspaceId?: string;
+  accepted?: number;
+  materialized?: number;
+}

--- a/src/shared/lib/supabase/types.ts
+++ b/src/shared/lib/supabase/types.ts
@@ -732,6 +732,92 @@ export type Database = {
           },
         ]
       }
+      connector_runs: {
+        Row: {
+          id: string
+          created_by: string
+          workspace_id: string | null
+          connected_account_id: string | null
+          connector_id: string
+          stream: string | null
+          event: string
+          status: string
+          sync_mode: string | null
+          pages: number
+          fetched: number
+          accepted: number
+          skipped: number
+          rejected: number
+          materialized: number
+          cursor: string | null
+          error_class: string | null
+          error_message: string | null
+          resumable: boolean
+          duration_ms: number | null
+          started_at: string | null
+          finished_at: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          created_by?: string
+          workspace_id?: string | null
+          connected_account_id?: string | null
+          connector_id: string
+          stream?: string | null
+          event: string
+          status?: string
+          sync_mode?: string | null
+          pages?: number
+          fetched?: number
+          accepted?: number
+          skipped?: number
+          rejected?: number
+          materialized?: number
+          cursor?: string | null
+          error_class?: string | null
+          error_message?: string | null
+          resumable?: boolean
+          duration_ms?: number | null
+          started_at?: string | null
+          finished_at?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          created_by?: string
+          workspace_id?: string | null
+          connected_account_id?: string | null
+          connector_id?: string
+          stream?: string | null
+          event?: string
+          status?: string
+          sync_mode?: string | null
+          pages?: number
+          fetched?: number
+          accepted?: number
+          skipped?: number
+          rejected?: number
+          materialized?: number
+          cursor?: string | null
+          error_class?: string | null
+          error_message?: string | null
+          resumable?: boolean
+          duration_ms?: number | null
+          started_at?: string | null
+          finished_at?: string | null
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "connector_runs_connected_account_id_fkey"
+            columns: ["connected_account_id"]
+            isOneToOne: false
+            referencedRelation: "connected_accounts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       connected_accounts: {
         Row: {
           id: string

--- a/supabase/migrations/20260706130000_connector_runs.sql
+++ b/supabase/migrations/20260706130000_connector_runs.sql
@@ -1,0 +1,69 @@
+-- =====================================================================
+-- CONNECTOR OBSERVABILITY — payload-free run/audit log (CVS-145)
+-- Metrimap : iqrclwolhookzzmiedun. Identity = requesting_user_id(); workspace =
+-- requesting_org_id(). Idempotent. RLS ENABLED, workspace-scoped, APPEND-ONLY
+-- (select + insert only — an audit log is never edited or deleted by clients).
+--
+-- Records connector run health + connection events WITHOUT raw source payloads:
+-- only counts, cursor tokens, error CLASSES, and safe/redacted messages. There is
+-- deliberately no column for request bodies, tokens, or record contents. See
+-- docs/data/connector-observability.md.
+-- =====================================================================
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.connector_runs (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_by           text NOT NULL DEFAULT public.requesting_user_id(),
+  workspace_id         text DEFAULT public.requesting_org_id(),
+  connected_account_id uuid REFERENCES public.connected_accounts(id) ON DELETE SET NULL,
+  connector_id         text NOT NULL,
+  stream               text,
+  -- 'run' events (run_started/finished/failed) or 'connection' events
+  -- (connected/refreshed/revoked/disconnected/auth_failed). Free text, app-validated.
+  event                text NOT NULL,
+  status               text NOT NULL DEFAULT 'success'
+                         CHECK (status IN ('running', 'success', 'error', 'partial')),
+  sync_mode            text,
+  -- counts (payload-free)
+  pages                integer NOT NULL DEFAULT 0,
+  fetched              integer NOT NULL DEFAULT 0,
+  accepted             integer NOT NULL DEFAULT 0,
+  skipped              integer NOT NULL DEFAULT 0,
+  rejected             integer NOT NULL DEFAULT 0,
+  materialized         integer NOT NULL DEFAULT 0,
+  -- payload-free cursor token + error class + SAFE (redacted) message only
+  cursor               text,
+  error_class          text,
+  error_message        text,
+  resumable            boolean NOT NULL DEFAULT false,
+  duration_ms          integer,
+  started_at           timestamptz,
+  finished_at          timestamptz,
+  created_at           timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_runs_workspace_id
+  ON public.connector_runs(workspace_id);
+-- fast "latest run for this account+stream" (health derivation)
+CREATE INDEX IF NOT EXISTS idx_connector_runs_account_recent
+  ON public.connector_runs(connected_account_id, stream, created_at DESC);
+
+ALTER TABLE public.connector_runs ENABLE ROW LEVEL SECURITY;
+
+-- Workspace-scoped read (creator or org member).
+DROP POLICY IF EXISTS connector_runs_select ON public.connector_runs;
+CREATE POLICY connector_runs_select ON public.connector_runs
+  FOR SELECT USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+-- Insert-only for clients (append-only audit). No update/delete policies => immutable.
+DROP POLICY IF EXISTS connector_runs_insert ON public.connector_runs;
+CREATE POLICY connector_runs_insert ON public.connector_runs
+  FOR INSERT WITH CHECK (
+    created_by = public.requesting_user_id()
+    AND (workspace_id IS NULL OR workspace_id = public.requesting_org_id())
+  );
+
+COMMIT;


### PR DESCRIPTION
Builds **CVS-145** — connector observability. Completes the M2 runtime. Records what each sync did and derives operator health, **payload-free** (no tokens, no raw source data).

Migration (owner-applies, append-only audit table — low-risk, idempotent): `connector_runs`.

## What
- **`connector_runs`** — workspace-scoped, **append-only** (RLS select+insert; no update/delete → immutable). Payload-free columns only: counts, cursor token, `error_class`, redacted `error_message`, timings, `event`.
- **`recordRun(client, report, meta)`** — maps the CVS-142 (already payload-free) `RunReport` → row; computes `accepted`/`duration`; `safeMessage` redacts token-like runs + `sk_`/`pk_`/`Bearer`/JWT prefixes. **`recordConnectionEvent`** logs connected/refreshed/revoked/disconnected/auth_failed.
- **`deriveHealth(latestRun, {connectionStatus, staleAfterMs})`** — pure: `revoked`→needs_reconnect, `paused`→paused; else `auth`→needs_reconnect, `rate_limit`→rate_limited, other error→failing, fresh success→healthy, old→stale.
- `listRuns` / `latestRun` for the admin panel. **11 tests**; doc `docs/data/connector-observability.md`.

## Acceptance criteria
- [x] Workspace-scoped run history
- [x] Run summaries + error classes via a safe service (safe columns only)
- [x] Logs payload-free + token-free (redaction + no payload columns)
- [x] Health derived consistently from recent runs + connection state
- [x] Retry-safe (cursor advances post-handle in CVS-142; binding upsert idempotent in CVS-144)

type-check + lint + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)