### PR TITLE
feat(connectors): run host — secrets → fetch → normalize → bind into metric_values (CVS-320)

### DIFF
--- a/docs/data/connector-run-host.md
+++ b/docs/data/connector-run-host.md
@@ -1,0 +1,67 @@
+# Connector run host (CVS-320)
+
+The orchestrator that composes the connector layers into one server-side invocation:
+
+```
+secrets (CVS-141) → fetch runtime (CVS-142) → normalize (CVS-143)
+    → bind/materialize (CVS-144) → metric_values, audited by CVS-145
+```
+
+Library: `src/shared/lib/connectors/host/` (SERVER-ONLY — reads decrypted secrets).
+Entrypoint: `supabase/functions/connector-run` (Deno; reuses the library through the
+function's `deno.json` import map + sloppy imports).
+
+## Flow (`runConnectorStream`)
+
+1. Load the `connected_accounts` row; only `connected`/`error` are runnable (`error`
+   heals on a clean run; `revoked`/`pending` are rejected with a readable message).
+2. Resolve the manifest + stream (CVS-140) and the normalizer (`getMapper`).
+3. `resolveCredentials`: decrypt the secret; if the OAuth token is within 60s of
+   expiry, refresh via the connector's registered `TokenRefresher` (`ga4` → Google),
+   persist the rotated token *before* use, and log `connection_refreshed`. Failure
+   → `markConnectionError` + `auth_failed` event + a payload-free `auth` summary.
+4. Build the adapter from `ADAPTER_FACTORIES` (GA4 first; CVS-147+ register here).
+5. `runStream` with `toRecordHandler(mapper, ctx, collectRecords().sink)` — canonical
+   records are held in memory for the run only (locked decision CVS-137: no raw
+   payloads persist).
+6. Load enabled `metric_bindings` for the (account, stream); `materializeBinding`
+   each and upsert `metric_values` (idempotent by `tracked_metric_id, period`).
+   Malformed recipes are skipped and reported, never guessed at.
+7. `recordRun` (CVS-145) + bump `last_synced_at` on success.
+
+**Preview mode** (`preview: true`): capped fetch (default 10 records), in-memory
+cursor, nothing persisted; the normalized sample is returned to the caller only.
+
+## Tables (migration `20260711120000_connector_run_host.sql`)
+
+| Table | Purpose | Write access |
+| --- | --- | --- |
+| `connector_cursors` | one opaque incremental cursor per (account, stream) | service role only (no client policies); workspace read |
+| `metric_bindings` | persisted CVS-144 recipes: stream → tracked metric | workspace-scoped CRUD |
+
+## Edge function
+
+```
+POST /functions/v1/connector-run
+{ "account_id": "…", "stream": "page_metrics", "sync_mode?": "full_refresh",
+  "preview?": true, "max_records?": 10 }
+```
+
+- **User JWT**: caller must be able to see the connected account under RLS
+  ("Sync now"). The run itself uses the service role.
+- **Service-role JWT**: trusted as-is (the CVS-323 scheduler / pg_cron path).
+
+Function secrets: `CONNECTOR_SECRET_KEY` (required), `GOOGLE_OAUTH_CLIENT_ID` /
+`GOOGLE_OAUTH_CLIENT_SECRET` (GA4 refresh). Deploy:
+`npx supabase functions deploy connector-run`.
+
+The function's `deno.json` maps `@/` → `src/`, pins `zod` + `@supabase/supabase-js`
+to esm.sh, and enables `sloppy-imports` so the extensionless repo imports resolve
+under Deno (verified with `deno run`; deploy bundling does not type-check).
+
+## Adding a connector to the host
+
+1. Register an adapter factory in `host/adapters.ts`.
+2. OAuth connectors: register a `TokenRefresher` in `host/credentials.ts`.
+3. Ensure the mapper key `connector:stream` matches the manifest stream name —
+   `normalize.test.ts` has a regression test that cross-checks every key.

--- a/src/shared/lib/connectors/host/adapters.ts
+++ b/src/shared/lib/connectors/host/adapters.ts
@@ -1,0 +1,30 @@
+// Adapter factory registry (CVS-320). Maps a connector id to a factory that builds its
+// CVS-142 ConnectorAdapter from the connected account's metadata. New connectors
+// (CVS-147+) register here; the run host stays connector-agnostic.
+import { createGa4Adapter } from '../adapters/ga4';
+import type { ConnectorAdapter } from '../runtime';
+
+/** The slice of a connected_accounts row a factory needs. */
+export interface AdapterAccount {
+  id: string;
+  connector_id: string;
+  source_account_id: string | null;
+}
+
+export type AdapterFactory = (account: AdapterAccount, fetchImpl?: typeof fetch) => ConnectorAdapter;
+
+export const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
+  ga4: (account, fetchImpl) => {
+    if (!account.source_account_id) {
+      throw new Error('GA4 connection has no property id — reconnect the account');
+    }
+    return createGa4Adapter({ propertyId: account.source_account_id, fetchImpl });
+  },
+};
+
+/** Build the adapter for a connected account, or throw a readable, payload-free error. */
+export function createAdapter(account: AdapterAccount, fetchImpl?: typeof fetch): ConnectorAdapter {
+  const factory = ADAPTER_FACTORIES[account.connector_id];
+  if (!factory) throw new Error(`no adapter registered for connector '${account.connector_id}'`);
+  return factory(account, fetchImpl);
+}

--- a/src/shared/lib/connectors/host/bindings.ts
+++ b/src/shared/lib/connectors/host/bindings.ts
@@ -1,0 +1,69 @@
+// Persisted metric bindings (CVS-320). Loads `metric_bindings` rows into the CVS-144
+// MetricBinding shape so the run host can materialize a stream's records into every
+// bound tracked metric. Rows with a malformed recipe are skipped (payload-free warning
+// left to the caller's run report), never guessed at — silently-wrong numbers are worse
+// than missing ones.
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import type { Aggregation, MetricBinding, MetricRecipe, PeriodGrain } from '../binding';
+
+type Client = SupabaseClient<Database>;
+
+const AGGREGATIONS: readonly Aggregation[] = ['sum', 'count', 'average'];
+const GRAINS: readonly PeriodGrain[] = ['day', 'week', 'month'];
+
+/** Parse a `recipe` jsonb value into a MetricRecipe, or undefined if malformed. */
+export function parseRecipe(value: unknown): MetricRecipe | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const r = value as Record<string, unknown>;
+  if (!AGGREGATIONS.includes(r.aggregation as Aggregation)) return undefined;
+  if (!GRAINS.includes(r.grain as PeriodGrain)) return undefined;
+  const recipe: MetricRecipe = {
+    aggregation: r.aggregation as Aggregation,
+    grain: r.grain as PeriodGrain,
+  };
+  if (typeof r.field === 'string') recipe.field = r.field;
+  if (typeof r.filter === 'object' && r.filter !== null) {
+    const f = r.filter as Record<string, unknown>;
+    if (typeof f.path === 'string' && ['string', 'number', 'boolean'].includes(typeof f.equals)) {
+      recipe.filter = { path: f.path, equals: f.equals as string | number | boolean };
+    }
+  }
+  return recipe;
+}
+
+export interface LoadedBindings {
+  bindings: MetricBinding[];
+  /** Ids of rows whose recipe failed to parse — surfaced payload-free, never executed. */
+  malformedIds: string[];
+}
+
+/** Enabled bindings for one connected account + stream, as CVS-144 MetricBindings. */
+export async function loadBindings(client: Client, accountId: string, stream: string): Promise<LoadedBindings> {
+  const { data, error } = await client
+    .from('metric_bindings')
+    .select('id, connector_id, stream, canonical_schema, recipe, tracked_metric_id, connected_account_id')
+    .eq('connected_account_id', accountId)
+    .eq('stream', stream)
+    .eq('enabled', true);
+  if (error) throw new Error(error.message);
+
+  const bindings: MetricBinding[] = [];
+  const malformedIds: string[] = [];
+  for (const row of data ?? []) {
+    const recipe = parseRecipe(row.recipe);
+    if (!recipe) {
+      malformedIds.push(row.id);
+      continue;
+    }
+    bindings.push({
+      connectorId: row.connector_id,
+      stream: row.stream,
+      canonicalSchema: row.canonical_schema,
+      recipe,
+      targetTrackedMetricId: row.tracked_metric_id,
+      connectedAccountId: row.connected_account_id,
+    });
+  }
+  return { bindings, malformedIds };
+}

