### PR TITLE
feat(canvas): evidence notepad page — full-content, per-pin resizable card (CVS-342)

### DIFF
--- a/e2e/evidence-notepad.spec.ts
+++ b/e2e/evidence-notepad.spec.ts
@@ -133,6 +133,18 @@ test('CVS-336 evidence notepad: full block menu, drag-resizable dock, width pers
     hasText: title,
   });
   await expect(reloadedCard).toBeVisible({ timeout: 15_000 });
+  // Notepad page (CVS-342): the card itself renders the FULL notebook content
+  // at page size — the writing is readable directly on the canvas.
+  await expect(
+    reloadedCard.getByText('FLUSH-TAIL', { exact: false }).first()
+  ).toBeVisible({ timeout: 10_000 });
+  // Exactly ONE rendered copy — re-init races used to duplicate the notebook DOM.
+  await expect(
+    reloadedCard.getByText('FLUSH-TAIL', { exact: false })
+  ).toHaveCount(1);
+  const cardBox = await reloadedCard.boundingBox();
+  expect(cardBox!.width).toBeGreaterThan(400); // portrait page, not the old w-80
+  await shot(page, 'cvs342-notepad-page');
   await reloadedCard.getByRole('button', { name: 'Edit' }).first().click();
   await page.waitForTimeout(1200);
   await expect(

--- a/src/features/canvas/components/nodes/EvidenceNode.tsx
+++ b/src/features/canvas/components/nodes/EvidenceNode.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/shared/components/ui/button';
 import { Card } from '@/shared/components/ui/card';
 import { Input } from '@/shared/components/ui/input';
 import type { EvidenceItem } from '@/shared/types';
+import { NodeResizer } from '@xyflow/react';
 import type { Node, NodeProps } from '@xyflow/react';
 import {
   BookOpen,
@@ -53,7 +54,10 @@ const TYPE_META: Record<
   'User Interview': { icon: Users, chip: 'bg-pink-500/10 text-pink-600 dark:text-pink-400' },
 };
 
-export default function EvidenceNode({ data }: NodeProps<EvidenceFlowNode>) {
+export default function EvidenceNode({
+  data,
+  selected,
+}: NodeProps<EvidenceFlowNode>) {
   const onUpdateEvidence = data?.onUpdateEvidence;
   const onDeleteEvidence = data?.onDeleteEvidence;
   const evidence = data?.evidence ?? ({} as EvidenceItem);
@@ -196,15 +200,34 @@ export default function EvidenceNode({ data }: NodeProps<EvidenceFlowNode>) {
     );
   }
 
+  // Notepad page (CVS-342): a portrait paper default, per-pin resizable;
+  // size is client-side layout, persisted via settings.evidenceLayout.
+  const pageSize = evidence.size ?? { width: 440, height: 560 };
+
   return (
     <div className="relative select-none cursor-move">
+      <NodeResizer
+        minWidth={320}
+        minHeight={280}
+        isVisible={!!selected}
+        lineClassName="border-primary"
+        handleClassName="h-2.5 w-2.5 bg-primary border-2 border-background rounded-sm z-20"
+        onResize={(_, params) => {
+          onUpdateEvidence?.(evidence.id, {
+            size: { width: params.width, height: params.height },
+          });
+        }}
+      />
       <FourSideHandles />
       {/* Card-only bubble, NOT counter-scaled: the expanded card is a
           first-class node with connection handles, and scaling its visuals
           detaches them from the layout box the handles sit on. Zoom
           invariance is for the collapsed pin only. */}
       <div>
-        <Card className="w-80 rounded-xl rounded-tl-sm border bg-card/95 p-3 shadow-md backdrop-blur-sm">
+        <Card
+          className="flex flex-col gap-0 overflow-hidden rounded-xl rounded-tl-sm border bg-card/95 p-3 shadow-lg backdrop-blur-sm"
+          style={{ width: pageSize.width, height: pageSize.height }}
+        >
           {/* Header: type chip + inline-editable title + actions */}
           <div className="flex items-start gap-2">
             <span
@@ -266,10 +289,31 @@ export default function EvidenceNode({ data }: NodeProps<EvidenceFlowNode>) {
             </Button>
           </div>
 
-          {/* Content preview */}
-          <div className="relative mt-2 max-h-32 overflow-hidden rounded-md">
-            <EvidenceContentRenderer evidence={evidence} className="text-sm" />
-            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-card to-transparent" />
+          {/* Notepad body: the FULL notebook, scrollable on the canvas.
+              nodrag/nowheel: scrolling and text selection stay inside the
+              page (drag the card by its header); clicking opens the docked
+              editor — reading happens here, writing in the dock (CVS-342). */}
+          <div
+            className="nodrag nowheel relative mt-2 min-h-0 flex-1 cursor-text overflow-y-auto rounded-md"
+            title="Click to write in the side panel"
+            onClick={() => {
+              if (window.getSelection()?.toString()) return; // selecting ≠ editing
+              setEditOpen(true);
+            }}
+          >
+            {evidence.content ||
+            evidence.summary?.trim() ||
+            evidence.hypothesis?.trim() ||
+            evidence.impactOnConfidence?.trim() ? (
+              <EvidenceContentRenderer
+                evidence={evidence}
+                className="text-sm"
+              />
+            ) : (
+              <div className="flex h-full min-h-24 items-center justify-center text-sm italic text-muted-foreground">
+                Click to start writing…
+              </div>
+            )}
           </div>
 
           {/* Linked targets (drag an edge to a node, or via the relationship

--- a/src/features/evidence/components/EvidenceContentRenderer.tsx
+++ b/src/features/evidence/components/EvidenceContentRenderer.tsx
@@ -16,37 +16,47 @@ export default function EvidenceContentRenderer({
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (containerRef.current && evidence.content && !editorRef.current) {
-      try {
-        console.log("🔍 Rendering evidence content with stable tools...");
+    const holder = containerRef.current;
+    if (!holder || !evidence.content) return;
 
-        const editor = createReadOnlyEditorJSInstance({
-          holder: containerRef.current,
-          data: evidence.content,
-          onReady: () => {
-            console.log("🎨 ReadOnly EditorJS ready with stable toolkit");
-          },
-          onError: (error) => {
-            console.warn("⚠️ ReadOnly EditorJS error:", error);
-          },
-        });
-
-        editorRef.current = editor;
-      } catch (error) {
-        console.error("❌ Failed to initialize readonly editor:", error);
-      }
+    // One instance per effect run, each in its OWN child mount: content
+    // identity changes on every autosave, and re-init races (incl. StrictMode
+    // double-effects) either duplicated the notebook DOM or let a late
+    // destroy() wipe the successor's. A private mount node makes teardown
+    // touch only its own subtree.
+    holder.innerHTML = "";
+    const mount = document.createElement("div");
+    holder.appendChild(mount);
+    let editor: EditorJS | null = null;
+    try {
+      editor = createReadOnlyEditorJSInstance({
+        holder: mount,
+        data: evidence.content,
+        onError: (error) => {
+          console.warn("⚠️ ReadOnly EditorJS error:", error);
+        },
+      });
+      editorRef.current = editor;
+    } catch (error) {
+      console.error("❌ Failed to initialize readonly editor:", error);
     }
 
     return () => {
-      if (editorRef.current) {
+      editorRef.current = null;
+      const closing = editor;
+      void (async () => {
         try {
-          editorRef.current.destroy();
-          editorRef.current = null;
-        } catch (error) {
-          console.warn("Error destroying readonly editor:", error);
-          editorRef.current = null;
+          await closing?.isReady;
+        } catch {
+          /* init failed — nothing mounted */
         }
-      }
+        try {
+          closing?.destroy();
+        } catch {
+          /* pre-ready destroy can throw */
+        }
+        mount.remove(); // only our own subtree, never the successor's
+      })();
     };
   }, [evidence.content]);
 

