### PR TITLE
feat(connectors): GA4 native connector — OAuth + Data API (CVS-146)

### DIFF
--- a/docs/data/connector-ga4.md
+++ b/docs/data/connector-ga4.md
@@ -1,0 +1,58 @@
+# GA4 connector
+
+The first native connector (`src/shared/lib/connectors/adapters/ga4/`, CVS-146): Google
+Analytics 4 via the **Data API**, over the shared runtime. Proves the end-to-end path
+fetch → normalize → bind for an analytics source.
+
+## Pieces
+
+- **`oauth.ts`** — Google OAuth 2.0 auth-code flow (`access_type=offline` → refresh token),
+  scope **`analytics.readonly`** (least privilege). `buildGoogleAuthUrl` starts the connect;
+  `exchangeGoogleCode` / `refreshGoogleToken` get + refresh tokens. Client id/secret come from
+  server env `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` (**owner setup: CVS-280**).
+  Returned tokens are stored encrypted via the connection layer (CVS-141).
+- **`adapter.ts`** — `createGa4Adapter({ propertyId })` returns a CVS-142 `ConnectorAdapter`.
+  `fetchPage` POSTs a `runReport` (dimensions/metrics from the manifest stream), classifies
+  HTTP errors (401/403 → `auth`, 429 → `rate_limit`, 5xx → `transient`) so the runtime retries
+  correctly, paginates by `offset`, and advances the incremental cursor by max `date`.
+
+Credentials are **injected** by the runtime per run — the adapter never reads secrets.
+
+## Streams (match the CVS-140 GA4 manifest + CVS-143 mappers)
+
+| stream | dimensions → metrics | canonical | mapper key |
+| --- | --- | --- | --- |
+| `page_metrics` | `date, pagePath` → `screenPageViews, sessions` | `page_metric` | `ga4:page_metrics` |
+| `events` | `date, eventName` → `eventCount` | `analytics_event` | `ga4:events` |
+
+`page_metrics` flattens to **one row per metric** (2 metrics → 2 `page_metric` records per
+page/day); `events` flattens to one row per event.
+
+## Live wiring (once CVS-280 is done)
+
+```ts
+// OAuth callback (edge fn): exchange code → store encrypted tokens (CVS-141)
+const tokens = await exchangeGoogleCode({ code, clientId, clientSecret, redirectUri });
+await storeAccountSecret(service, accountId, tokens, CONNECTOR_SECRET_KEY, { sourceAccountId: propertyId });
+
+// Sync: resolve token → run stream → normalize → bind → observe
+const secret = await readAccountSecret(service, accountId, CONNECTOR_SECRET_KEY);
+const adapter = createGa4Adapter({ propertyId });
+const { records, sink } = collectRecords();
+const report = await runStream(adapter, stream, {
+  credentials: { access_token: secret.accessToken }, syncMode: 'incremental',
+  cursorStore, cursorKey: cursorKeyFor(accountId, 'ga4', stream.name),
+  onRecords: toRecordHandler(getMapper('ga4', stream.name)!, ctx, sink),
+});
+const bound = materializeBinding(records, binding, account);
+if (bound.status === 'materialized') await upsertMetricValues(client, bound.rows);
+await recordRun(client, report, { connectedAccountId: accountId, materialized: bound.rows.length });
+```
+
+`needsRefresh(secret.expiresAt)` (CVS-141) gates a `refreshGoogleToken` before the run.
+
+## Status
+
+Built + fixture-tested (mocked `fetch`). **Going live needs CVS-280** (the Google OAuth app +
+`GOOGLE_OAUTH_CLIENT_ID/_SECRET`). The full OAuth-callback + scheduled-sync wiring lands with
+the Connected-Accounts UI (CVS-90) / a sync scheduler.