--- a/src/shared/lib/connectors/host/credentials.ts
+++ b/src/shared/lib/connectors/host/credentials.ts
@@ -1,0 +1,114 @@
+// SERVER-ONLY credential resolution + token refresh (CVS-320). Before every run:
+// read the encrypted secret (CVS-141), refresh an expiring OAuth token through the
+// provider's refresher, persist the rotated token, and hand the runtime an opaque
+// ConnectorCredentials object. A refresh/auth failure marks the connection `error`
+// (payload-free) and records an `auth_failed` connection event — never a silent zero.
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import { refreshGoogleToken } from '../adapters/ga4';
+import {
+  markConnectionError,
+  needsRefresh,
+  readAccountSecret,
+  storeAccountSecret,
+  type AccountSecret,
+} from '../connections/secrets';
+import { recordConnectionEvent } from '../observability';
+import { ConnectorFetchError, type ConnectorCredentials } from '../runtime';
+
+type ServiceClient = SupabaseClient<Database>;
+
+/** Server env the refreshers draw provider client credentials from. */
+export interface HostEnv {
+  googleClientId?: string;
+  googleClientSecret?: string;
+}
+
+export type TokenRefresher = (
+  secret: AccountSecret,
+  env: HostEnv,
+  fetchImpl: typeof fetch
+) => Promise<AccountSecret>;
+
+async function refreshGoogle(secret: AccountSecret, env: HostEnv, fetchImpl: typeof fetch): Promise<AccountSecret> {
+  if (!secret.refreshToken) throw new Error('no refresh token stored — reconnect the account');
+  if (!env.googleClientId || !env.googleClientSecret) {
+    throw new Error('GOOGLE_OAUTH_CLIENT_ID / _SECRET not configured');
+  }
+  const tokens = await refreshGoogleToken(
+    { refreshToken: secret.refreshToken, clientId: env.googleClientId, clientSecret: env.googleClientSecret },
+    fetchImpl
+  );
+  return {
+    accessToken: tokens.accessToken,
+    // Google usually omits a new refresh token on refresh — keep the old one.
+    refreshToken: tokens.refreshToken ?? secret.refreshToken,
+    tokenType: tokens.tokenType ?? secret.tokenType,
+    expiresAt: tokens.expiresAt ?? null,
+  };
+}
+
+/** Provider refreshers keyed by connector id. OAuth connectors register here (CVS-146+). */
+export const TOKEN_REFRESHERS: Record<string, TokenRefresher> = {
+  ga4: refreshGoogle,
+};
+
+export interface ResolveCredentialsInput {
+  accountId: string;
+  connectorId: string;
+  workspaceId?: string;
+  secretKey: string; // CONNECTOR_SECRET_KEY (base64)
+  env: HostEnv;
+  fetchImpl?: typeof fetch;
+  nowMs?: number;
+}
+
+/**
+ * Resolve run credentials for a connected account: decrypt the stored secret,
+ * refresh-and-rotate an expiring OAuth token, and return the opaque credentials
+ * the adapter consumes (`access_token` or `api_key` — matching the adapter contract).
+ * Throws a classified `auth` ConnectorFetchError after marking the connection.
+ */
+export async function resolveCredentials(
+  service: ServiceClient,
+  input: ResolveCredentialsInput
+): Promise<ConnectorCredentials> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const fail = async (detail: string): Promise<never> => {
+    await markConnectionError(service, input.accountId, detail);
+    await recordConnectionEvent(service, {
+      connectorId: input.connectorId,
+      connectedAccountId: input.accountId,
+      event: 'auth_failed',
+      errorClass: 'auth',
+      workspaceId: input.workspaceId,
+    });
+    throw new ConnectorFetchError('auth', detail);
+  };
+
+  let secret = await readAccountSecret(service, input.accountId, input.secretKey);
+  if (!secret) return fail('no credential stored for this connection');
+
+  if (secret.apiKey) return { api_key: secret.apiKey };
+
+  if (needsRefresh(secret.expiresAt, 60, input.nowMs)) {
+    const refresher = TOKEN_REFRESHERS[input.connectorId];
+    if (!refresher) return fail('access token expired and no refresher is registered');
+    try {
+      secret = await refresher(secret, input.env, fetchImpl);
+    } catch (err) {
+      return fail(`token refresh failed: ${err instanceof Error ? err.message : 'unknown error'}`);
+    }
+    // Rotated token is persisted before use so a crash mid-run never strands it.
+    await storeAccountSecret(service, input.accountId, secret, input.secretKey);
+    await recordConnectionEvent(service, {
+      connectorId: input.connectorId,
+      connectedAccountId: input.accountId,
+      event: 'connection_refreshed',
+      workspaceId: input.workspaceId,
+    });
+  }
+
+  if (!secret.accessToken) return fail('no access token stored for this connection');
+  return { access_token: secret.accessToken };
+}

--- a/src/shared/lib/connectors/host/cursorStore.ts
+++ b/src/shared/lib/connectors/host/cursorStore.ts
@@ -1,0 +1,54 @@
+// SERVER-ONLY DB-backed cursor store (CVS-320). Persists the CVS-142 runtime's opaque
+// incremental cursors in `connector_cursors` so a run resumes across invocations.
+// Written with a SERVICE-ROLE client only — the table has no client write policies;
+// workspace members can read for debug surfaces. Payload-free by construction.
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import type { CursorStore } from '../runtime';
+
+type ServiceClient = SupabaseClient<Database>;
+
+/** Split a `${accountId}:${connectorId}:${stream}` cursor key (see cursorKeyFor). */
+function parseKey(key: string): { accountId: string; connectorId: string; stream: string } {
+  const first = key.indexOf(':');
+  const second = key.indexOf(':', first + 1);
+  if (first < 0 || second < 0) throw new Error(`invalid cursor key: expected accountId:connectorId:stream`);
+  return { accountId: key.slice(0, first), connectorId: key.slice(first + 1, second), stream: key.slice(second + 1) };
+}
+
+/** CursorStore over `connector_cursors`, scoped to one account's workspace/owner. */
+export class SupabaseCursorStore implements CursorStore {
+  constructor(
+    private readonly service: ServiceClient,
+    private readonly scope: { workspaceId: string | null; createdBy: string | null }
+  ) {}
+
+  async read(key: string): Promise<string | undefined> {
+    const { accountId, stream } = parseKey(key);
+    const { data, error } = await this.service
+      .from('connector_cursors')
+      .select('cursor')
+      .eq('connected_account_id', accountId)
+      .eq('stream', stream)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    return data?.cursor ?? undefined;
+  }
+
+  async write(key: string, cursor: string): Promise<void> {
+    const { accountId, connectorId, stream } = parseKey(key);
+    const { error } = await this.service.from('connector_cursors').upsert(
+      {
+        connected_account_id: accountId,
+        connector_id: connectorId,
+        stream,
+        cursor,
+        workspace_id: this.scope.workspaceId,
+        created_by: this.scope.createdBy,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'connected_account_id,stream' }
+    );
+    if (error) throw new Error(error.message);
+  }
+}