--- a/src/features/evidence/services/hydrateProjectEvidence.ts
+++ b/src/features/evidence/services/hydrateProjectEvidence.ts
@@ -18,6 +18,7 @@ type Client = SupabaseClient<Database>;
 
 export interface EvidenceLayoutEntry {
   position?: { x: number; y: number };
+  size?: { width: number; height: number };
   isExpanded?: boolean;
   isVisible?: boolean;
   zIndex?: number | null;
@@ -30,6 +31,7 @@ export interface EvidenceLayoutEntry {
 
 const LAYOUT_KEYS = [
   'position',
+  'size',
   'isExpanded',
   'isVisible',
   'zIndex',

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -264,6 +264,13 @@ export interface EvidenceItem {
     y: number;
   };
 
+  /** Notepad-page size on canvas (NodeResizer, CVS-342) — client-side,
+      persisted in settings.evidenceLayout like position. */
+  size?: {
+    width: number;
+    height: number;
+  };
+
   // UI state for canvas evidence cards
   isVisible?: boolean;
   isExpanded?: boolean;


### PR DESCRIPTION
Closes CVS-342 · Linear: https://linear.app/canvasm/issue/CVS-342

> **Stacked on #150 (CVS-338)** — merge order: #149 → #150 → this.

## What

The canvas side of the "big notepad" (owner-requested after seeing the tablet mock on their canvas): the expanded evidence card becomes a **portrait paper page that renders the full notebook on the canvas**. Reading happens on the map; clicking the page body opens the docked editor from CVS-336 (locked decision: no inline EditorJS on canvas).

- Default 440×560, **per-pin resizable** via React Flow `NodeResizer` (min 320×280, visible when selected — same pattern as group nodes); size lives on the new client-side `EvidenceItem.size` and persists through `settings.evidenceLayout` like position.
- Body is a `nodrag nowheel` scroll container: wheel scrolls the page (not the canvas zoom), text is selectable, drag the card by its header. Empty pages say "Click to start writing…" instead of "No content available".
- **Renderer lifecycle fix** (`EvidenceContentRenderer`): re-init races — content identity changes on every autosave, plus StrictMode double-effects — either duplicated the notebook DOM 2–4× on one card or let a late `destroy()` wipe the live copy's DOM (EditorJS destroy clears the shared holder). Each instance now gets its own child mount node, so teardown touches only its own subtree. Both failure modes were caught live by the extended e2e spec.
- Collapsed pin state unchanged.

## Verification

- `type-check` ✓ · `vitest` 505/505 ✓
- Playwright vs the live app: extended `evidence-notepad` spec asserts the reloaded canvas card shows the notebook text at page size with **exactly one** rendered copy ✓; `evidence-editor` + `dock-panels` regression ✓ (renderer is shared with the embed page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)