### PR TITLE
CVS-275: dark-mode tokens for Value/Action/Hypothesis node cards

### DIFF
--- a/src/features/canvas/components/nodes/ActionNode.tsx
+++ b/src/features/canvas/components/nodes/ActionNode.tsx
@@ -70,7 +70,7 @@ const ActionNode = memo(({ data, selected }: NodeProps<ActionNodeData>) => {
       case 'Business Driver':
         return 'bg-red-100 text-red-800 border-red-200';
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200';
+        return 'bg-muted text-foreground border-border';
     }
   };
 
@@ -83,7 +83,7 @@ const ActionNode = memo(({ data, selected }: NodeProps<ActionNodeData>) => {
       case 'Completed':
         return <CheckCircle className="w-3 h-3 text-green-600" />;
       case 'On Hold':
-        return <Pause className="w-3 h-3 text-gray-600" />;
+        return <Pause className="w-3 h-3 text-muted-foreground" />;
       default:
         return null;
     }
@@ -98,18 +98,18 @@ const ActionNode = memo(({ data, selected }: NodeProps<ActionNodeData>) => {
       case 'Low':
         return 'border-green-200 text-green-700 bg-green-50';
       default:
-        return 'border-gray-200 text-gray-700 bg-gray-50';
+        return 'border-border text-foreground bg-muted';
     }
   };
 
   return (
     <div
       className={cn(
-        'relative bg-white rounded-lg border-2 shadow-sm transition-all duration-200 cursor-pointer',
+        'relative bg-card rounded-lg border-2 shadow-sm transition-all duration-200 cursor-pointer',
         'min-w-[280px] max-w-[320px]',
         isSelected
           ? 'border-orange-500 shadow-lg ring-2 ring-orange-200'
-          : 'border-gray-200 hover:border-gray-300',
+          : 'border-border hover:border-border',
         isHovered &&
           !isSelected &&
           'shadow-md transform scale-[1.02] border-orange-300',
@@ -189,19 +189,19 @@ const ActionNode = memo(({ data, selected }: NodeProps<ActionNodeData>) => {
           </div>
           <div className="flex items-center gap-1">
             {getStatusIcon(node.status)}
-            <GripVertical className="w-4 h-4 text-gray-400 cursor-move" />
+            <GripVertical className="w-4 h-4 text-muted-foreground cursor-move" />
           </div>
         </div>
       </div>
 
       {/* Content */}
       <div className="p-3">
-        <h3 className="font-semibold text-gray-900 text-sm mb-1 line-clamp-2">
+        <h3 className="font-semibold text-foreground text-sm mb-1 line-clamp-2">
           {node.title}
         </h3>
 
         {node.description && (
-          <p className="text-xs text-gray-600 mb-3 line-clamp-2">
+          <p className="text-xs text-muted-foreground mb-3 line-clamp-2">
             {node.description}
           </p>
         )}
@@ -227,14 +227,14 @@ const ActionNode = memo(({ data, selected }: NodeProps<ActionNodeData>) => {
         <div className="space-y-1 mb-2">
           {node.assignee && (
             <div className="flex items-center gap-2">
-              <User className="w-3 h-3 text-gray-400" />
-              <span className="text-xs text-gray-600">{node.assignee}</span>
+              <User className="w-3 h-3 text-muted-foreground" />
+              <span className="text-xs text-muted-foreground">{node.assignee}</span>
             </div>
           )}
           {node.dueDate && (
             <div className="flex items-center gap-2">
-              <Calendar className="w-3 h-3 text-gray-400" />
-              <span className="text-xs text-gray-600">
+              <Calendar className="w-3 h-3 text-muted-foreground" />
+              <span className="text-xs text-muted-foreground">
                 {new Date(node.dueDate).toLocaleDateString()}
               </span>
             </div>
@@ -244,8 +244,8 @@ const ActionNode = memo(({ data, selected }: NodeProps<ActionNodeData>) => {
         {/* Effort */}
         {node.effort && (
           <div className="flex items-center gap-2 mb-2">
-            <Clock className="w-3 h-3 text-gray-400" />
-            <span className="text-xs text-gray-600">
+            <Clock className="w-3 h-3 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground">
               {node.effort} {node.effort === 1 ? 'point' : 'points'}
             </span>
           </div>
@@ -273,8 +273,8 @@ const ActionNode = memo(({ data, selected }: NodeProps<ActionNodeData>) => {
       </div>
 
       {/* Footer */}
-      <div className="px-3 py-2 bg-gray-50 rounded-b-lg border-t border-gray-100">
-        <div className="flex items-center justify-between text-xs text-gray-500">
+      <div className="px-3 py-2 bg-muted rounded-b-lg border-t border-gray-100">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span>Action Node</span>
           <span className="font-mono">{node.id.slice(0, 8)}</span>
         </div>

--- a/src/features/canvas/components/nodes/HypothesisNode.tsx
+++ b/src/features/canvas/components/nodes/HypothesisNode.tsx
@@ -62,7 +62,7 @@ const HypothesisNode = memo(
         case 'Seller Solution':
           return 'bg-indigo-100 text-indigo-800 border-indigo-200';
         default:
-          return 'bg-gray-100 text-gray-800 border-gray-200';
+          return 'bg-muted text-foreground border-border';
       }
     };
 
@@ -75,18 +75,18 @@ const HypothesisNode = memo(
         case 'Low':
           return 'border-red-200 text-red-700 bg-red-50';
         default:
-          return 'border-gray-200 text-gray-700 bg-gray-50';
+          return 'border-border text-foreground bg-muted';
       }
     };
 
     return (
       <div
         className={cn(
-          'relative bg-white rounded-lg border-2 shadow-sm transition-all duration-200 cursor-pointer',
+          'relative bg-card rounded-lg border-2 shadow-sm transition-all duration-200 cursor-pointer',
           'min-w-[280px] max-w-[320px]',
           isSelected
             ? 'border-purple-500 shadow-lg ring-2 ring-purple-200'
-            : 'border-gray-200 hover:border-gray-300',
+            : 'border-border hover:border-border',
           isHovered &&
             !isSelected &&
             'shadow-md transform scale-[1.02] border-purple-300',
@@ -168,19 +168,19 @@ const HypothesisNode = memo(
               {node.testable && (
                 <CheckSquare className="w-3 h-3 text-green-600" />
               )}
-              <GripVertical className="w-4 h-4 text-gray-400 cursor-move" />
+              <GripVertical className="w-4 h-4 text-muted-foreground cursor-move" />
             </div>
           </div>
         </div>
 
         {/* Content */}
         <div className="p-3">
-          <h3 className="font-semibold text-gray-900 text-sm mb-1 line-clamp-2">
+          <h3 className="font-semibold text-foreground text-sm mb-1 line-clamp-2">
             {node.title}
           </h3>
 
           {node.description && (
-            <p className="text-xs text-gray-600 mb-3 line-clamp-2">
+            <p className="text-xs text-muted-foreground mb-3 line-clamp-2">
               {node.description}
             </p>
           )}
@@ -210,18 +210,18 @@ const HypothesisNode = memo(
             <div className="mb-2">
               <div className="flex items-center gap-2 mb-1">
                 <AlertTriangle className="w-3 h-3 text-amber-500" />
-                <span className="text-xs font-medium text-gray-700">
+                <span className="text-xs font-medium text-foreground">
                   Assumptions
                 </span>
               </div>
               <div className="space-y-1">
                 {node.assumptions.slice(0, 2).map((assumption, index) => (
-                  <div key={index} className="text-xs text-gray-600 pl-5">
+                  <div key={index} className="text-xs text-muted-foreground pl-5">
                     • {assumption}
                   </div>
                 ))}
                 {node.assumptions.length > 2 && (
-                  <div className="text-xs text-gray-500 pl-5">
+                  <div className="text-xs text-muted-foreground pl-5">
                     +{node.assumptions.length - 2} more
                   </div>
                 )}
@@ -234,18 +234,18 @@ const HypothesisNode = memo(
             <div className="mb-2">
               <div className="flex items-center gap-2 mb-1">
                 <Target className="w-3 h-3 text-green-500" />
-                <span className="text-xs font-medium text-gray-700">
+                <span className="text-xs font-medium text-foreground">
                   Success Criteria
                 </span>
               </div>
               <div className="space-y-1">
                 {node.successCriteria.slice(0, 2).map((criteria, index) => (
-                  <div key={index} className="text-xs text-gray-600 pl-5">
+                  <div key={index} className="text-xs text-muted-foreground pl-5">
                     • {criteria}
                   </div>
                 ))}
                 {node.successCriteria.length > 2 && (
-                  <div className="text-xs text-gray-500 pl-5">
+                  <div className="text-xs text-muted-foreground pl-5">
                     +{node.successCriteria.length - 2} more
                   </div>
                 )}
@@ -275,8 +275,8 @@ const HypothesisNode = memo(
         </div>
 
         {/* Footer */}
-        <div className="px-3 py-2 bg-gray-50 rounded-b-lg border-t border-gray-100">
-          <div className="flex items-center justify-between text-xs text-gray-500">
+        <div className="px-3 py-2 bg-muted rounded-b-lg border-t border-gray-100">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
             <span>Hypothesis Node</span>
             <span className="font-mono">{node.id.slice(0, 8)}</span>
           </div>

--- a/src/features/canvas/components/nodes/ValueNode.tsx
+++ b/src/features/canvas/components/nodes/ValueNode.tsx
@@ -57,7 +57,7 @@ const ValueNode = memo(({ data, selected }: NodeProps<ValueNodeData>) => {
       case 'Critical Path':
         return 'bg-red-100 text-red-800 border-red-200';
       default:
-        return 'bg-gray-100 text-gray-800 border-gray-200';
+        return 'bg-muted text-foreground border-border';
     }
   };
 
@@ -77,11 +77,11 @@ const ValueNode = memo(({ data, selected }: NodeProps<ValueNodeData>) => {
   return (
     <div
       className={cn(
-        'relative bg-white rounded-lg border-2 shadow-sm transition-all duration-200 cursor-pointer',
+        'relative bg-card rounded-lg border-2 shadow-sm transition-all duration-200 cursor-pointer',
         'min-w-[280px] max-w-[320px]',
         isSelected
           ? 'border-blue-500 shadow-lg ring-2 ring-blue-200'
-          : 'border-gray-200 hover:border-gray-300',
+          : 'border-border hover:border-border',
         isHovered &&
           !isSelected &&
           'shadow-md transform scale-[1.02] border-blue-300',
@@ -161,19 +161,19 @@ const ValueNode = memo(({ data, selected }: NodeProps<ValueNodeData>) => {
           </div>
           <div className="flex items-center gap-1">
             {getBusinessImpactIcon(node.businessImpact)}
-            <GripVertical className="w-4 h-4 text-gray-400 cursor-move" />
+            <GripVertical className="w-4 h-4 text-muted-foreground cursor-move" />
           </div>
         </div>
       </div>
 
       {/* Content */}
       <div className="p-3">
-        <h3 className="font-semibold text-gray-900 text-sm mb-1 line-clamp-2">
+        <h3 className="font-semibold text-foreground text-sm mb-1 line-clamp-2">
           {node.title}
         </h3>
 
         {node.description && (
-          <p className="text-xs text-gray-600 mb-3 line-clamp-2">
+          <p className="text-xs text-muted-foreground mb-3 line-clamp-2">
             {node.description}
           </p>
         )}
@@ -181,7 +181,7 @@ const ValueNode = memo(({ data, selected }: NodeProps<ValueNodeData>) => {
         {/* Business Impact */}
         {node.businessImpact && (
           <div className="flex items-center gap-2 mb-2">
-            <span className="text-xs text-gray-500">Impact:</span>
+            <span className="text-xs text-muted-foreground">Impact:</span>
             <Badge
               variant="outline"
               className={cn(
@@ -202,8 +202,8 @@ const ValueNode = memo(({ data, selected }: NodeProps<ValueNodeData>) => {
         {/* Stakeholders */}
         {node.stakeholders && node.stakeholders.length > 0 && (
           <div className="flex items-center gap-2 mb-2">
-            <Users className="w-3 h-3 text-gray-400" />
-            <span className="text-xs text-gray-600">
+            <Users className="w-3 h-3 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground">
               {node.stakeholders.length} stakeholder
               {node.stakeholders.length !== 1 ? 's' : ''}
             </span>
@@ -232,8 +232,8 @@ const ValueNode = memo(({ data, selected }: NodeProps<ValueNodeData>) => {
       </div>
 
       {/* Footer */}
-      <div className="px-3 py-2 bg-gray-50 rounded-b-lg border-t border-gray-100">
-        <div className="flex items-center justify-between text-xs text-gray-500">
+      <div className="px-3 py-2 bg-muted rounded-b-lg border-t border-gray-100">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span>Value Node</span>
           <span className="font-mono">{node.id.slice(0, 8)}</span>
         </div>


### PR DESCRIPTION
The PRD node cards hardcoded bg-white → white in dark. Swapped structural colors for tokens. **Correction:** MetricCard is actually dark-fine (diagnostic: computed bg oklch(0.205)); my CVS-164 screenshot read was wrong, so only these three PRD cards were offenders. type-check/lint/tests green.