--- a/src/shared/lib/connectors/host/host.test.ts
+++ b/src/shared/lib/connectors/host/host.test.ts
@@ -1,0 +1,334 @@
+// Run host tests (CVS-320): the composed pipeline over a fake Supabase client —
+// secrets (real AES-GCM) → GA4 adapter (mock fetch) → normalize → bind → metric_values,
+// plus cursor persistence across runs, token refresh, auth failure, and preview mode.
+import { describe, it, expect, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import { storeAccountSecret } from '../connections/secrets';
+import { cursorKeyFor } from '../runtime';
+import { parseRecipe } from './bindings';
+import { SupabaseCursorStore } from './cursorStore';
+import { resolveCredentials } from './credentials';
+import { runConnectorStream } from './runConnector';
+
+const SECRET_KEY = btoa(String.fromCharCode(...new Array(32).fill(7)));
+
+// --- minimal fake Supabase client (tables in memory, thenable builders) ------------
+type Row = Record<string, unknown>;
+
+class FakeQuery {
+  private filters: [string, unknown][] = [];
+  private op: 'select' | 'insert' | 'upsert' | 'update' | 'delete' = 'select';
+  private payload: unknown;
+  private conflictKeys: string[] = [];
+
+  constructor(
+    private readonly tables: Record<string, Row[]>,
+    private readonly table: string
+  ) {}
+
+  select(): this { return this; }
+  eq(col: string, val: unknown): this { this.filters.push([col, val]); return this; }
+  in(): this { return this; }
+  order(): this { return this; }
+  limit(): this { return this; }
+  insert(rows: unknown): this { this.op = 'insert'; this.payload = rows; return this; }
+  update(patch: unknown): this { this.op = 'update'; this.payload = patch; return this; }
+  delete(): this { this.op = 'delete'; return this; }
+  upsert(rows: unknown, opts?: { onConflict?: string }): this {
+    this.op = 'upsert';
+    this.payload = rows;
+    this.conflictKeys = (opts?.onConflict ?? '').split(',').filter(Boolean);
+    return this;
+  }
+
+  private matching(): Row[] {
+    return this.tables[this.table].filter((r) => this.filters.every(([c, v]) => r[c] === v));
+  }
+
+  private exec(): { data: Row[] | null; error: null } {
+    const rows = this.tables[this.table];
+    if (this.op === 'select') return { data: this.matching(), error: null };
+    if (this.op === 'insert') {
+      const arr = Array.isArray(this.payload) ? this.payload : [this.payload];
+      rows.push(...arr.map((r) => ({ ...(r as Row) })));
+      return { data: null, error: null };
+    }
+    if (this.op === 'upsert') {
+      const arr = Array.isArray(this.payload) ? this.payload : [this.payload];
+      for (const raw of arr) {
+        const row = raw as Row;
+        const idx = this.conflictKeys.length
+          ? rows.findIndex((r) => this.conflictKeys.every((k) => r[k] === row[k]))
+          : -1;
+        if (idx >= 0) rows[idx] = { ...rows[idx], ...row };
+        else rows.push({ ...row });
+      }
+      return { data: null, error: null };
+    }
+    if (this.op === 'update') {
+      for (const r of this.matching()) Object.assign(r, this.payload as Row);
+      return { data: null, error: null };
+    }
+    // delete
+    this.tables[this.table] = rows.filter((r) => !this.filters.every(([c, v]) => r[c] === v));
+    return { data: null, error: null };
+  }
+
+  maybeSingle(): Promise<{ data: Row | null; error: null }> {
+    const { data } = this.exec();
+    return Promise.resolve({ data: data?.[0] ?? null, error: null });
+  }
+  single(): Promise<{ data: Row | null; error: null }> { return this.maybeSingle(); }
+  then<T>(res: (v: { data: Row[] | null; error: null }) => T, rej?: (e: unknown) => T): Promise<T> {
+    return Promise.resolve(this.exec()).then(res, rej);
+  }
+}
+
+function fakeDb(): { client: SupabaseClient<Database>; tables: Record<string, Row[]> } {
+  const tables: Record<string, Row[]> = {
+    connected_accounts: [],
+    connected_account_secrets: [],
+    connector_cursors: [],
+    metric_bindings: [],
+    metric_values: [],
+    connector_runs: [],
+  };
+  const client = { from: (table: string) => new FakeQuery(tables, table) } as unknown as SupabaseClient<Database>;
+  return { client, tables };
+}
+
+// --- fixtures -----------------------------------------------------------------------
+const ACCOUNT = {
+  id: 'acc-1',
+  created_by: 'user_1',
+  workspace_id: 'org_1',
+  connector_id: 'ga4',
+  auth_type: 'oauth2',
+  source_account_id: 'properties/123',
+  source_account_label: 'Metrimap GA4',
+  granted_scopes: [],
+  status: 'connected',
+  status_detail: null,
+  last_synced_at: null,
+  last_query_at: null,
+  revoked_at: null,
+  created_at: '2026-07-01T00:00:00.000Z',
+  updated_at: '2026-07-01T00:00:00.000Z',
+};
+
+const BINDING_ROW = {
+  id: 'bind-1',
+  created_by: 'user_1',
+  workspace_id: 'org_1',
+  connected_account_id: 'acc-1',
+  connector_id: 'ga4',
+  stream: 'page_metrics',
+  canonical_schema: 'page_metric',
+  recipe: { aggregation: 'sum', grain: 'day', field: 'attributes.value', filter: { path: 'attributes.metric', equals: 'screenPageViews' } },
+  tracked_metric_id: 'tm-1',
+  enabled: true,
+};
+
+const GA4_RESPONSE = {
+  dimensionHeaders: [{ name: 'date' }, { name: 'pagePath' }],
+  metricHeaders: [{ name: 'screenPageViews' }, { name: 'sessions' }],
+  rows: [
+    { dimensionValues: [{ value: '20260701' }, { value: '/pricing' }], metricValues: [{ value: '1240' }, { value: '300' }] },
+    { dimensionValues: [{ value: '20260702' }, { value: '/pricing' }], metricValues: [{ value: '900' }, { value: '210' }] },
+  ],
+  rowCount: 2,
+};
+
+const TOKENS = { access_token: 'fresh-at', expires_in: 3599, token_type: 'Bearer' };
+
+/** Routes Google token refreshes and GA4 runReport calls; records GA4 request bodies. */
+function routedFetch(opts: { tokenStatus?: number } = {}) {
+  const ga4Bodies: Record<string, unknown>[] = [];
+  const impl = vi.fn(async (url: unknown, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes('oauth2.googleapis.com')) {
+      const status = opts.tokenStatus ?? 200;
+      return { ok: status < 400, status, json: async () => TOKENS } as unknown as Response;
+    }
+    ga4Bodies.push(JSON.parse(String(init?.body ?? '{}')));
+    return { ok: true, status: 200, json: async () => GA4_RESPONSE } as unknown as Response;
+  });
+  return { impl: impl as unknown as typeof fetch, ga4Bodies };
+}
+
+async function seedAccount(
+  client: SupabaseClient<Database>,
+  tables: Record<string, Row[]>,
+  secret: { accessToken?: string; refreshToken?: string; apiKey?: string; expiresAt?: string | null }
+) {
+  tables.connected_accounts.push({ ...ACCOUNT });
+  await storeAccountSecret(client, ACCOUNT.id, secret, SECRET_KEY);
+  tables.connected_accounts[0].status = 'connected'; // storeAccountSecret flips it anyway
+}
+
+const FUTURE = new Date(Date.now() + 3600_000).toISOString();
+const PAST = new Date(Date.now() - 3600_000).toISOString();
+
+// --- tests ---------------------------------------------------------------------------
+describe('parseRecipe', () => {
+  it('parses a full recipe and rejects malformed ones', () => {
+    expect(parseRecipe(BINDING_ROW.recipe)).toEqual(BINDING_ROW.recipe);
+    expect(parseRecipe({ aggregation: 'sum' })).toBeUndefined();
+    expect(parseRecipe({ aggregation: 'max', grain: 'day' })).toBeUndefined();
+    expect(parseRecipe(null)).toBeUndefined();
+    expect(parseRecipe({ aggregation: 'count', grain: 'week' })).toEqual({ aggregation: 'count', grain: 'week' });
+  });
+});
+
+describe('SupabaseCursorStore', () => {
+  it('round-trips a cursor keyed by account+stream', async () => {
+    const { client, tables } = fakeDb();
+    const store = new SupabaseCursorStore(client, { workspaceId: 'org_1', createdBy: 'user_1' });
+    const key = cursorKeyFor('acc-1', 'ga4', 'page_metrics');
+    expect(await store.read(key)).toBeUndefined();
+    await store.write(key, '20260702');
+    expect(await store.read(key)).toBe('20260702');
+    await store.write(key, '20260703'); // upsert replaces
+    expect(tables.connector_cursors).toHaveLength(1);
+    expect(tables.connector_cursors[0]).toMatchObject({ cursor: '20260703', workspace_id: 'org_1' });
+  });
+});
+
+describe('resolveCredentials', () => {
+  it('returns an api_key credential without refreshing', async () => {
+    const { client, tables } = fakeDb();
+    await seedAccount(client, tables, { apiKey: 'sk-live-x', expiresAt: null });
+    const creds = await resolveCredentials(client, {
+      accountId: ACCOUNT.id, connectorId: 'ga4', secretKey: SECRET_KEY, env: {},
+    });
+    expect(creds).toEqual({ api_key: 'sk-live-x' });
+  });
+
+  it('refreshes an expiring OAuth token, persists the rotation, and logs the event', async () => {
+    const { client, tables } = fakeDb();
+    await seedAccount(client, tables, { accessToken: 'old-at', refreshToken: 'rt-1', expiresAt: PAST });
+    const { impl } = routedFetch();
+    const creds = await resolveCredentials(client, {
+      accountId: ACCOUNT.id, connectorId: 'ga4', secretKey: SECRET_KEY,
+      env: { googleClientId: 'cid', googleClientSecret: 'sec' }, fetchImpl: impl,
+    });
+    expect(creds).toEqual({ access_token: 'fresh-at' });
+    expect(tables.connector_runs.some((r) => r.event === 'connection_refreshed')).toBe(true);
+    // rotated token was persisted (encrypted — decrypt via another resolve, no refresh now)
+    const again = await resolveCredentials(client, {
+      accountId: ACCOUNT.id, connectorId: 'ga4', secretKey: SECRET_KEY, env: {},
+    });
+    expect(again).toEqual({ access_token: 'fresh-at' });
+  });
+
+  it('marks the connection error + records auth_failed when refresh fails', async () => {
+    const { client, tables } = fakeDb();
+    await seedAccount(client, tables, { accessToken: 'old-at', refreshToken: 'rt-1', expiresAt: PAST });
+    const { impl } = routedFetch({ tokenStatus: 500 });
+    await expect(
+      resolveCredentials(client, {
+        accountId: ACCOUNT.id, connectorId: 'ga4', secretKey: SECRET_KEY,
+        env: { googleClientId: 'cid', googleClientSecret: 'sec' }, fetchImpl: impl,
+      })
+    ).rejects.toThrow(/refresh failed/);
+    expect(tables.connected_accounts[0].status).toBe('error');
+    expect(tables.connector_runs.some((r) => r.event === 'auth_failed')).toBe(true);
+  });
+});
+
+describe('runConnectorStream (full pipeline)', () => {
+  it('fetches, normalizes, binds, and persists metric values + cursor + audit row', async () => {
+    const { client, tables } = fakeDb();
+    await seedAccount(client, tables, { accessToken: 'at', expiresAt: FUTURE });
+    tables.metric_bindings.push({ ...BINDING_ROW });
+    const { impl } = routedFetch();
+
+    const summary = await runConnectorStream(
+      { service: client, secretKey: SECRET_KEY, fetchImpl: impl },
+      { accountId: ACCOUNT.id, stream: 'page_metrics' }
+    );
+
+    expect(summary.ok).toBe(true);
+    expect(summary.bindingsApplied).toBe(1);
+    expect(summary.materialized).toBe(2);
+    expect(tables.metric_values).toEqual([
+      expect.objectContaining({ tracked_metric_id: 'tm-1', period: '2026-07-01', value: 1240 }),
+      expect.objectContaining({ tracked_metric_id: 'tm-1', period: '2026-07-02', value: 900 }),
+    ]);
+    expect(String(tables.metric_values[0].source)).toContain('connector=ga4');
+    expect(tables.connector_cursors[0]).toMatchObject({ connected_account_id: 'acc-1', stream: 'page_metrics', cursor: '20260702' });
+    expect(tables.connector_runs.some((r) => r.event === 'run_finished' && r.materialized === 2)).toBe(true);
+    expect(tables.connected_accounts[0].last_synced_at).toBeTruthy();
+  });
+
+  it('resumes from the persisted cursor and stays idempotent on re-run', async () => {
+    const { client, tables } = fakeDb();
+    await seedAccount(client, tables, { accessToken: 'at', expiresAt: FUTURE });
+    tables.metric_bindings.push({ ...BINDING_ROW });
+    const { impl, ga4Bodies } = routedFetch();
+
+    const deps = { service: client, secretKey: SECRET_KEY, fetchImpl: impl };
+    await runConnectorStream(deps, { accountId: ACCOUNT.id, stream: 'page_metrics' });
+    await runConnectorStream(deps, { accountId: ACCOUNT.id, stream: 'page_metrics' });
+
+    expect(ga4Bodies[0].dateRanges).toEqual([{ startDate: '90daysAgo', endDate: 'today' }]);
+    expect(ga4Bodies[1].dateRanges).toEqual([{ startDate: '2026-07-02', endDate: 'today' }]); // resumed
+    expect(tables.metric_values).toHaveLength(2); // upsert by (metric, period) — no duplicates
+    expect(tables.connector_cursors).toHaveLength(1);
+  });
+
+  it('preview mode returns a sample and persists nothing', async () => {
+    const { client, tables } = fakeDb();
+    await seedAccount(client, tables, { accessToken: 'at', expiresAt: FUTURE });
+    tables.metric_bindings.push({ ...BINDING_ROW });
+    const { impl } = routedFetch();
+
+    const summary = await runConnectorStream(
+      { service: client, secretKey: SECRET_KEY, fetchImpl: impl },
+      { accountId: ACCOUNT.id, stream: 'page_metrics', preview: true, maxRecords: 3 }
+    );
+
+    expect(summary.ok).toBe(true);
+    expect(summary.sample).toHaveLength(3); // capped fetch, normalized in memory
+    expect(summary.sample?.[0]).toMatchObject({ schema: 'page_metric', source: 'ga4' });
+    expect(tables.metric_values).toHaveLength(0);
+    expect(tables.connector_cursors).toHaveLength(0);
+    expect(tables.connector_runs.filter((r) => r.event === 'run_finished')).toHaveLength(0);
+  });
+
+  it('surfaces auth failure as a payload-free summary and marks the connection', async () => {
+    const { client, tables } = fakeDb();
+    await seedAccount(client, tables, { accessToken: 'old', refreshToken: 'rt', expiresAt: PAST });
+    const { impl } = routedFetch({ tokenStatus: 401 });
+
+    const summary = await runConnectorStream(
+      { service: client, secretKey: SECRET_KEY, env: { googleClientId: 'cid', googleClientSecret: 'sec' }, fetchImpl: impl },
+      { accountId: ACCOUNT.id, stream: 'page_metrics' }
+    );
+
+    expect(summary.ok).toBe(false);
+    expect(summary.errorClass).toBe('auth');
+    expect(summary.error).not.toContain('old'); // never echoes token material
+    expect(tables.connected_accounts[0].status).toBe('error');
+    expect(tables.metric_values).toHaveLength(0);
+  });
+
+  it('rejects unknown streams and unregistered connectors with readable errors', async () => {
+    const { client, tables } = fakeDb();
+    await seedAccount(client, tables, { accessToken: 'at', expiresAt: FUTURE });
+    const bad = await runConnectorStream(
+      { service: client, secretKey: SECRET_KEY },
+      { accountId: ACCOUNT.id, stream: 'nope' }
+    );
+    expect(bad.ok).toBe(false);
+    expect(bad.error).toMatch(/no stream 'nope'/);
+
+    tables.connected_accounts[0].connector_id = 'not-a-connector';
+    const worse = await runConnectorStream(
+      { service: client, secretKey: SECRET_KEY },
+      { accountId: ACCOUNT.id, stream: 'page_metrics' }
+    );
+    expect(worse.error).toMatch(/unknown connector/);
+  });
+});

