### PR TITLE
refactor(evidence): consumers cleanup after persistence unification (CVS-338)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ CVS). See the **Docs policy** in [`../AGENTS.md`](../AGENTS.md).
 - **[auth/](auth/)** — Clerk + Supabase authentication integration
 - **[database/](database/)** — Prisma + Zod, Supabase client singleton, RLS solution + testing, [security advisors triage](database/SECURITY_ADVISORS.md)
 - **[environment/](environment/)** — environment setup + secrets guide
-- **[state-management/](state-management/)** — XState patterns, [React #185 canvas fix + runbook](state-management/react-185-canvas-nodes.md)
+- **[state-management/](state-management/)** — XState patterns, [React #185 canvas fix + runbook](state-management/react-185-canvas-nodes.md), [evidence persistence model](state-management/evidence-persistence.md)
 - **[testing/](testing/)** — [E2E / visual-verification harness (Playwright + Clerk)](testing/e2e-visual-verification.md)
 - **features/ (infra only)** — [system-health-intake](features/system-health-intake.md),
   [linear-setup](features/linear-setup.md), [linear-initiatives](features/linear-initiatives.md),

--- a/docs/state-management/evidence-persistence.md
+++ b/docs/state-management/evidence-persistence.md
@@ -1,0 +1,61 @@
+# Evidence persistence model (CVS-337/CVS-338)
+
+How evidence data flows between the canvas, the store, Supabase, and project
+settings. This replaced the legacy `projects.settings.evidence` JSON blob.
+
+## Sources of truth
+
+| Data | Where it lives | Written by |
+| --- | --- | --- |
+| Content fields (title, type, date, summary, hypothesis, link, impact, `content` EditorJS jsonb, `is_public`, scope) | `evidence_items` table | `src/features/evidence/services/evidenceSync.ts` (debounced per-id), `evidence.ts` / `relationships.ts` services |
+| Scope (card / relationship / general) | `evidence_items.card_id` / `relationship_id` columns | mapped ⇄ domain `context` in `rowToEvidence` / `transformEvidenceItem` |
+| Canvas presentation: `position`, `isExpanded`, `isVisible`, `zIndex`, `links`, `comments`, `tags`, `category`, context target name | `projects.settings.evidenceLayout` — a map keyed by evidence id | CanvasPage debounced layout save (600ms), built by `buildEvidenceLayoutMap` |
+| UI working copy | `useEvidenceStore` (Zustand, **not** localStorage-persisted) | hydrated per canvas; all mutations go through `evidenceSync` |
+
+## Write path (`evidenceSync.ts`)
+
+`createEvidenceSynced` / `updateEvidenceSynced` / `deleteEvidenceSynced`:
+optimistic store write first, then DB. Content-field updates debounce 800ms
+per id onto a per-id promise chain (a create can never race its own updates);
+failed creates are retried on the next edit. `flushEvidenceSync(id)` forces
+the pending update out immediately — called on panel close and manual saves
+(EvidencePage, repository editor) so the row never trails the store.
+
+Layout-field updates deliberately skip the DB — CanvasPage's debounced
+`evidenceLayout` settings save owns them.
+
+## Hydration (`hydrateProjectEvidence.ts`)
+
+Canvas load: `evidence_items` rows for the project + `evidenceLayout` overlay
+(`applyEvidenceLayout`). The evidence store is cleared on canvas switch —
+nothing bleeds across projects. The canvas-scoped repository route hydrates
+itself the same way on direct load.
+
+## One-time legacy migration
+
+Pre-CVS-337 canvases hold evidence in `settings.evidence` (blob). On first
+load by an **editor** (RLS rejects viewer inserts), `migrateLegacyEvidence`:
+
+1. Partitions blob items vs existing rows — by id, then by
+   `(title, date, created_by)` fingerprint (the repository page used to
+   dual-write), so re-runs never duplicate.
+2. Inserts missing items — UUID ids preserved; legacy `evidence_…` ids get
+   fresh ids, remapped across layout keys, `links`, and
+   `settings.dataFlowEdges` reference edges (`ref-<old>-<card>` ids too).
+3. Finalizes in a single `mergeProjectSettings` write: `evidenceLayout`,
+   `evidenceMigratedAt` stamp, `evidenceLegacyBackup` (kept one release —
+   remove with the blob-read fallback after CVS-337 has been in production),
+   and empties `settings.evidence`.
+
+Viewers on an unmigrated canvas still see blob items read-only.
+
+## Gotchas
+
+- **Prisma/Zod**: `prisma db pull` re-creates a `projects.tags` relation that
+  collides with the scalar `tags` column — re-apply the `tag_records` rename
+  in `schema.prisma` after every pull. Validation re-exports in
+  `src/shared/lib/validation/zod.ts` must stay on the **Unchecked** variants
+  (services build flat column payloads). `date` (date-only string) and
+  `causal_metadata`/raw-null json stay on the post-parse pattern.
+- **Offline**: dropping the store's localStorage persist removed the
+  accidental offline cache; a hard-offline session doesn't survive reload.

--- a/src/features/evidence/components/EvidenceEditor.tsx
+++ b/src/features/evidence/components/EvidenceEditor.tsx
@@ -41,6 +41,7 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { generateUUID } from '@/shared/utils/validation';
 
 interface EvidenceEditorProps {
   evidence: EvidenceItem | null;
@@ -96,7 +97,7 @@ export default function EvidenceEditor({
   const [isAutoSaving, setIsAutoSaving] = useState(false);
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [formData, setFormData] = useState<Partial<EvidenceItem>>({
-    id: evidence?.id || `evidence_${Date.now()}`,
+    id: evidence?.id || generateUUID(),
     title: evidence?.title || '',
     type: evidence?.type || 'Analysis',
     date: evidence?.date || new Date().toISOString().split('T')[0],
@@ -114,7 +115,7 @@ export default function EvidenceEditor({
   useEffect(() => {
     if (!isOpen) return;
     setFormData({
-      id: evidence?.id || `evidence_${Date.now()}`,
+      id: evidence?.id || generateUUID(),
       title: evidence?.title || '',
       type: evidence?.type || 'Analysis',
       date: evidence?.date || new Date().toISOString().split('T')[0],
@@ -134,7 +135,7 @@ export default function EvidenceEditor({
         setIsAutoSaving(true);
         const validatedContent = validateAndMigrateEditorData(content);
         const updated: EvidenceItem = {
-          id: evidence?.id || formData.id || `evidence_${Date.now()}`,
+          id: evidence?.id || formData.id || generateUUID(),
           title: metadata.title || '',
           type: metadata.type || 'Analysis',
           date: metadata.date || new Date().toISOString().split('T')[0],
@@ -262,7 +263,7 @@ export default function EvidenceEditor({
       const outputData = await editorRef.current.save();
       const validated = validateAndMigrateEditorData(outputData);
       const updated: EvidenceItem = {
-        id: evidence?.id || formData.id || `evidence_${Date.now()}`,
+        id: evidence?.id || formData.id || generateUUID(),
         title: formData.title || '',
         type: formData.type || 'Analysis',
         date: formData.date || new Date().toISOString().split('T')[0],

--- a/src/features/evidence/pages/EvidencePage.tsx
+++ b/src/features/evidence/pages/EvidencePage.tsx
@@ -19,7 +19,10 @@ import {
   createProjectEvidence,
   getEvidenceItemById,
 } from '@/shared/lib/supabase/services/evidence';
-import { updateEvidenceItem } from '@/shared/lib/supabase/services/relationships';
+import {
+  flushEvidenceSync,
+  updateEvidenceSynced,
+} from '@/features/evidence/services/evidenceSync';
 import type { EvidenceItem } from '@/shared/types';
 import EditorJS from '@editorjs/editorjs';
 import EvidenceLinkChips from '@/features/evidence/components/EvidenceLinkChips';
@@ -32,7 +35,7 @@ export default function EvidencePage() {
   const { evidenceId, canvasId } = useParams();
   const navigate = useNavigate();
   const client = useClerkSupabase();
-  const { getEvidenceById, addEvidence, updateEvidence } = useEvidenceStore();
+  const { getEvidenceById, addEvidence } = useEvidenceStore();
   const { user } = useAppStore();
 
   const editorRef = useRef<EditorJS | null>(null);
@@ -127,16 +130,11 @@ export default function EvidencePage() {
       };
 
       if (initialEvidence) {
-        updateEvidence(initialEvidence.id, updated); // in-memory store
-        if (client) {
-          // Persist the notebook (incl. content) to the DB so it survives reload.
-          // Don't let a DB failure discard the save — the store already has it.
-          try {
-            await updateEvidenceItem(initialEvidence.id, updated, client);
-          } catch (e) {
-            console.error('Failed to persist evidence to DB', e);
-          }
-        }
+        // One write path with the docked panel (CVS-338): store immediately,
+        // row via evidenceSync's per-id chain; flush right away — this is a
+        // manual save, not a keystroke.
+        updateEvidenceSynced(initialEvidence.id, updated);
+        flushEvidenceSync(initialEvidence.id);
       } else {
         // Brand-new evidence: persist to the DB (project-scoped) when in a canvas
         // context so it isn't store-only, then adopt the DB id so reload works
@@ -173,7 +171,6 @@ export default function EvidencePage() {
     formData,
     initialEvidence,
     addEvidence,
-    updateEvidence,
     client,
     user?.id,
     canvasId,

--- a/src/features/evidence/pages/EvidenceRepositoryPage.tsx
+++ b/src/features/evidence/pages/EvidenceRepositoryPage.tsx
@@ -1,5 +1,10 @@
 import { useEvidenceStore } from '@/features/evidence/stores/useEvidenceStore';
-import { deleteEvidenceSynced } from '@/features/evidence/services/evidenceSync';
+import {
+  deleteEvidenceSynced,
+  ensureEvidenceRowSynced,
+  flushEvidenceSync,
+  updateEvidenceSynced,
+} from '@/features/evidence/services/evidenceSync';
 import { useCanvasStore } from '@/lib/stores';
 import { usePageHeader } from '@/shared/hooks/usePageHeader';
 import { useConfirm } from '@/shared/components/ConfirmDialog';
@@ -48,7 +53,7 @@ import {
   User,
   Users,
 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import EvidenceEditor from '../components/EvidenceEditor';
 import { useClerkSupabase } from '@/shared/hooks/useClerkSupabase';
@@ -58,7 +63,6 @@ import {
   getProjectEvidence,
   setEvidencePublic,
 } from '@/shared/lib/supabase/services/evidence';
-import { updateEvidenceItem } from '@/shared/lib/supabase/services/relationships';
 import { toast } from 'sonner';
 
 const evidenceTypeOptions = [
@@ -117,12 +121,7 @@ export default function EvidenceRepositoryPage() {
   const { user } = useAppStore();
   const { canvas } = useCanvasStore();
   const confirm = useConfirm();
-  const {
-    evidence,
-    addEvidence,
-    updateEvidence,
-    duplicateEvidence,
-  } = useEvidenceStore();
+  const { evidence, addEvidence, duplicateEvidence } = useEvidenceStore();
 
   // DB hydration (CVS-337): the evidence store is no longer localStorage-
   // persisted, so on a direct load/reload of this route the store is empty.
@@ -158,6 +157,8 @@ export default function EvidenceRepositoryPage() {
   const [selectedEvidence, setSelectedEvidence] = useState<EvidenceItem | null>(
     null
   );
+  // Serializes the editor's create path — see handleSaveEvidence.
+  const createInFlight = useRef(false);
 
   // Combine standalone evidence with relationship evidence
   const allEvidence = useMemo(() => {
@@ -234,33 +235,38 @@ export default function EvidenceRepositoryPage() {
     options?: { autoSave?: boolean }
   ) => {
     if (selectedEvidence) {
-      // Update existing evidence (store + DB)
-      updateEvidence(selectedEvidence.id, evidence);
-      if (client) {
-        try {
-          await updateEvidenceItem(selectedEvidence.id, evidence, client);
-        } catch (e) {
-          console.error('Failed to persist evidence edit to DB', e);
-        }
-      }
+      // One write path with the canvas/panel editors (CVS-338): store now,
+      // row via evidenceSync; flush immediately on manual save.
+      updateEvidenceSynced(selectedEvidence.id, evidence, canvasId);
+      if (!options?.autoSave) flushEvidenceSync(selectedEvidence.id);
     } else {
       // Create new evidence — persist to the DB (project-scoped) when we have a
       // canvas/project context, so it's DB-backed rather than store-only and
       // resolvable by id across surfaces (CVS-34 slice 3).
-      let created = evidence;
-      if (canvasId && client && user?.id) {
-        try {
-          created = await createProjectEvidence(
-            evidence,
-            canvasId,
-            user.id,
-            client
-          );
-        } catch (e) {
-          console.error('Failed to create evidence in DB; storing locally', e);
+      // Guard the double-create (CVS-338): autosave + manual Save both landed
+      // here with selectedEvidence still null, inserting two rows. Serialize
+      // the first create and adopt the created item for subsequent saves.
+      if (createInFlight.current) return;
+      createInFlight.current = true;
+      try {
+        let created = evidence;
+        if (canvasId && client && user?.id) {
+          try {
+            created = await createProjectEvidence(
+              evidence,
+              canvasId,
+              user.id,
+              client
+            );
+          } catch (e) {
+            console.error('Failed to create evidence in DB; storing locally', e);
+          }
         }
+        addEvidence(created);
+        setSelectedEvidence(created); // later saves are updates, not inserts
+      } finally {
+        createInFlight.current = false;
       }
-      addEvidence(created);
     }
 
     // Only close dialog on manual save, not auto-save
@@ -297,6 +303,8 @@ export default function EvidenceRepositoryPage() {
   const handleDuplicateEvidence = (evidenceItem: EvidenceItem) => {
     const duplicate = duplicateEvidence(evidenceItem.id);
     if (duplicate) {
+      // The copy is a real evidence_items row, not a store-only ghost (CVS-338).
+      if (canvasId) ensureEvidenceRowSynced(duplicate.id, canvasId);
       setSelectedEvidence(duplicate);
       setIsEditorOpen(true);
     }

--- a/src/features/evidence/services/evidenceSync.ts
+++ b/src/features/evidence/services/evidenceSync.ts
@@ -110,6 +110,14 @@ export function createEvidenceSynced(
   runCreate(item.id);
 }
 
+/** Ensure a DB row exists for an item already in the store (e.g. a
+ *  store-side duplicate that minted a fresh UUID). */
+export function ensureEvidenceRowSynced(id: string, projectId: string): void {
+  projectOf.set(id, projectId);
+  needsCreate.add(id);
+  runCreate(id);
+}
+
 /** Optimistic store update; content-ish fields debounce into the row. */
 export function updateEvidenceSynced(
   id: string,


### PR DESCRIPTION
Closes CVS-338 · Linear: https://linear.app/canvasm/issue/CVS-338

> **Stacked on #149 (CVS-337)** — merge #149 first. If GitHub auto-closes this on that merge, the branch re-targets with one command; ping me.

## What

Slice C of the evidence "big notepad" plan — every evidence surface now writes through one path:

- **`EvidencePage`** (full-page notebook) and **`EvidenceRepositoryPage`** (modal editor) route updates through `evidenceSync` — same per-id debounce/ordering chain as the docked panel; manual saves flush immediately.
- **Repository double-create fixed**: autosave + manual Save both hit the create branch while `selectedEvidence` was still null, inserting two rows for one item (caught by direct DB inspection during e2e — two identical rows 200ms apart). The created item is now adopted into state and creates are serialized with an in-flight guard.
- **Duplicate is DB-backed**: repository duplicate creates a real `evidence_items` row via `ensureEvidenceRowSynced`; `EvidenceEditor` ids are now UUIDs (were `evidence_<timestamp>`, which can't insert into the uuid PK).
- **Docs**: `docs/state-management/evidence-persistence.md` — the persistence model, migration lifecycle, and the Prisma/Zod gotchas (tag_records rename after `db pull`, Unchecked variants, post-parse pattern) + index link.
- Verified the no-change consumers (LayersPanel, AdvancedSearchModal, LinkedEvidenceList, MCP tools, EmbedEvidencePage) all read the DB-hydrated store or services directly.

## Verification

- `type-check` ✓ · lint 0 errors ✓ · `vitest` 505/505 ✓
- Playwright vs the live app (this branch): `evidence-notepad` (flush-on-close, DB reload round-trip, delete persistence), `evidence-editor`, `dock-panels` — all ✓
- **DB-level checks** (Supabase SQL against the e2e project): exactly **one** row per repository-editor create (double-create gone); notepad spec leaves zero leftovers; legacy migration ran once (`evidenceMigratedAt` stamped, blob emptied, 4 items → rows, backup kept) and a second canvas load added **no duplicates**.

## Left for a future release

Removing `evidenceLegacyBackup` + the viewer blob-read fallback once CVS-337 has soaked in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)