--- a/src/shared/lib/connectors/adapters/ga4/adapter.ts
+++ b/src/shared/lib/connectors/adapters/ga4/adapter.ts
@@ -1,0 +1,132 @@
+// GA4 Data API adapter (CVS-146). Implements the CVS-142 ConnectorAdapter: fetches one
+// page of a GA4 `runReport` and flattens rows into the shape the CVS-143 GA4 mappers
+// expect. Credentials (access token) are injected per-run by the runtime — the adapter
+// never reads secrets. Property id + report window are bound at creation from the
+// connection. `fetchImpl` is injectable for tests.
+import {
+  ConnectorFetchError,
+  type ConnectorAdapter,
+  type ConnectorErrorClass,
+  type FetchPageInput,
+  type FetchPageResult,
+} from '../../runtime';
+
+const GA4_API = 'https://analyticsdata.googleapis.com/v1beta';
+const DEFAULT_PAGE_SIZE = 10_000;
+const DEFAULT_LOOKBACK_DAYS = 90;
+
+interface HeaderName {
+  name: string;
+}
+interface GaValue {
+  value: string;
+}
+interface GaRow {
+  dimensionValues?: GaValue[];
+  metricValues?: GaValue[];
+}
+interface RunReportResponse {
+  dimensionHeaders?: HeaderName[];
+  metricHeaders?: HeaderName[];
+  rows?: GaRow[];
+  rowCount?: number;
+}
+
+function classifyHttp(status: number): ConnectorErrorClass {
+  if (status === 401 || status === 403) return 'auth';
+  if (status === 429) return 'rate_limit';
+  if (status === 408) return 'timeout';
+  if (status >= 500) return 'transient';
+  return 'permanent';
+}
+
+/** `20260701` (GA4 cursor) → `2026-07-01` for the runReport dateRange. */
+function toDateRange(cursor: string): string {
+  return cursor.length === 8 ? `${cursor.slice(0, 4)}-${cursor.slice(4, 6)}-${cursor.slice(6, 8)}` : cursor;
+}
+
+/** Flatten GA4 rows into the flat objects the CVS-143 mappers consume (one row per metric
+ *  for the page_metrics stream; one row per event for the events stream). */
+function flatten(streamName: string, res: RunReportResponse): unknown[] {
+  const dimHeaders = res.dimensionHeaders ?? [];
+  const metricHeaders = res.metricHeaders ?? [];
+  const out: unknown[] = [];
+  for (const row of res.rows ?? []) {
+    const dims: Record<string, string> = {};
+    dimHeaders.forEach((h, i) => (dims[h.name] = row.dimensionValues?.[i]?.value ?? ''));
+    if (streamName === 'events') {
+      const idx = Math.max(0, metricHeaders.findIndex((h) => h.name === 'eventCount'));
+      out.push({ date: dims.date, eventName: dims.eventName, eventCount: Number(row.metricValues?.[idx]?.value ?? 0) });
+    } else {
+      metricHeaders.forEach((h, i) =>
+        out.push({ date: dims.date, pagePath: dims.pagePath, metric: h.name, value: Number(row.metricValues?.[i]?.value ?? 0) })
+      );
+    }
+  }
+  return out;
+}
+
+/** Highest `date` dimension seen this page → the incremental cursor for the next run. */
+function maxDate(res: RunReportResponse): string | undefined {
+  const dateIdx = (res.dimensionHeaders ?? []).findIndex((h) => h.name === 'date');
+  if (dateIdx < 0) return undefined;
+  let max: string | undefined;
+  for (const row of res.rows ?? []) {
+    const v = row.dimensionValues?.[dateIdx]?.value;
+    if (v && (!max || v > max)) max = v;
+  }
+  return max;
+}
+
+export interface Ga4AdapterOptions {
+  propertyId: string; // GA4 property id (from the connection's source_account_id)
+  pageSize?: number;
+  lookbackDays?: number;
+  fetchImpl?: typeof fetch;
+}
+
+/** Create a GA4 ConnectorAdapter for one connected property. */
+export function createGa4Adapter(opts: Ga4AdapterOptions): ConnectorAdapter {
+  const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
+  const lookbackDays = opts.lookbackDays ?? DEFAULT_LOOKBACK_DAYS;
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  return {
+    connectorId: 'ga4',
+    async fetchPage(input: FetchPageInput): Promise<FetchPageResult> {
+      const dims = input.stream.default_dimensions ?? (input.stream.name === 'events' ? ['date', 'eventName'] : ['date', 'pagePath']);
+      const metrics = input.stream.default_metrics ?? (input.stream.name === 'events' ? ['eventCount'] : ['screenPageViews', 'sessions']);
+      const offset = input.pageToken ? Number(input.pageToken) : 0;
+      const startDate = input.syncMode === 'incremental' && input.cursor ? toDateRange(input.cursor) : `${lookbackDays}daysAgo`;
+
+      const body = {
+        dateRanges: [{ startDate, endDate: 'today' }],
+        dimensions: dims.map((name) => ({ name })),
+        metrics: metrics.map((name) => ({ name })),
+        limit: pageSize,
+        offset,
+        orderBys: [{ dimension: { dimensionName: 'date' } }],
+        keepEmptyRows: false,
+      };
+
+      const propPath = opts.propertyId.startsWith('properties/') ? opts.propertyId : `properties/${opts.propertyId}`;
+      const res = await doFetch(`${GA4_API}/${propPath}:runReport`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${input.credentials.access_token ?? ''}`, 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: input.signal,
+      });
+      if (!res.ok) throw new ConnectorFetchError(classifyHttp(res.status), `GA4 runReport failed (${res.status})`);
+
+      const json = (await res.json()) as RunReportResponse;
+      const records = flatten(input.stream.name, json);
+      const rowCount = json.rowCount ?? json.rows?.length ?? 0;
+      const nextOffset = offset + pageSize;
+      return {
+        records,
+        nextPageToken: nextOffset < rowCount ? String(nextOffset) : undefined,
+        cursor: maxDate(json) ?? input.cursor,
+      };
+    },
+  };
+}

--- a/src/shared/lib/connectors/adapters/ga4/ga4.test.ts
+++ b/src/shared/lib/connectors/adapters/ga4/ga4.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { StreamManifest } from '../../manifests';
+import type { FetchPageInput } from '../../runtime';
+import { getMapper, normalizeRecords, type NormalizationContext } from '../../normalize';
+import { createGa4Adapter } from './adapter';
+import { GA4_SCOPE, buildGoogleAuthUrl, exchangeGoogleCode, refreshGoogleToken } from './oauth';
+
+const pageStream: StreamManifest = {
+  name: 'page_metrics', display_name: 'Page metrics', canonical_schema: 'page_metric', cursor_field: 'date',
+  supported_sync_modes: ['full_refresh', 'incremental'], default_dimensions: ['date', 'pagePath'], default_metrics: ['screenPageViews', 'sessions'],
+};
+const eventStream: StreamManifest = {
+  name: 'events', display_name: 'Events', canonical_schema: 'analytics_event', cursor_field: 'date',
+  supported_sync_modes: ['full_refresh', 'incremental'], default_dimensions: ['date', 'eventName'], default_metrics: ['eventCount'],
+};
+
+const input = (stream: StreamManifest, over: Partial<FetchPageInput> = {}): FetchPageInput => ({
+  stream, syncMode: 'incremental', credentials: { access_token: 'tok' }, signal: new AbortController().signal, ...over,
+});
+
+const okFetch = (body: unknown, status = 200) =>
+  vi.fn(async () => ({ ok: status < 400, status, json: async () => body }) as unknown as Response);
+
+/** Read a recorded fetch call as [url, init] (vi.fn infers no params, so cast). */
+const callOf = (f: ReturnType<typeof okFetch>, i = 0) => f.mock.calls[i] as unknown as [string, RequestInit];
+
+const PAGE_RESPONSE = {
+  dimensionHeaders: [{ name: 'date' }, { name: 'pagePath' }],
+  metricHeaders: [{ name: 'screenPageViews' }, { name: 'sessions' }],
+  rows: [{ dimensionValues: [{ value: '20260701' }, { value: '/pricing' }], metricValues: [{ value: '1240' }, { value: '300' }] }],
+  rowCount: 1,
+};
+
+describe('GA4 OAuth', () => {
+  it('builds a consent URL with offline access + read-only scope', () => {
+    const u = buildGoogleAuthUrl({ clientId: 'cid', redirectUri: 'https://app/cb', state: 'st' });
+    expect(u).toContain('client_id=cid');
+    expect(u).toContain('access_type=offline');
+    expect(u).toContain('state=st');
+    expect(decodeURIComponent(u)).toContain(GA4_SCOPE);
+  });
+
+  it('exchanges a code for tokens', async () => {
+    const f = okFetch({ access_token: 'at1', refresh_token: 'rt1', expires_in: 3599, token_type: 'Bearer' });
+    const t = await exchangeGoogleCode({ code: 'c', clientId: 'id', clientSecret: 'sec', redirectUri: 'https://app/cb' }, f);
+    expect(t).toMatchObject({ accessToken: 'at1', refreshToken: 'rt1', tokenType: 'Bearer' });
+    expect(t.expiresAt).toBeTruthy();
+    expect(String(callOf(f)[1].body)).toContain('grant_type=authorization_code');
+  });
+
+  it('refreshes an access token', async () => {
+    const f = okFetch({ access_token: 'at2', expires_in: 3599 });
+    const t = await refreshGoogleToken({ refreshToken: 'rt1', clientId: 'id', clientSecret: 'sec' }, f);
+    expect(t.accessToken).toBe('at2');
+    expect(String(callOf(f)[1].body)).toContain('grant_type=refresh_token');
+  });
+
+  it('throws on a token error', async () => {
+    await expect(exchangeGoogleCode({ code: 'c', clientId: 'i', clientSecret: 's', redirectUri: 'r' }, okFetch({}, 400))).rejects.toThrow(/token endpoint/);
+  });
+});
+
+describe('GA4 adapter — fetchPage', () => {
+  it('flattens page_metrics into one row per metric', async () => {
+    const adapter = createGa4Adapter({ propertyId: 'properties/123', fetchImpl: okFetch(PAGE_RESPONSE) });
+    const res = await adapter.fetchPage(input(pageStream));
+    expect(res.records).toEqual([
+      { date: '20260701', pagePath: '/pricing', metric: 'screenPageViews', value: 1240 },
+      { date: '20260701', pagePath: '/pricing', metric: 'sessions', value: 300 },
+    ]);
+    expect(res.cursor).toBe('20260701');
+    expect(res.nextPageToken).toBeUndefined();
+  });
+
+  it('flattens events into one row per event', async () => {
+    const body = { dimensionHeaders: [{ name: 'date' }, { name: 'eventName' }], metricHeaders: [{ name: 'eventCount' }], rows: [{ dimensionValues: [{ value: '20260701' }, { value: 'sign_up' }], metricValues: [{ value: '42' }] }], rowCount: 1 };
+    const adapter = createGa4Adapter({ propertyId: 'properties/1', fetchImpl: okFetch(body) });
+    const res = await adapter.fetchPage(input(eventStream));
+    expect(res.records).toEqual([{ date: '20260701', eventName: 'sign_up', eventCount: 42 }]);
+  });
+
+  it('paginates via offset when more rows remain', async () => {
+    const adapter = createGa4Adapter({ propertyId: 'p', pageSize: 1, fetchImpl: okFetch({ ...PAGE_RESPONSE, rowCount: 2 }) });
+    const res = await adapter.fetchPage(input(pageStream));
+    expect(res.nextPageToken).toBe('1');
+  });
+
+  it('classifies a 401 as an auth error (so the runtime surfaces needs_reconnect)', async () => {
+    const adapter = createGa4Adapter({ propertyId: 'p', fetchImpl: okFetch({}, 401) });
+    await expect(adapter.fetchPage(input(pageStream))).rejects.toMatchObject({ class: 'auth' });
+  });
+
+  it('sends the property runReport request with a bearer token', async () => {
+    const f = okFetch(PAGE_RESPONSE);
+    await createGa4Adapter({ propertyId: 'properties/999', fetchImpl: f }).fetchPage(input(pageStream));
+    const [url, init] = callOf(f);
+    expect(url).toBe('https://analyticsdata.googleapis.com/v1beta/properties/999:runReport');
+    expect((init.headers as Record<string, string>).authorization).toBe('Bearer tok');
+  });
+});
+
+describe('GA4 adapter → CVS-143 mapper → canonical (end-to-end)', () => {
+  it('adapter rows normalize into valid page_metric records', async () => {
+    const adapter = createGa4Adapter({ propertyId: 'p', fetchImpl: okFetch(PAGE_RESPONSE) });
+    const { records } = await adapter.fetchPage(input(pageStream));
+    const mapper = getMapper('ga4', 'page_metrics');
+    expect(mapper).toBeDefined();
+    const ctx: NormalizationContext = { source: 'ga4', sourceAccountId: 'properties/123', workspaceId: 'ws', connectorVersion: 'ga4@1.0.0', observedAt: '2026-07-02T00:00:00Z' };
+    const report = normalizeRecords(records, mapper!, ctx);
+    expect(report.rejectedCount).toBe(0);
+    expect(report.accepted.map((r) => r.schema)).toEqual(['page_metric', 'page_metric']);
+    if (report.accepted[0].schema === 'page_metric') expect(report.accepted[0].attributes.value).toBe(1240);
+  });
+});

--- a/src/shared/lib/connectors/adapters/ga4/index.ts
+++ b/src/shared/lib/connectors/adapters/ga4/index.ts
@@ -1,0 +1,11 @@
+// GA4 connector (CVS-146): OAuth 2.0 + a Data API adapter over the CVS-142 runtime.
+// The adapter's flat rows feed the CVS-143 GA4 mappers (`ga4:page_metrics`, `ga4:events`).
+// See docs/data/connector-ga4.md.
+export { createGa4Adapter, type Ga4AdapterOptions } from './adapter';
+export {
+  buildGoogleAuthUrl,
+  exchangeGoogleCode,
+  refreshGoogleToken,
+  GA4_SCOPE,
+  type GoogleTokens,
+} from './oauth';

--- a/src/shared/lib/connectors/adapters/ga4/oauth.ts
+++ b/src/shared/lib/connectors/adapters/ga4/oauth.ts
@@ -1,0 +1,94 @@
+// Google OAuth 2.0 for the GA4 connector (CVS-146). Standard auth-code flow with
+// offline access so we get a refresh token. Client id/secret come from server env
+// (GOOGLE_OAUTH_CLIENT_ID / _SECRET — owner setup CVS-280); the returned tokens are
+// stored encrypted via the connection layer (CVS-141). `fetchImpl` is injectable for tests.
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+/** Read-only GA4 Data API scope (least privilege). */
+export const GA4_SCOPE = 'https://www.googleapis.com/auth/analytics.readonly';
+
+type FetchImpl = typeof fetch;
+
+/** Tokens shaped for the CVS-141 secret store (`AccountSecret`). */
+export interface GoogleTokens {
+  accessToken: string;
+  refreshToken?: string;
+  tokenType?: string;
+  /** ISO-8601 expiry, computed from `expires_in`. */
+  expiresAt?: string;
+}
+
+function expiryFrom(expiresIn: unknown): string | undefined {
+  const secs = typeof expiresIn === 'number' ? expiresIn : Number(expiresIn);
+  return Number.isFinite(secs) ? new Date(Date.now() + secs * 1000).toISOString() : undefined;
+}
+
+/** Build the consent-screen URL to start the connect flow. */
+export function buildGoogleAuthUrl(opts: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  scope?: string;
+}): string {
+  const params = new URLSearchParams({
+    client_id: opts.clientId,
+    redirect_uri: opts.redirectUri,
+    response_type: 'code',
+    scope: opts.scope ?? GA4_SCOPE,
+    access_type: 'offline', // → refresh token
+    prompt: 'consent',
+    include_granted_scopes: 'true',
+    state: opts.state,
+  });
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+}
+
+async function postToken(body: URLSearchParams, fetchImpl: FetchImpl): Promise<GoogleTokens> {
+  const res = await fetchImpl(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!res.ok) throw new Error(`Google token endpoint failed (${res.status})`);
+  const j = (await res.json()) as Record<string, unknown>;
+  return {
+    accessToken: String(j.access_token ?? ''),
+    refreshToken: j.refresh_token ? String(j.refresh_token) : undefined,
+    tokenType: j.token_type ? String(j.token_type) : undefined,
+    expiresAt: expiryFrom(j.expires_in),
+  };
+}
+
+/** Exchange the authorization code (from the callback) for tokens. */
+export function exchangeGoogleCode(
+  opts: { code: string; clientId: string; clientSecret: string; redirectUri: string },
+  fetchImpl: FetchImpl = fetch
+): Promise<GoogleTokens> {
+  return postToken(
+    new URLSearchParams({
+      code: opts.code,
+      client_id: opts.clientId,
+      client_secret: opts.clientSecret,
+      redirect_uri: opts.redirectUri,
+      grant_type: 'authorization_code',
+    }),
+    fetchImpl
+  );
+}
+
+/** Refresh an access token. Google usually omits a new refresh token — keep the old one. */
+export function refreshGoogleToken(
+  opts: { refreshToken: string; clientId: string; clientSecret: string },
+  fetchImpl: FetchImpl = fetch
+): Promise<GoogleTokens> {
+  return postToken(
+    new URLSearchParams({
+      refresh_token: opts.refreshToken,
+      client_id: opts.clientId,
+      client_secret: opts.clientSecret,
+      grant_type: 'refresh_token',
+    }),
+    fetchImpl
+  );
+}

--- a/src/shared/lib/connectors/normalize/registry.ts
+++ b/src/shared/lib/connectors/normalize/registry.ts
@@ -10,7 +10,7 @@ import type { Mapper } from './types';
 
 export const MAPPERS: Record<string, Mapper> = {
   'stripe:payment_intents': mapStripePayment,
-  'ga4:page_report': mapGa4PageMetric,
+  'ga4:page_metrics': mapGa4PageMetric, // stream name matches the CVS-140 GA4 manifest
   'ga4:events': mapGa4Event,
   'woocommerce:orders': mapWooOrder,
   'shopify:orders': mapShopifyOrder,


### PR DESCRIPTION
Builds **CVS-146** — the first native connector: **GA4** via the Data API, over the shared runtime. Proves the full fetch → normalize → bind path for an analytics source. Built + **fixture-tested** (mocked `fetch`).

⚡ **Going live needs owner setup — CVS-280** (Google OAuth app + `GOOGLE_OAUTH_CLIENT_ID/_SECRET`).

## What
- **`oauth.ts`** — Google OAuth2 auth-code flow (`access_type=offline` → refresh token, scope `analytics.readonly`). `buildGoogleAuthUrl` / `exchangeGoogleCode` / `refreshGoogleToken`; tokens shaped for the CVS-141 secret store.
- **`adapter.ts`** — `createGa4Adapter({ propertyId })` → a CVS-142 `ConnectorAdapter`. `fetchPage` runs a `runReport` (dims/metrics from the manifest stream), classifies HTTP errors (401/403→`auth`, 429→`rate_limit`, 5xx→`transient`) so the runtime retries right, paginates by offset, advances the cursor by max date. Flattens `page_metrics` → one row per metric, `events` → one per event.
- Fixed the CVS-143 mapper key `ga4:page_report` → **`ga4:page_metrics`** to match the CVS-140 manifest.
- **10 tests** including an adapter → mapper → canonical **end-to-end**; doc `docs/data/connector-ga4.md`.

## Acceptance criteria
- [x] GA4 manifest streams (page_metrics/events) fetched + normalized into `page_metric`/`analytics_event`
- [x] OAuth (authenticate + refresh) implemented
- [x] Errors classified for retry/health; incremental cursor
- [x] Credentials injected (adapter never reads secrets)
- [ ] Live end-to-end against a real property — blocked on CVS-280 (owner OAuth app)

Pure code — no DB, no secrets. Green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)