--- a/src/shared/lib/connectors/host/index.ts
+++ b/src/shared/lib/connectors/host/index.ts
@@ -1,0 +1,20 @@
+// SERVER-ONLY connector run host (CVS-320): the orchestrator composing secrets →
+// fetch → normalize → bind into metric_values, plus its DB-backed cursor store,
+// credential/refresh resolution, adapter factories, and persisted-binding loader.
+// ⚠️ Never import from a browser bundle — this module reads decrypted secrets.
+export { SupabaseCursorStore } from './cursorStore';
+export { loadBindings, parseRecipe, type LoadedBindings } from './bindings';
+export {
+  resolveCredentials,
+  TOKEN_REFRESHERS,
+  type HostEnv,
+  type TokenRefresher,
+  type ResolveCredentialsInput,
+} from './credentials';
+export { createAdapter, ADAPTER_FACTORIES, type AdapterAccount, type AdapterFactory } from './adapters';
+export {
+  runConnectorStream,
+  type RunHostDeps,
+  type RunConnectorInput,
+  type RunHostSummary,
+} from './runConnector';

--- a/src/shared/lib/connectors/host/runConnector.ts
+++ b/src/shared/lib/connectors/host/runConnector.ts
@@ -1,0 +1,207 @@
+// SERVER-ONLY connector run host (CVS-320) — the orchestrator that composes every
+// merged connector layer into one invocation:
+//
+//   secrets (CVS-141) → fetch runtime (CVS-142) → normalize (CVS-143)
+//     → bind/materialize (CVS-144) → metric_values, audited by CVS-145.
+//
+// Runs wherever a service-role client exists (the connector-run edge function, tests,
+// later the CVS-323 scheduler). Holds canonical records in memory for the duration of
+// the run only — no raw payloads persist (locked decision CVS-137).
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/shared/lib/supabase/types';
+import type { CanonicalRecord } from '../canonical';
+import { collectRecords, materializeBinding, upsertMetricValues } from '../binding';
+import { getConnector, type SyncMode } from '../manifests';
+import { getMapper, toRecordHandler, type NormalizationContext } from '../normalize';
+import { recordRun } from '../observability';
+import {
+  ConnectorFetchError,
+  InMemoryCursorStore,
+  cursorKeyFor,
+  runStream,
+  type Clock,
+  type CursorStore,
+  type RunReport,
+} from '../runtime';
+import { loadBindings } from './bindings';
+import { createAdapter } from './adapters';
+import { resolveCredentials, type HostEnv } from './credentials';
+import { SupabaseCursorStore } from './cursorStore';
+
+type ServiceClient = SupabaseClient<Database>;
+
+const PREVIEW_MAX_RECORDS = 10; // sample-preview cap (locked decision CVS-137 §8)
+
+export interface RunHostDeps {
+  /** SERVICE-ROLE client — the host reads secrets and writes cursors/values/audit. */
+  service: ServiceClient;
+  /** CONNECTOR_SECRET_KEY (base64, 32 bytes). */
+  secretKey: string;
+  env?: HostEnv;
+  fetchImpl?: typeof fetch;
+  clock?: Clock;
+  /** Injectable for tests; defaults to the DB-backed store (in-memory for previews). */
+  cursorStore?: CursorStore;
+}
+
+export interface RunConnectorInput {
+  accountId: string;
+  stream: string;
+  syncMode?: SyncMode;
+  /** Preview: capped fetch, in-memory cursor, nothing persisted, sample returned. */
+  preview?: boolean;
+  maxRecords?: number;
+  pageTimeoutMs?: number;
+}
+
+export interface RunHostSummary {
+  ok: boolean;
+  report?: RunReport;
+  /** metric_values rows written across all bindings. */
+  materialized: number;
+  bindingsApplied: number;
+  /** Binding rows whose recipe failed to parse — skipped, never guessed at. */
+  malformedBindingIds: string[];
+  /** Preview only: the normalized sample (held in memory, never persisted). */
+  sample?: CanonicalRecord[];
+  /** Safe, payload-free error when the run could not start or fetch failed. */
+  error?: string;
+  errorClass?: string;
+}
+
+const RUNNABLE_STATUSES = new Set(['connected', 'error']); // error = retry may heal
+
+/** Run one connected account's stream through the full pipeline. Never throws for
+ *  source/auth failures — they come back as a payload-free summary. */
+export async function runConnectorStream(deps: RunHostDeps, input: RunConnectorInput): Promise<RunHostSummary> {
+  const { service } = deps;
+  const preview = input.preview === true;
+
+  const { data: account, error: accErr } = await service
+    .from('connected_accounts')
+    .select('*')
+    .eq('id', input.accountId)
+    .maybeSingle();
+  if (accErr) throw new Error(accErr.message);
+  if (!account) return failSummary('connection not found');
+  if (!RUNNABLE_STATUSES.has(account.status)) {
+    return failSummary(`connection is ${account.status} — reconnect before syncing`);
+  }
+
+  const manifest = getConnector(account.connector_id);
+  if (!manifest) return failSummary(`unknown connector '${account.connector_id}'`);
+  const stream = manifest.streams.find((s) => s.name === input.stream);
+  if (!stream) return failSummary(`connector '${manifest.id}' has no stream '${input.stream}'`);
+  const mapper = getMapper(manifest.id, stream.name);
+  if (!mapper) return failSummary(`no normalizer registered for ${manifest.id}:${stream.name}`);
+
+  let credentials;
+  try {
+    credentials = await resolveCredentials(service, {
+      accountId: account.id,
+      connectorId: account.connector_id,
+      workspaceId: account.workspace_id ?? undefined,
+      secretKey: deps.secretKey,
+      env: deps.env ?? {},
+      fetchImpl: deps.fetchImpl,
+    });
+  } catch (err) {
+    if (err instanceof ConnectorFetchError) {
+      return { ...failSummary(err.message), errorClass: err.class };
+    }
+    throw err;
+  }
+
+  const adapter = createAdapter(account, deps.fetchImpl);
+  const ctx: NormalizationContext = {
+    source: manifest.id,
+    sourceAccountId: account.source_account_id ?? account.id,
+    workspaceId: account.workspace_id ?? account.created_by,
+    connectorVersion: `${manifest.id}@${manifest.normalizer_version}`,
+    observedAt: new Date().toISOString(),
+  };
+  const collected = collectRecords();
+
+  const cursorStore =
+    deps.cursorStore ??
+    (preview
+      ? new InMemoryCursorStore()
+      : new SupabaseCursorStore(service, { workspaceId: account.workspace_id, createdBy: account.created_by }));
+
+  const report = await runStream(adapter, manifest, stream, {
+    credentials,
+    syncMode: preview ? 'full_refresh' : (input.syncMode ?? 'incremental'),
+    cursorStore,
+    cursorKey: cursorKeyFor(account.id, manifest.id, stream.name),
+    maxRecords: preview ? (input.maxRecords ?? PREVIEW_MAX_RECORDS) : input.maxRecords,
+    pageTimeoutMs: input.pageTimeoutMs ?? 30_000,
+    clock: deps.clock,
+    onRecords: toRecordHandler(mapper, ctx, collected.sink),
+  });
+
+  if (preview) {
+    return {
+      ok: !report.error_class,
+      report,
+      materialized: 0,
+      bindingsApplied: 0,
+      malformedBindingIds: [],
+      sample: collected.records,
+      error: report.error_message,
+      errorClass: report.error_class,
+    };
+  }
+
+  // A clean run heals an `error` connection; an auth failure during fetch marks it.
+  const now = new Date().toISOString();
+  let effectiveStatus = account.status;
+  if (!report.error_class && account.status === 'error') {
+    await service
+      .from('connected_accounts')
+      .update({ status: 'connected', status_detail: null, updated_at: now })
+      .eq('id', account.id);
+    effectiveStatus = 'connected';
+  } else if (report.error_class === 'auth') {
+    await service
+      .from('connected_accounts')
+      .update({ status: 'error', status_detail: 'authentication failed during sync', updated_at: now })
+      .eq('id', account.id);
+    effectiveStatus = 'error';
+  }
+
+  const { bindings, malformedIds } = await loadBindings(service, account.id, stream.name);
+  let materialized = 0;
+  for (const binding of bindings) {
+    const result = materializeBinding(collected.records, binding, { status: effectiveStatus });
+    if (result.status === 'materialized') {
+      materialized += await upsertMetricValues(service, result.rows);
+    }
+  }
+
+  await recordRun(service, report, {
+    connectedAccountId: account.id,
+    workspaceId: account.workspace_id ?? undefined,
+    materialized,
+  });
+
+  if (!report.error_class) {
+    await service
+      .from('connected_accounts')
+      .update({ last_synced_at: now, updated_at: now })
+      .eq('id', account.id);
+  }
+
+  return {
+    ok: !report.error_class,
+    report,
+    materialized,
+    bindingsApplied: bindings.length,
+    malformedBindingIds: malformedIds,
+    error: report.error_message,
+    errorClass: report.error_class,
+  };
+}
+
+function failSummary(error: string): RunHostSummary {
+  return { ok: false, materialized: 0, bindingsApplied: 0, malformedBindingIds: [], error };
+}

--- a/src/shared/lib/connectors/normalize/normalize.test.ts
+++ b/src/shared/lib/connectors/normalize/normalize.test.ts
@@ -151,8 +151,22 @@ describe('toRecordHandler — plugs into the fetch runtime', () => {
 
 describe('getMapper', () => {
   it('resolves registered connector:stream keys', () => {
-    expect(getMapper('stripe', 'payment_intents')).toBe(mapStripePayment);
+    expect(getMapper('stripe', 'payments')).toBe(mapStripePayment);
     expect(getMapper('woocommerce', 'orders')).toBe(mapWooOrder);
     expect(getMapper('nope', 'nope')).toBeUndefined();
+  });
+
+  it('every mapper key matches a manifest stream (CVS-320 regression)', async () => {
+    const { getConnector } = await import('../manifests');
+    const { MAPPER_KEYS } = await import('./registry');
+    for (const key of MAPPER_KEYS) {
+      const [connectorId, stream] = key.split(':');
+      const manifest = getConnector(connectorId);
+      expect(manifest, `manifest for ${connectorId}`).toBeDefined();
+      expect(
+        manifest!.streams.some((s) => s.name === stream),
+        `stream '${stream}' on connector '${connectorId}'`
+      ).toBe(true);
+    }
   });
 });

--- a/src/shared/lib/connectors/normalize/registry.ts
+++ b/src/shared/lib/connectors/normalize/registry.ts
@@ -9,7 +9,7 @@ import { mapWooOrder } from './mappers/woocommerce';
 import type { Mapper } from './types';
 
 export const MAPPERS: Record<string, Mapper> = {
-  'stripe:payment_intents': mapStripePayment,
+  'stripe:payments': mapStripePayment, // stream name matches the CVS-140 Stripe manifest (CVS-320 fix)
   'ga4:page_metrics': mapGa4PageMetric, // stream name matches the CVS-140 GA4 manifest
   'ga4:events': mapGa4Event,
   'woocommerce:orders': mapWooOrder,

--- a/src/shared/lib/supabase/types.ts
+++ b/src/shared/lib/supabase/types.ts
@@ -1044,6 +1044,104 @@ export type Database = {
           },
         ]
       }
+      connector_cursors: {
+        Row: {
+          connected_account_id: string
+          connector_id: string
+          stream: string
+          cursor: string
+          workspace_id: string | null
+          created_by: string | null
+          updated_at: string
+        }
+        Insert: {
+          connected_account_id: string
+          connector_id: string
+          stream: string
+          cursor: string
+          workspace_id?: string | null
+          created_by?: string | null
+          updated_at?: string
+        }
+        Update: {
+          connected_account_id?: string
+          connector_id?: string
+          stream?: string
+          cursor?: string
+          workspace_id?: string | null
+          created_by?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "connector_cursors_connected_account_id_fkey"
+            columns: ["connected_account_id"]
+            isOneToOne: false
+            referencedRelation: "connected_accounts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      metric_bindings: {
+        Row: {
+          id: string
+          created_by: string
+          workspace_id: string | null
+          connected_account_id: string
+          connector_id: string
+          stream: string
+          canonical_schema: string
+          recipe: Json
+          tracked_metric_id: string
+          enabled: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          created_by?: string
+          workspace_id?: string | null
+          connected_account_id: string
+          connector_id: string
+          stream: string
+          canonical_schema: string
+          recipe: Json
+          tracked_metric_id: string
+          enabled?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          created_by?: string
+          workspace_id?: string | null
+          connected_account_id?: string
+          connector_id?: string
+          stream?: string
+          canonical_schema?: string
+          recipe?: Json
+          tracked_metric_id?: string
+          enabled?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "metric_bindings_connected_account_id_fkey"
+            columns: ["connected_account_id"]
+            isOneToOne: false
+            referencedRelation: "connected_accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "metric_bindings_tracked_metric_id_fkey"
+            columns: ["tracked_metric_id"]
+            isOneToOne: false
+            referencedRelation: "tracked_metrics"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       source_connection_secrets: {
         Row: {
           connection_id: string

--- a/supabase/functions/connector-run/deno.json
+++ b/supabase/functions/connector-run/deno.json
@@ -1,0 +1,11 @@
+{
+  "imports": {
+    "@/": "../../../src/",
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.53.0",
+    "zod": "https://esm.sh/zod@3.23.8"
+  },
+  "unstable": ["sloppy-imports"],
+  "compilerOptions": {
+    "noImplicitAny": false
+  }
+}

--- a/supabase/functions/connector-run/deno.lock
+++ b/supabase/functions/connector-run/deno.lock
@@ -1,0 +1,7 @@
+{
+  "version": "5",
+  "remote": {
+    "https://esm.sh/zod@3.23.8": "15e60c792ac21d4818f181671c7c74bf33bf7526d487dc524911e42785d8b5c2",
+    "https://esm.sh/zod@3.23.8/denonext/zod.mjs": "6ee0474ec5a765b112eca12525d7e30c8e77eedbe2f2ac5e19f2af468b759517"
+  }
+}

--- a/supabase/functions/connector-run/index.ts
+++ b/supabase/functions/connector-run/index.ts
@@ -1,0 +1,101 @@
+// Connector run host entrypoint (CVS-320). Executes one connected account's stream
+// through the full pipeline (secrets → fetch → normalize → bind → metric_values)
+// using the shared library at src/shared/lib/connectors/host (mapped via deno.json).
+//
+//   POST /connector-run  { account_id, stream, sync_mode?, preview?, max_records? }
+//     -> RunHostSummary (payload-free unless preview, which returns the in-memory sample)
+//
+// Auth (verify_jwt stays ON — the gateway checks the JWT signature):
+//   * user JWT     — caller must be able to SEE the connected account under RLS
+//                    ("Sync now" from the app). The run itself uses the service role.
+//   * service JWT  — role=service_role (scheduler/pg_cron, CVS-323) is trusted as-is.
+//
+// Required function secrets: CONNECTOR_SECRET_KEY (+ GOOGLE_OAUTH_CLIENT_ID/_SECRET
+// for GA4 refresh). Deploy: npx supabase functions deploy connector-run
+import { createClient } from '@supabase/supabase-js';
+import { runConnectorStream } from '@/shared/lib/connectors/host/index.ts';
+
+const cors = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...cors, 'Content-Type': 'application/json' },
+  });
+}
+
+/** Role claim from an already-gateway-verified JWT (no signature re-check needed). */
+function jwtRole(authHeader: string | null): string | undefined {
+  const token = authHeader?.replace(/^Bearer\s+/i, '');
+  if (!token) return undefined;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return typeof payload.role === 'string' ? payload.role : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: cors });
+  if (req.method !== 'POST') return json({ error: 'POST only' }, 405);
+
+  const secretKey = Deno.env.get('CONNECTOR_SECRET_KEY');
+  if (!secretKey) return json({ error: 'CONNECTOR_SECRET_KEY is not configured' }, 500);
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: 'invalid JSON body' }, 400);
+  }
+  const accountId = typeof body.account_id === 'string' ? body.account_id : null;
+  const stream = typeof body.stream === 'string' ? body.stream : null;
+  if (!accountId || !stream) return json({ error: 'account_id and stream are required' }, 400);
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+  const service = createClient(supabaseUrl, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+
+  // Authorization: a user must be able to see the account under their own RLS.
+  const authHeader = req.headers.get('authorization');
+  if (jwtRole(authHeader) !== 'service_role') {
+    const rls = createClient(supabaseUrl, Deno.env.get('SUPABASE_ANON_KEY')!, {
+      global: { headers: { Authorization: authHeader ?? '' } },
+    });
+    const { data: visible } = await rls
+      .from('connected_accounts')
+      .select('id')
+      .eq('id', accountId)
+      .maybeSingle();
+    if (!visible) return json({ error: 'connection not found' }, 404);
+  }
+
+  try {
+    const summary = await runConnectorStream(
+      {
+        service,
+        secretKey,
+        env: {
+          googleClientId: Deno.env.get('GOOGLE_OAUTH_CLIENT_ID') ?? undefined,
+          googleClientSecret: Deno.env.get('GOOGLE_OAUTH_CLIENT_SECRET') ?? undefined,
+        },
+      },
+      {
+        accountId,
+        stream,
+        syncMode: body.sync_mode === 'full_refresh' ? 'full_refresh' : undefined,
+        preview: body.preview === true,
+        maxRecords: typeof body.max_records === 'number' ? body.max_records : undefined,
+      }
+    );
+    return json(summary, summary.ok ? 200 : 422);
+  } catch (err) {
+    // Library errors are already payload-free; still avoid echoing unknown shapes.
+    const msg = err instanceof Error ? err.message : 'run failed';
+    return json({ error: msg.slice(0, 300) }, 500);
+  }
+});

--- a/supabase/migrations/20260711120000_connector_run_host.sql
+++ b/supabase/migrations/20260711120000_connector_run_host.sql
@@ -1,0 +1,112 @@
+-- =====================================================================
+-- CONNECTOR RUN HOST — cursors + metric bindings (CVS-320)
+-- Metrimap : iqrclwolhookzzmiedun. Clerk-via-Supabase-native auth.
+-- Identity = public.requesting_user_id() (text); workspace = public.requesting_org_id().
+-- Idempotent: safe to apply/re-apply. RLS ENABLED on both tables.
+--
+--   * connector_cursors — one opaque incremental cursor per (connected account,
+--     stream). Payload-free by construction (CVS-142). Written ONLY by the run
+--     host (service role); workspace members may read for debug surfaces.
+--   * metric_bindings   — persisted CVS-144 MetricBinding recipes: "aggregate this
+--     connector stream into this tracked metric". Workspace-scoped CRUD so the
+--     Connect/binding UI can manage them; the run host reads them per run.
+-- See docs/data/connector-run-host.md and Linear CVS-320.
+-- =====================================================================
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. CURSOR STORE (service-role write, workspace read)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.connector_cursors (
+  connected_account_id uuid NOT NULL
+                         REFERENCES public.connected_accounts(id) ON DELETE CASCADE,
+  connector_id         text NOT NULL,
+  stream               text NOT NULL,
+  -- opaque incremental cursor (e.g. a GA4 date '20260710') — never payload data
+  cursor               text NOT NULL,
+  -- denormalized from connected_accounts for the read policy
+  workspace_id         text,
+  created_by           text,
+  updated_at           timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (connected_account_id, stream)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_cursors_workspace_id
+  ON public.connector_cursors(workspace_id);
+
+ALTER TABLE public.connector_cursors ENABLE ROW LEVEL SECURITY;
+
+-- Workspace-scoped read (creator or org member) — mirrors connector_runs_select.
+DROP POLICY IF EXISTS connector_cursors_select ON public.connector_cursors;
+CREATE POLICY connector_cursors_select ON public.connector_cursors
+  FOR SELECT USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+-- No INSERT/UPDATE/DELETE policies => clients cannot write; only the service-role
+-- run host advances cursors (safe-resume guarantee stays server-owned).
+
+-- ---------------------------------------------------------------------
+-- 2. METRIC BINDINGS (workspace-scoped CRUD)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.metric_bindings (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_by           text NOT NULL DEFAULT public.requesting_user_id(),
+  workspace_id         text DEFAULT public.requesting_org_id(),
+  connected_account_id uuid NOT NULL
+                         REFERENCES public.connected_accounts(id) ON DELETE CASCADE,
+  connector_id         text NOT NULL,
+  stream               text NOT NULL,
+  canonical_schema     text NOT NULL,
+  -- CVS-144 MetricRecipe: { aggregation, grain, field?, filter? }
+  recipe               jsonb NOT NULL,
+  tracked_metric_id    uuid NOT NULL
+                         REFERENCES public.tracked_metrics(id) ON DELETE CASCADE,
+  enabled              boolean NOT NULL DEFAULT true,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  updated_at           timestamptz NOT NULL DEFAULT now(),
+  -- one binding per (account, stream, target metric)
+  UNIQUE (connected_account_id, stream, tracked_metric_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metric_bindings_workspace_id
+  ON public.metric_bindings(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_metric_bindings_account_stream
+  ON public.metric_bindings(connected_account_id, stream);
+
+ALTER TABLE public.metric_bindings ENABLE ROW LEVEL SECURITY;
+
+-- Workspace-scoped CRUD — mirrors the audited connected_accounts policy shape.
+DROP POLICY IF EXISTS metric_bindings_select ON public.metric_bindings;
+CREATE POLICY metric_bindings_select ON public.metric_bindings
+  FOR SELECT USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+DROP POLICY IF EXISTS metric_bindings_insert ON public.metric_bindings;
+CREATE POLICY metric_bindings_insert ON public.metric_bindings
+  FOR INSERT WITH CHECK (
+    created_by = public.requesting_user_id()
+    AND (workspace_id IS NULL OR workspace_id = public.requesting_org_id())
+  );
+
+DROP POLICY IF EXISTS metric_bindings_update ON public.metric_bindings;
+CREATE POLICY metric_bindings_update ON public.metric_bindings
+  FOR UPDATE USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  ) WITH CHECK (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+DROP POLICY IF EXISTS metric_bindings_delete ON public.metric_bindings;
+CREATE POLICY metric_bindings_delete ON public.metric_bindings
+  FOR DELETE USING (
+    created_by = public.requesting_user_id()
+    OR (public.requesting_org_id() IS NOT NULL AND workspace_id = public.requesting_org_id())
+  );
+
+COMMIT;


### PR DESCRIPTION
Builds **CVS-320** — the orchestrator that makes the merged connector foundation actually runnable. Milestone 2 keystone of the connectors lane; unblocks GA4 going live (CVS-146) and every connector after it.

## ⚠️ Owner steps before it functions
1. Apply `supabase/migrations/20260711120000_connector_run_host.sql` (adds `connector_cursors` + `metric_bindings`).
2. Function secrets: `CONNECTOR_SECRET_KEY` (same value as the CVS-141 layer), plus `GOOGLE_OAUTH_CLIENT_ID`/`_SECRET` for GA4 refresh (CVS-280/CVS-321 §1).
3. `npx supabase functions deploy connector-run`.

## What
- **`src/shared/lib/connectors/host/`** (server-only): `runConnectorStream` composes secrets (CVS-141) → fetch runtime (CVS-142) → normalize (CVS-143) → bind (CVS-144) → `metric_values`, audited via CVS-145. Preview mode = capped fetch, in-memory cursor, nothing persisted (CVS-137 §8). Payload-free failure summaries; a clean run heals an `error` connection, an auth failure marks it.
- **Token refresh loop**: `resolveCredentials` refreshes expiring OAuth tokens through a per-connector `TokenRefresher` registry (Google first), persisting the rotation before use; failures → `markConnectionError` + `auth_failed` event.
- **DB-backed CursorStore** over new `connector_cursors` (service-role write only, workspace read) — runs resume across invocations.
- **`metric_bindings` table** persists CVS-144 recipes; malformed recipes are skipped and surfaced, never guessed at.
- **`connector-run` edge function**: user-JWT path (RLS visibility check → "Sync now") + service-role path (CVS-323 scheduler). Reuses the repo library via deno.json import map + sloppy imports — **runtime-verified with `deno run`** (deploy bundling does not type-check).
- **Bug fix**: normalize registry key `stripe:payment_intents` → `stripe:payments` (matches the CVS-140 manifest) + a regression test that cross-checks every mapper key against its manifest stream.
- Types hand-patched (`prisma:types` broken); doc `docs/data/connector-run-host.md`; **10 new tests** (full-pipeline GA4 fixture → metric_values with lineage, cursor resume across two runs with no duplicates, token refresh + rotation persistence, auth-failure marking, preview isolation, readable errors).

## Acceptance criteria
- [x] One invocation runs the full pipeline for a GA4 fixture account; rows land in `metric_values` with lineage
- [x] Cursor persists across two invocations (second run resumes from `2026-07-02`, no duplicates)
- [x] Expired token triggers refresh before fetch; refresh failure → `markConnectionError` (payload-free)
- [x] Stripe mapper-key mismatch fixed with a regression test
- [x] No raw payloads persisted anywhere (records held in memory per run only)
- [ ] Live GA4 end-to-end — needs migration + OAuth app (manual test, post-deploy)

type-check + lint (0 errors) + 462 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZofmQpFSrfyiGuoaVSbwC